### PR TITLE
Fix nil ptr crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 BUILDINFOSDET ?=
 PROGRAM_ARGS ?=
 
-PROJECT_VERSION           := 1.0.5
+PROJECT_VERSION           := 1.0.6
 DOCKER_REPO               := synfinatic
 PROJECT_NAME              := rss4transmission
 PROJECT_TAG               := $(shell git describe --tags 2>/dev/null $(git rev-list --tags --max-count=1))

--- a/cmd/rss4transmission/once.go
+++ b/cmd/rss4transmission/once.go
@@ -59,12 +59,15 @@ func (cmd *OnceCmd) Run(ctx *RunContext) error {
 
 		log.Debugf("Processing %s: %v", name, feed)
 		// have we already fetched this RSS feed?
-		if _, ok := feeds[feed.URL]; !ok {
+		if f, ok := feeds[feed.URL]; !ok {
 			p := gofeed.NewParser()
 			if feeds[feed.URL], err = p.ParseURL(feed.URL); err != nil {
 				log.WithError(err).Warnf("Unable to process URL: %s", feed.URL)
 				continue
 			}
+		} else if f == nil {
+			// we can have the same URL in multiple feeds, so we need to skip them too
+			continue
 		}
 
 		for _, item := range feed.NewItems(name, feeds[feed.URL]) {


### PR DESCRIPTION
When we failed to fetch the RSS items for a given URL we tried to use the existing cache (containing nil) for subsequent feed lookups.