### PR TITLE
Add fail2ban-compatible access logging for the cancel endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,12 @@ ENV HISTORY_FILE=""
 ENV HISTORY_LISTEN=""
 ENV CANCEL_LISTEN=""
 ENV TORRENT_CACHE_DIR=""
+ENV ACCESS_LOG=""
 
 ENTRYPOINT exec /usr/local/bin/rss4transmission watch --sleep $POLL_SECONDS \
     --log-level $LOG_LEVEL --config /mnt/config.yaml --seen-file /mnt/cache.json \
     ${HISTORY_FILE:+--history-file $HISTORY_FILE} \
     ${HISTORY_LISTEN:+--history-listen $HISTORY_LISTEN} \
     ${CANCEL_LISTEN:+--cancel-listen $CANCEL_LISTEN} \
-    ${TORRENT_CACHE_DIR:+--torrent-cache-dir $TORRENT_CACHE_DIR}
+    ${TORRENT_CACHE_DIR:+--torrent-cache-dir $TORRENT_CACHE_DIR} \
+    ${ACCESS_LOG:+--access-log $ACCESS_LOG}

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Pre-built images are available on [DockerHub](https://hub.docker.com/r/synfinati
   Transmission when running behind [Gluetun](https://github.com/qdm12/gluetun)
 - **Torrent file cache** — avoids re-fetching `.torrent` files on every watch-loop iteration;
   pruned automatically
+- **fail2ban integration** — optional access log with timestamps and client IPs lets fail2ban
+  detect and ban brute-force attempts against the cancel endpoint
 
 ## Documentation
 
@@ -48,6 +50,8 @@ Pre-built images are available on [DockerHub](https://hub.docker.com/r/synfinati
   deduplication, preference ranking, full config example
 - [Notifications & History](docs/notifications.md) — ntfy push notifications, cancel endpoint
   (Traefik and direct port-forward models), history web UI, completed notification script
+- [fail2ban Integration](docs/fail2ban.md) — access log setup, filter and jail configuration,
+  Docker volume-mount example, client IP resolution with Cloudflare support
 
 ## License
 

--- a/cmd/rss4transmission/watch.go
+++ b/cmd/rss4transmission/watch.go
@@ -20,6 +20,7 @@ type WatchCmd struct {
 	HistoryListen   string   `kong:"help='Address to serve torrent history on, as host:port or bare port (disabled if empty)'"`
 	CancelListen    string   `kong:"help='Address to serve /cancel and /healthz on (host:port or bare port); splits listeners so history stays internal'"`
 	TorrentCacheDir string   `kong:"help='Directory to cache fetched .torrent files across runs'"`
+	AccessLog       string   `kong:"help='Path to append-mode HTTP access log for fail2ban integration (disabled if empty)'"`
 }
 
 // retryLoadConfig calls tryLoad repeatedly, sleeping interval between attempts.
@@ -148,6 +149,8 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 		}
 	}
 
+	accessLog := openAccessLog(cmd.AccessLog)
+
 	if cmd.CancelListen != "" {
 		// Split-listener mode: /cancel and /healthz on the public port, history on a
 		// separate internal port. Cancel routes are NOT registered on the history mux.
@@ -158,7 +161,7 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 		if err != nil {
 			log.Fatalf("--cancel-listen: %s", err)
 		}
-		cancelMux := newCancelMux(ctx.CancelStore, ctx.Config.Cancel, removeT, getProgress)
+		cancelMux := newCancelMux(ctx.CancelStore, ctx.Config.Cancel, removeT, getProgress, accessLog)
 		go startWebServer(cancelMux, addr)
 
 		if cmd.HistoryListen != "" {
@@ -182,7 +185,7 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 		}
 		mux := newWebMux(ctx.History)
 		if ctx.CancelStore != nil {
-			registerCancelRoutes(mux, ctx.CancelStore, ctx.Config.Cancel, removeT, getProgress)
+			registerCancelRoutes(mux, ctx.CancelStore, ctx.Config.Cancel, removeT, getProgress, accessLog)
 			ctx.CancelListenEnabled = true
 		}
 		go startWebServer(mux, addr)

--- a/cmd/rss4transmission/watch_test.go
+++ b/cmd/rss4transmission/watch_test.go
@@ -13,6 +13,13 @@ func TestWatchCmd_HasHistoryFileField(t *testing.T) {
 	}
 }
 
+func TestWatchCmd_HasAccessLogField(t *testing.T) {
+	_, ok := reflect.TypeOf(WatchCmd{}).FieldByName("AccessLog")
+	if !ok {
+		t.Error("WatchCmd must have an AccessLog field")
+	}
+}
+
 func TestConfig_NoHistoryFileField(t *testing.T) {
 	_, ok := reflect.TypeOf(Config{}).FieldByName("HistoryFile")
 	if ok {

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -26,7 +26,11 @@ import (
 	"html/template"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 //go:embed web/history.html
@@ -55,6 +59,61 @@ type cancelPageData struct {
 	ID            string
 	Expires       int64
 	Sig           string
+}
+
+// clientIP extracts the real client IP from a request. It checks Cloudflare
+// headers first (CF-Connecting-IP, CF-Connecting-IPv6), then X-Forwarded-For
+// (first entry), then X-Real-IP, and falls back to RemoteAddr.
+func clientIP(r *http.Request) string {
+	if cf := r.Header.Get("CF-Connecting-IP"); cf != "" {
+		return strings.TrimSpace(cf)
+	}
+	if cf6 := r.Header.Get("CF-Connecting-IPv6"); cf6 != "" {
+		return strings.TrimSpace(cf6)
+	}
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		parts := strings.SplitN(xff, ",", 2)
+		return strings.TrimSpace(parts[0])
+	}
+	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		return strings.TrimSpace(xri)
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// openAccessLog opens the access log at path and returns a logrus logger for it.
+// Returns nil when path is empty. Fatals on open failure.
+func openAccessLog(path string) *logrus.Logger {
+	if path == "" {
+		return nil
+	}
+	al, err := newAccessLogger(path)
+	if err != nil {
+		log.WithError(err).Fatalf("Failed to open access log: %s", path)
+	}
+	return al
+}
+
+// newAccessLogger creates a logrus logger that appends structured log lines with
+// timestamps to path. Used for fail2ban-compatible access logging.
+func newAccessLogger(path string) (*logrus.Logger, error) {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("open access log %q: %w", path, err)
+	}
+	lg := logrus.New()
+	lg.SetOutput(f)
+	lg.SetFormatter(&logrus.TextFormatter{
+		DisableColors:    true,
+		DisableTimestamp: false,
+		FullTimestamp:    true,
+	})
+	lg.SetLevel(logrus.InfoLevel)
+	return lg, nil
 }
 
 // parseHistoryAddr normalises a --history-listen value to a "host:port" address.
@@ -120,12 +179,13 @@ func newWebMux(history *HistoryFile) *http.ServeMux {
 // and GET /healthz. Use this when --cancel-listen is set to expose the cancel
 // endpoint on its own port, keeping the history page on a separate internal listener.
 // POST /cancel is only registered when both store and remove are non-nil.
-func newCancelMux(store *Store, cfg CancelConfig, remove removeFunc, getProgress progressFunc) *http.ServeMux {
+// accessLog is optional; when non-nil each request outcome is written to it.
+func newCancelMux(store *Store, cfg CancelConfig, remove removeFunc, getProgress progressFunc, accessLog *logrus.Logger) *http.ServeMux {
 	mux := http.NewServeMux()
 	if store != nil {
-		mux.HandleFunc("GET /cancel", makeGetCancelHandler(store, cfg, getProgress))
+		mux.HandleFunc("GET /cancel", makeGetCancelHandler(store, cfg, getProgress, accessLog))
 		if remove != nil {
-			mux.HandleFunc("POST /cancel", makePostCancelHandler(store, cfg, remove))
+			mux.HandleFunc("POST /cancel", makePostCancelHandler(store, cfg, remove, accessLog))
 		}
 	}
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -135,9 +195,10 @@ func newCancelMux(store *Store, cfg CancelConfig, remove removeFunc, getProgress
 }
 
 // registerCancelRoutes adds GET /cancel and POST /cancel handlers to mux.
-func registerCancelRoutes(mux *http.ServeMux, store *Store, cfg CancelConfig, remove removeFunc, getProgress progressFunc) {
-	mux.HandleFunc("GET /cancel", makeGetCancelHandler(store, cfg, getProgress))
-	mux.HandleFunc("POST /cancel", makePostCancelHandler(store, cfg, remove))
+// accessLog is optional; when non-nil each request outcome is written to it.
+func registerCancelRoutes(mux *http.ServeMux, store *Store, cfg CancelConfig, remove removeFunc, getProgress progressFunc, accessLog *logrus.Logger) {
+	mux.HandleFunc("GET /cancel", makeGetCancelHandler(store, cfg, getProgress, accessLog))
+	mux.HandleFunc("POST /cancel", makePostCancelHandler(store, cfg, remove, accessLog))
 }
 
 // tokenErrorResponse translates a parseCancelToken error into the appropriate HTTP response.
@@ -154,7 +215,7 @@ func tokenErrorResponse(w http.ResponseWriter, err error) {
 // makeGetCancelHandler serves the confirmation form. It validates the token,
 // peeks the store for metadata without consuming the entry, and queries
 // Transmission for live download progress via getProgress.
-func makeGetCancelHandler(store *Store, cfg CancelConfig, getProgress progressFunc) http.HandlerFunc {
+func makeGetCancelHandler(store *Store, cfg CancelConfig, getProgress progressFunc, accessLog *logrus.Logger) http.HandlerFunc {
 	secret := []byte(cfg.HMACSecret)
 	tmpl := template.Must(template.New("cancel").Parse(cancelTmpl))
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -162,6 +223,18 @@ func makeGetCancelHandler(store *Store, cfg CancelConfig, getProgress progressFu
 		id := q.Get("id")
 		expires, err := parseCancelToken(secret, id, q.Get("expires"), q.Get("sig"))
 		if err != nil {
+			if accessLog != nil {
+				result := "invalid_token"
+				if errors.Is(err, ErrTokenExpired) {
+					result = "expired"
+				}
+				accessLog.WithFields(logrus.Fields{
+					"client_ip": clientIP(r),
+					"endpoint":  "/cancel",
+					"method":    r.Method,
+					"result":    result,
+				}).Warn("cancel access")
+			}
 			tokenErrorResponse(w, err)
 			return
 		}
@@ -169,8 +242,25 @@ func makeGetCancelHandler(store *Store, cfg CancelConfig, getProgress progressFu
 
 		torrentID, meta, ok := store.Peek(id)
 		if !ok {
+			if accessLog != nil {
+				accessLog.WithFields(logrus.Fields{
+					"client_ip": clientIP(r),
+					"endpoint":  "/cancel",
+					"method":    r.Method,
+					"result":    "not_found",
+				}).Warn("cancel access")
+			}
 			http.Error(w, "download not found or already cancelled", http.StatusNotFound)
 			return
+		}
+
+		if accessLog != nil {
+			accessLog.WithFields(logrus.Fields{
+				"client_ip": clientIP(r),
+				"endpoint":  "/cancel",
+				"method":    r.Method,
+				"result":    "ok",
+			}).Info("cancel access")
 		}
 
 		downloaded := "Unknown"
@@ -204,7 +294,7 @@ func makeGetCancelHandler(store *Store, cfg CancelConfig, getProgress progressFu
 // makePostCancelHandler processes the confirmation form submission. It re-validates
 // the token, removes the torrent from Transmission, and only then consumes the
 // store entry so users can retry if the Transmission call fails.
-func makePostCancelHandler(store *Store, cfg CancelConfig, remove removeFunc) http.HandlerFunc {
+func makePostCancelHandler(store *Store, cfg CancelConfig, remove removeFunc, accessLog *logrus.Logger) http.HandlerFunc {
 	secret := []byte(cfg.HMACSecret)
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
@@ -215,6 +305,18 @@ func makePostCancelHandler(store *Store, cfg CancelConfig, remove removeFunc) ht
 		id := r.FormValue("id")
 		_, err := parseCancelToken(secret, id, r.FormValue("expires"), r.FormValue("sig"))
 		if err != nil {
+			if accessLog != nil {
+				result := "invalid_token"
+				if errors.Is(err, ErrTokenExpired) {
+					result = "expired"
+				}
+				accessLog.WithFields(logrus.Fields{
+					"client_ip": clientIP(r),
+					"endpoint":  "/cancel",
+					"method":    r.Method,
+					"result":    result,
+				}).Warn("cancel access")
+			}
 			tokenErrorResponse(w, err)
 			return
 		}
@@ -222,12 +324,28 @@ func makePostCancelHandler(store *Store, cfg CancelConfig, remove removeFunc) ht
 		// Peek (not Take) so the entry survives a failed remove and the user can retry.
 		torrentID, _, ok := store.Peek(id)
 		if !ok {
+			if accessLog != nil {
+				accessLog.WithFields(logrus.Fields{
+					"client_ip": clientIP(r),
+					"endpoint":  "/cancel",
+					"method":    r.Method,
+					"result":    "not_found",
+				}).Warn("cancel access")
+			}
 			http.Error(w, "download not found or already cancelled", http.StatusNotFound)
 			return
 		}
 
 		if err := remove(r.Context(), []int64{torrentID}); err != nil {
 			log.WithError(err).Errorf("Failed to remove torrent %d from Transmission", torrentID)
+			if accessLog != nil {
+				accessLog.WithFields(logrus.Fields{
+					"client_ip": clientIP(r),
+					"endpoint":  "/cancel",
+					"method":    r.Method,
+					"result":    "error",
+				}).Warn("cancel access")
+			}
 			http.Error(w, "failed to cancel download", http.StatusInternalServerError)
 			return
 		}
@@ -235,6 +353,14 @@ func makePostCancelHandler(store *Store, cfg CancelConfig, remove removeFunc) ht
 		// Remove succeeded: consume the store entry.
 		store.Take(id) //nolint:errcheck
 
+		if accessLog != nil {
+			accessLog.WithFields(logrus.Fields{
+				"client_ip": clientIP(r),
+				"endpoint":  "/cancel",
+				"method":    r.Method,
+				"result":    "cancelled",
+			}).Info("cancel access")
+		}
 		log.Infof("Cancelled download via web confirmation: torrent %d (cancel-id %s)", torrentID, id)
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusOK)

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -1,15 +1,19 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -73,7 +77,7 @@ func TestGetCancelHandler_RendersForm(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	mux := newWebMux(nil)
-	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc())
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
 		fmt.Sprintf("/cancel?id=test-id&expires=%d&sig=%s", expires, sig), nil)
@@ -98,7 +102,7 @@ func TestGetCancelHandler_RendersProgress(t *testing.T) {
 	getProgress := makeProgressFunc(int64(2.5*float64(1<<30)), 0.25)
 
 	mux := newWebMux(nil)
-	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), getProgress)
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), getProgress, nil)
 
 	req := httptest.NewRequest("GET",
 		fmt.Sprintf("/cancel?id=test-id&expires=%d&sig=%s", expires, sig), nil)
@@ -123,7 +127,7 @@ func TestGetCancelHandler_ProgressUnknownOnError(t *testing.T) {
 	}
 
 	mux := newWebMux(nil)
-	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), errProgress)
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), errProgress, nil)
 
 	req := httptest.NewRequest("GET",
 		fmt.Sprintf("/cancel?id=test-id&expires=%d&sig=%s", expires, sig), nil)
@@ -138,7 +142,7 @@ func TestGetCancelHandler_MissingParams(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
 	mux := newWebMux(nil)
-	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc())
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET", "/cancel?id=test-id", nil)
 	rr := httptest.NewRecorder()
@@ -154,7 +158,7 @@ func TestGetCancelHandler_BadSignature(t *testing.T) {
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	mux := newWebMux(nil)
-	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc())
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
 		fmt.Sprintf("/cancel?id=test-id&expires=%d&sig=badsig", expires), nil)
@@ -171,7 +175,7 @@ func TestGetCancelHandler_Expired(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
 	mux := newWebMux(nil)
-	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc())
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
 		fmt.Sprintf("/cancel?id=test-id&expires=%d&sig=%s", expires, sig), nil)
@@ -187,7 +191,7 @@ func TestGetCancelHandler_NotFound(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
 	mux := newWebMux(nil)
-	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc())
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
 		fmt.Sprintf("/cancel?id=ghost-id&expires=%d&sig=%s", expires, sig), nil)
@@ -206,7 +210,7 @@ func TestGetCancelHandler_DoesNotConsumeEntry(t *testing.T) {
 
 	mux := newWebMux(nil)
 	removed := false
-	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc())
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
 		fmt.Sprintf("/cancel?id=test-id&expires=%d&sig=%s", expires, sig), nil)
@@ -232,7 +236,7 @@ func TestPostCancelHandler_Valid(t *testing.T) {
 
 	removed := false
 	mux := newWebMux(nil)
-	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc())
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
 	req := httptest.NewRequest("POST", "/cancel", body)
@@ -248,7 +252,7 @@ func TestPostCancelHandler_MissingParams(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
 	mux := newWebMux(nil)
-	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc())
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := strings.NewReader("id=test-id") // missing expires and sig
 	req := httptest.NewRequest("POST", "/cancel", body)
@@ -266,7 +270,7 @@ func TestPostCancelHandler_BadSignature(t *testing.T) {
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	mux := newWebMux(nil)
-	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc())
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, "badsig")
 	req := httptest.NewRequest("POST", "/cancel", body)
@@ -284,7 +288,7 @@ func TestPostCancelHandler_Expired(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
 	mux := newWebMux(nil)
-	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc())
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
 	req := httptest.NewRequest("POST", "/cancel", body)
@@ -301,7 +305,7 @@ func TestPostCancelHandler_NotFound(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
 	mux := newWebMux(nil)
-	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc())
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("ghost-id", expires, sig)
 	req := httptest.NewRequest("POST", "/cancel", body)
@@ -317,7 +321,7 @@ func TestPostCancelHandler_NotFound(t *testing.T) {
 func TestNewCancelMux_HealthzReachable(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newCancelMux(store, cfg, makeRemoveFunc(new(bool)), noProgressFunc())
+	mux := newCancelMux(store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET", "/healthz", nil)
 	rr := httptest.NewRecorder()
@@ -328,7 +332,7 @@ func TestNewCancelMux_HealthzReachable(t *testing.T) {
 func TestNewCancelMux_CancelReachable(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newCancelMux(store, cfg, makeRemoveFunc(new(bool)), noProgressFunc())
+	mux := newCancelMux(store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	// A POST with missing params should return 400, not 404 — proving the route exists.
 	body := strings.NewReader("id=x")
@@ -342,7 +346,7 @@ func TestNewCancelMux_CancelReachable(t *testing.T) {
 func TestNewCancelMux_HistoryNotReachable(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newCancelMux(store, cfg, makeRemoveFunc(new(bool)), noProgressFunc())
+	mux := newCancelMux(store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
@@ -352,7 +356,7 @@ func TestNewCancelMux_HistoryNotReachable(t *testing.T) {
 
 func TestNewCancelMux_NilStoreHealthzStillWorks(t *testing.T) {
 	cfg := makeCancelCfg("", "")
-	mux := newCancelMux(nil, cfg, nil, nil)
+	mux := newCancelMux(nil, cfg, nil, nil, nil)
 
 	req := httptest.NewRequest("GET", "/healthz", nil)
 	rr := httptest.NewRecorder()
@@ -362,7 +366,7 @@ func TestNewCancelMux_NilStoreHealthzStillWorks(t *testing.T) {
 
 func TestNewCancelMux_NilStoreCancelReturns404(t *testing.T) {
 	cfg := makeCancelCfg("", "")
-	mux := newCancelMux(nil, cfg, nil, nil)
+	mux := newCancelMux(nil, cfg, nil, nil, nil)
 
 	body := strings.NewReader("id=x&expires=1&sig=y")
 	req := httptest.NewRequest("POST", "/cancel", body)
@@ -382,7 +386,7 @@ func TestPostCancelHandler_RemoveErrorPreservesStoreEntry(t *testing.T) {
 		return fmt.Errorf("transmission unreachable")
 	}
 	mux := newWebMux(nil)
-	registerCancelRoutes(mux, store, cfg, failRemove, noProgressFunc())
+	registerCancelRoutes(mux, store, cfg, failRemove, noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
 	req := httptest.NewRequest("POST", "/cancel", body)
@@ -403,7 +407,7 @@ func TestGetCancelHandler_ZeroBytesProgressBothUnknown(t *testing.T) {
 
 	// brand-new torrent: 0 bytes downloaded, 0% done
 	mux := newWebMux(nil)
-	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), makeProgressFunc(0, 0.0))
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), makeProgressFunc(0, 0.0), nil)
 
 	req := httptest.NewRequest("GET",
 		fmt.Sprintf("/cancel?id=test-id&expires=%d&sig=%s", expires, sig), nil)
@@ -420,7 +424,7 @@ func TestNewCancelMux_NilRemovePostReturns404(t *testing.T) {
 	store.Register("test-id", 42, CancelMetadata{})
 	cfg := makeCancelCfg("secret", "https://example.com")
 	// non-nil store, nil remove → POST /cancel must not be registered (no panic)
-	mux := newCancelMux(store, cfg, nil, nil)
+	mux := newCancelMux(store, cfg, nil, nil, nil)
 
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -431,6 +435,370 @@ func TestNewCancelMux_NilRemovePostReturns404(t *testing.T) {
 	// Go's mux returns 405 when GET /cancel is registered but POST is not — safe, not a panic.
 	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code,
 		"POST /cancel must not be registered when remove is nil")
+}
+
+// --- access log behavioral tests ---
+
+func TestGetCancelHandler_AccessLog_InvalidToken(t *testing.T) {
+	store := NewStore(time.Hour)
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
+
+	lg, buf := makeTestAccessLogger()
+	mux := newWebMux(nil)
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
+
+	req := httptest.NewRequest("GET",
+		fmt.Sprintf("/cancel?id=test-id&expires=%d&sig=badsig", expires), nil)
+	req.RemoteAddr = "10.0.0.1:5555"
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, buf.String(), "level=warning")
+	assert.Contains(t, buf.String(), "result=invalid_token")
+	assert.Contains(t, buf.String(), "client_ip=10.0.0.1")
+}
+
+func TestGetCancelHandler_AccessLog_MissingParams(t *testing.T) {
+	store := NewStore(time.Hour)
+	cfg := makeCancelCfg("secret", "https://example.com")
+
+	lg, buf := makeTestAccessLogger()
+	mux := newWebMux(nil)
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
+
+	req := httptest.NewRequest("GET", "/cancel?id=test-id", nil)
+	req.RemoteAddr = "10.0.0.1:5555"
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, buf.String(), "level=warning")
+	assert.Contains(t, buf.String(), "result=invalid_token")
+}
+
+func TestGetCancelHandler_AccessLog_Expired(t *testing.T) {
+	store := NewStore(time.Hour)
+	store.Register("test-id", 42, CancelMetadata{})
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
+
+	lg, buf := makeTestAccessLogger()
+	mux := newWebMux(nil)
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
+
+	req := httptest.NewRequest("GET",
+		fmt.Sprintf("/cancel?id=test-id&expires=%d&sig=%s", expires, sig), nil)
+	req.RemoteAddr = "10.0.0.1:5555"
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusGone, rr.Code)
+	assert.Contains(t, buf.String(), "level=warning")
+	assert.Contains(t, buf.String(), "result=expired")
+	assert.Contains(t, buf.String(), "client_ip=10.0.0.1")
+}
+
+func TestGetCancelHandler_AccessLog_NotFound(t *testing.T) {
+	store := NewStore(time.Hour)
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
+
+	lg, buf := makeTestAccessLogger()
+	mux := newWebMux(nil)
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
+
+	req := httptest.NewRequest("GET",
+		fmt.Sprintf("/cancel?id=ghost-id&expires=%d&sig=%s", expires, sig), nil)
+	req.RemoteAddr = "10.0.0.1:5555"
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	assert.Contains(t, buf.String(), "level=warning")
+	assert.Contains(t, buf.String(), "result=not_found")
+	assert.Contains(t, buf.String(), "client_ip=10.0.0.1")
+}
+
+func TestGetCancelHandler_AccessLog_Success(t *testing.T) {
+	store := NewStore(time.Hour)
+	store.Register("test-id", 42, CancelMetadata{Title: "Show"})
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
+
+	lg, buf := makeTestAccessLogger()
+	mux := newWebMux(nil)
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
+
+	req := httptest.NewRequest("GET",
+		fmt.Sprintf("/cancel?id=test-id&expires=%d&sig=%s", expires, sig), nil)
+	req.RemoteAddr = "10.0.0.1:5555"
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, buf.String(), "level=info")
+	assert.Contains(t, buf.String(), "result=ok")
+	assert.Contains(t, buf.String(), "client_ip=10.0.0.1")
+}
+
+func TestGetCancelHandler_AccessLog_NilNoOp(t *testing.T) {
+	store := NewStore(time.Hour)
+	store.Register("test-id", 42, CancelMetadata{Title: "Show"})
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
+
+	mux := newWebMux(nil)
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
+
+	req := httptest.NewRequest("GET",
+		fmt.Sprintf("/cancel?id=test-id&expires=%d&sig=%s", expires, sig), nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	// Must not panic and must still serve the page correctly.
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestPostCancelHandler_AccessLog_InvalidToken(t *testing.T) {
+	store := NewStore(time.Hour)
+	store.Register("test-id", 42, CancelMetadata{})
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
+
+	lg, buf := makeTestAccessLogger()
+	mux := newWebMux(nil)
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
+
+	body := makeCancelFormBody("test-id", expires, "badsig")
+	req := httptest.NewRequest("POST", "/cancel", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.RemoteAddr = "10.0.0.1:5555"
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, buf.String(), "level=warning")
+	assert.Contains(t, buf.String(), "result=invalid_token")
+	assert.Contains(t, buf.String(), "client_ip=10.0.0.1")
+}
+
+func TestPostCancelHandler_AccessLog_Expired(t *testing.T) {
+	store := NewStore(time.Hour)
+	store.Register("test-id", 42, CancelMetadata{})
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
+
+	lg, buf := makeTestAccessLogger()
+	mux := newWebMux(nil)
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
+
+	body := makeCancelFormBody("test-id", expires, sig)
+	req := httptest.NewRequest("POST", "/cancel", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.RemoteAddr = "10.0.0.1:5555"
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusGone, rr.Code)
+	assert.Contains(t, buf.String(), "level=warning")
+	assert.Contains(t, buf.String(), "result=expired")
+	assert.Contains(t, buf.String(), "client_ip=10.0.0.1")
+}
+
+func TestPostCancelHandler_AccessLog_NotFound(t *testing.T) {
+	store := NewStore(time.Hour)
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
+
+	lg, buf := makeTestAccessLogger()
+	mux := newWebMux(nil)
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
+
+	body := makeCancelFormBody("ghost-id", expires, sig)
+	req := httptest.NewRequest("POST", "/cancel", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.RemoteAddr = "10.0.0.1:5555"
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	assert.Contains(t, buf.String(), "level=warning")
+	assert.Contains(t, buf.String(), "result=not_found")
+	assert.Contains(t, buf.String(), "client_ip=10.0.0.1")
+}
+
+func TestPostCancelHandler_AccessLog_Success(t *testing.T) {
+	store := NewStore(time.Hour)
+	store.Register("test-id", 42, CancelMetadata{})
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
+
+	lg, buf := makeTestAccessLogger()
+	removed := false
+	mux := newWebMux(nil)
+	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), lg)
+
+	body := makeCancelFormBody("test-id", expires, sig)
+	req := httptest.NewRequest("POST", "/cancel", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.RemoteAddr = "10.0.0.1:5555"
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.True(t, removed)
+	assert.Contains(t, buf.String(), "level=info")
+	assert.Contains(t, buf.String(), "result=cancelled")
+	assert.Contains(t, buf.String(), "client_ip=10.0.0.1")
+}
+
+func TestPostCancelHandler_AccessLog_TransmissionError(t *testing.T) {
+	store := NewStore(time.Hour)
+	store.Register("test-id", 77, CancelMetadata{})
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
+
+	lg, buf := makeTestAccessLogger()
+	failRemove2 := func(_ context.Context, _ []int64) error {
+		return fmt.Errorf("transmission unreachable")
+	}
+	mux := newWebMux(nil)
+	registerCancelRoutes(mux, store, cfg, failRemove2, noProgressFunc(), lg)
+
+	body := makeCancelFormBody("test-id", expires, sig)
+	req := httptest.NewRequest("POST", "/cancel", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.RemoteAddr = "10.0.0.1:5555"
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, buf.String(), "level=warning")
+	assert.Contains(t, buf.String(), "result=error")
+	assert.Contains(t, buf.String(), "client_ip=10.0.0.1")
+}
+
+// --- clientIP ---
+
+func TestClientIP_RemoteAddr(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	// httptest.NewRequest sets RemoteAddr = "192.0.2.1:1234"
+	assert.Equal(t, "192.0.2.1", clientIP(req))
+}
+
+func TestClientIP_RemoteAddr_IPv6(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "[::1]:1234"
+	assert.Equal(t, "::1", clientIP(req))
+}
+
+func TestClientIP_RemoteAddr_NoPort(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "192.0.2.1"
+	assert.Equal(t, "192.0.2.1", clientIP(req))
+}
+
+func TestClientIP_CFConnectingIP(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("CF-Connecting-IP", "2.2.2.2")
+	assert.Equal(t, "2.2.2.2", clientIP(req))
+}
+
+func TestClientIP_CFConnectingIP_BeatsXFF(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("CF-Connecting-IP", "2.2.2.2")
+	req.Header.Set("X-Forwarded-For", "3.3.3.3")
+	assert.Equal(t, "2.2.2.2", clientIP(req))
+}
+
+func TestClientIP_CFConnectingIPv6(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("CF-Connecting-IPv6", "2001:db8::1")
+	assert.Equal(t, "2001:db8::1", clientIP(req))
+}
+
+func TestClientIP_CFConnectingIP_BeatsCFIPv6(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("CF-Connecting-IP", "2.2.2.2")
+	req.Header.Set("CF-Connecting-IPv6", "2001:db8::1")
+	assert.Equal(t, "2.2.2.2", clientIP(req))
+}
+
+func TestClientIP_XForwardedFor_Single(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+	assert.Equal(t, "1.2.3.4", clientIP(req))
+}
+
+func TestClientIP_XForwardedFor_Multiple(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Forwarded-For", "1.2.3.4, 5.6.7.8")
+	assert.Equal(t, "1.2.3.4", clientIP(req))
+}
+
+func TestClientIP_XRealIP(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Real-IP", "9.9.9.9")
+	assert.Equal(t, "9.9.9.9", clientIP(req))
+}
+
+func TestClientIP_XForwardedFor_BeatsXRealIP(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+	req.Header.Set("X-Real-IP", "9.9.9.9")
+	assert.Equal(t, "1.2.3.4", clientIP(req))
+}
+
+// --- newAccessLogger ---
+
+func TestNewAccessLogger_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "access.log")
+	lg, err := newAccessLogger(path)
+	require.NoError(t, err)
+	require.NotNil(t, lg)
+	lg.Info("ping")
+	data, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	body := string(data)
+	assert.Contains(t, body, "ping")
+	assert.Contains(t, body, "time=")
+}
+
+func TestNewAccessLogger_AppendMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "access.log")
+	require.NoError(t, os.WriteFile(path, []byte("existing line\n"), 0600))
+	lg, err := newAccessLogger(path)
+	require.NoError(t, err)
+	lg.Info("new entry")
+	data, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	body := string(data)
+	assert.Contains(t, body, "existing line")
+	assert.Contains(t, body, "new entry")
+}
+
+func TestNewAccessLogger_InvalidPath(t *testing.T) {
+	lg, err := newAccessLogger("/no_such_directory_xyz/access.log")
+	assert.Error(t, err)
+	assert.Nil(t, lg)
+}
+
+// makeTestAccessLogger returns a logrus logger writing to a buffer for testing.
+func makeTestAccessLogger() (*logrus.Logger, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	lg := logrus.New()
+	lg.SetOutput(buf)
+	lg.SetLevel(logrus.InfoLevel)
+	lg.SetFormatter(&logrus.TextFormatter{
+		DisableColors:    true,
+		DisableTimestamp: false,
+		FullTimestamp:    true,
+	})
+	return lg, buf
 }
 
 func TestParseHistoryAddr(t *testing.T) {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -242,3 +242,4 @@ environment:
 | `HISTORY_LISTEN` | `host:port` or bare port — starts the history/cancel web UI |
 | `CANCEL_LISTEN` | `host:port` — separate public-facing listener for `/cancel` and `/healthz` |
 | `TORRENT_CACHE_DIR` | Directory to cache fetched `.torrent` files across runs |
+| `ACCESS_LOG` | Path to the fail2ban-compatible HTTP access log file (append mode); disabled when empty |

--- a/docs/fail2ban.md
+++ b/docs/fail2ban.md
@@ -1,0 +1,123 @@
+# fail2ban Integration
+
+rss4transmission can write a structured access log that fail2ban can monitor to detect and block
+brute-force attempts against the `/cancel` endpoint.
+
+## Threat model
+
+The `/cancel` endpoint is publicly accessible so ntfy notification recipients can cancel pending
+Transmission downloads. The only authentication is an HMAC-signed token embedded in the ntfy
+notification. An attacker who discovers the endpoint URL could probe it with random or guessed
+tokens. Without a ban mechanism there is no cost to repeated attempts.
+
+Enabling an access log lets fail2ban observe failed token validations and ban source IPs that
+exceed a configurable threshold.
+
+## Enabling access logging
+
+Set `--access-log` (or the `ACCESS_LOG` environment variable in Docker) to the path where
+rss4transmission should append access log entries. The directory must already exist; the file
+is created if it does not exist and opened in append mode so entries survive restarts.
+
+```bash
+rss4transmission watch \
+  --cancel-listen 0.0.0.0:8080 \
+  --access-log /var/log/rss4transmission/access.log \
+  ...
+```
+
+Docker example:
+
+```yaml
+services:
+  rss4transmission:
+    environment:
+      - ACCESS_LOG=/logs/access.log
+    volumes:
+      - /host/path/rss4transmission-logs:/logs
+```
+
+fail2ban on the host then reads `/host/path/rss4transmission-logs/access.log`.
+
+## Log line format
+
+The access log uses logrus `TextFormatter` with RFC3339 timestamps and `key=value` fields:
+
+```
+time="2026-07-01T10:30:00Z" level=warning msg="cancel access" client_ip=1.2.3.4 endpoint=/cancel method=GET result=invalid_token
+time="2026-07-01T10:30:01Z" level=info msg="cancel access" client_ip=1.2.3.4 endpoint=/cancel method=POST result=cancelled
+```
+
+Fields are sorted alphabetically after `time`/`level`/`msg`: `client_ip`, `endpoint`, `method`,
+`result`.
+
+Result values logged per outcome:
+
+| Outcome | Level | `result=` |
+|---|---|---|
+| Missing or invalid token signature | `warning` | `invalid_token` |
+| Token expired | `warning` | `expired` |
+| Torrent ID not in store (already cancelled or never existed) | `warning` | `not_found` |
+| Transmission RPC call failed | `warning` | `error` |
+| Confirmation page rendered successfully | `info` | `ok` |
+| Torrent cancelled successfully | `info` | `cancelled` |
+
+Note: IPv6 addresses are quoted by logrus because they contain colons, e.g.
+`client_ip="2001:db8::1"`.
+
+## fail2ban filter
+
+Create `/etc/fail2ban/filter.d/rss4transmission.conf`:
+
+```ini
+[INCLUDES]
+before = common.conf
+
+[Definition]
+# logrus TextFormatter RFC3339 timestamp: time="2026-07-01T10:30:00Z"
+datepattern = {^LN-BEG}time="%%Y-%%m-%%dT%%H:%%M:%%S
+
+# Match any warning-level cancel access line (invalid_token, expired, not_found, error).
+# IPv6 addresses are quoted by logrus, so "? handles both quoted and unquoted forms.
+failregex = ^time="[^"]*"\s+level=warning\s+msg="cancel access"\s+client_ip="?<HOST>"?
+
+ignoreregex =
+```
+
+## fail2ban jail
+
+Create `/etc/fail2ban/jail.d/rss4transmission.conf`:
+
+```ini
+[rss4transmission]
+enabled  = true
+port     = http,https
+logpath  = /var/log/rss4transmission/access.log
+filter   = rss4transmission
+maxretry = 10
+findtime = 10m
+bantime  = 1h
+```
+
+This bans a source IP for 1 hour after 10 warning-level events within 10 minutes. Adjust
+`maxretry`, `findtime`, and `bantime` to suit your threat model.
+
+After creating both files, reload fail2ban:
+
+```bash
+fail2ban-client reload
+```
+
+## Client IP resolution
+
+The client IP logged is determined in this order:
+
+1. `CF-Connecting-IP` — Cloudflare's definitive visitor IP (IPv4 or IPv6)
+2. `CF-Connecting-IPv6` — Cloudflare IPv6-specific fallback
+3. `X-Forwarded-For` — first entry in the list (set by Traefik, nginx, and most proxies)
+4. `X-Real-IP` — set by nginx `proxy_set_header X-Real-IP $remote_addr`
+5. `RemoteAddr` — TCP peer address (used when not behind a proxy)
+
+When running behind a reverse proxy, configure the proxy to set a trustworthy
+`X-Forwarded-For` header so the correct visitor IP is logged. When Cloudflare is in front,
+`CF-Connecting-IP` is used automatically.


### PR DESCRIPTION
Adds an optional --access-log flag (ACCESS_LOG in Docker) that writes structured, timestamped log entries to a file whenever the /cancel endpoint is hit. Each entry records the client IP, method, endpoint, and outcome (invalid_token, expired, not_found, error, ok, cancelled).

Client IP is resolved from CF-Connecting-IP, CF-Connecting-IPv6, X-Forwarded-For, X-Real-IP, or RemoteAddr — in that order.

Includes a new docs/fail2ban.md covering the threat model, filter and jail config, Docker setup, and reverse proxy / Cloudflare notes.