### PR TITLE
rename http endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage.*
 *.rss
 plan.md
 torrents
+.build_files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,10 +110,12 @@ error hold-downs to avoid spamming retries.
 port into Transmission's session settings.
 
 **History web UI (`web.go`)**: The `watch` command accepts `--history-file` (path to the history JSON,
-env `HISTORY_FILE` in Docker) and `--history-listen` (env `HISTORY_LISTEN`). `--history-file` enables
-recording; `--history-listen` additionally starts an HTTP server (bare port or `host:port`) serving a
-browsable history. In the gluetun docker-compose, expose the port explicitly via the `ports:` block;
-in the plain docker-compose `network_mode: host` already exposes all ports.
+env `HISTORY_FILE` in Docker), `--private-listen` (env `PRIVATE_LISTEN`), and `--public-listen`
+(env `PUBLIC_LISTEN`). `--history-file` enables recording; `--private-listen` starts a private HTTP
+server (bare port or `host:port`) serving the history UI and optionally `/cancel`; `--public-listen`
+starts a separate public-facing server for `/cancel`, `/healthz`, and `/notify-complete` only.
+In the gluetun docker-compose, expose the port explicitly via the `ports:` block; in the plain
+docker-compose `network_mode: host` already exposes all ports.
 
 **Config defaults** are defined as a `map[string]interface{}` in `config.go` and loaded before the YAML
 file, so koanf's merge semantics provide defaults without nil-checks in code.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,15 @@ COPY --from=builder  /code/dist/rss4transmission /usr/local/bin/
 ENV POLL_SECONDS=300
 ENV LOG_LEVEL="info"
 ENV HISTORY_FILE=""
-ENV HISTORY_LISTEN=""
-ENV CANCEL_LISTEN=""
+ENV PRIVATE_LISTEN=""
+ENV PUBLIC_LISTEN=""
 ENV TORRENT_CACHE_DIR=""
 ENV ACCESS_LOG=""
 
 ENTRYPOINT exec /usr/local/bin/rss4transmission watch --sleep $POLL_SECONDS \
     --log-level $LOG_LEVEL --config /mnt/config.yaml --seen-file /mnt/cache.json \
     ${HISTORY_FILE:+--history-file $HISTORY_FILE} \
-    ${HISTORY_LISTEN:+--history-listen $HISTORY_LISTEN} \
-    ${CANCEL_LISTEN:+--cancel-listen $CANCEL_LISTEN} \
+    ${PRIVATE_LISTEN:+--private-listen $PRIVATE_LISTEN} \
+    ${PUBLIC_LISTEN:+--public-listen $PUBLIC_LISTEN} \
     ${TORRENT_CACHE_DIR:+--torrent-cache-dir $TORRENT_CACHE_DIR} \
     ${ACCESS_LOG:+--access-log $ACCESS_LOG}

--- a/cmd/rss4transmission/main.go
+++ b/cmd/rss4transmission/main.go
@@ -60,7 +60,7 @@ type RunContext struct {
 	Cache               *CacheFile
 	History             *HistoryFile
 	CancelStore         *Store
-	CancelListenEnabled bool
+	PublicListenEnabled bool
 	Transmission        *transmissionrpc.Client
 	Provider            *file.File
 }

--- a/cmd/rss4transmission/main.go
+++ b/cmd/rss4transmission/main.go
@@ -60,7 +60,7 @@ type RunContext struct {
 	Cache               *CacheFile
 	History             *HistoryFile
 	CancelStore         *Store
-	PublicListenEnabled bool
+	CancelRoutesEnabled bool
 	Transmission        *transmissionrpc.Client
 	Provider            *file.File
 }

--- a/cmd/rss4transmission/once.go
+++ b/cmd/rss4transmission/once.go
@@ -27,7 +27,7 @@ func extractSize(item *gofeed.Item) int64 {
 }
 
 // sendNtfyStarted sends a "torrent started" notification to ntfy. The cancel
-// action button is only included when --cancel-listen is active and all cancel
+// action button is only included when --public-listen is active and all cancel
 // config fields are set; otherwise a plain notification is sent.
 func sendNtfyStarted(ctx *RunContext, feedCfg Feed, torrentID int64, meta CancelMetadata, item *gofeed.Item) {
 	if feedCfg.NoNotify {
@@ -38,7 +38,7 @@ func sendNtfyStarted(ctx *RunContext, feedCfg Feed, torrentID int64, meta Cancel
 	}
 
 	var cancelURL, cancelID string
-	if ctx.CancelListenEnabled &&
+	if ctx.PublicListenEnabled &&
 		ctx.Config.Cancel.HMACSecret != "" &&
 		ctx.Config.Cancel.BaseURL != "" &&
 		ctx.CancelStore != nil &&

--- a/cmd/rss4transmission/once.go
+++ b/cmd/rss4transmission/once.go
@@ -27,8 +27,9 @@ func extractSize(item *gofeed.Item) int64 {
 }
 
 // sendNtfyStarted sends a "torrent started" notification to ntfy. The cancel
-// action button is only included when --public-listen is active and all cancel
-// config fields are set; otherwise a plain notification is sent.
+// action button is only included when cancel routes are registered (either via
+// --private-listen alone or --public-listen) and all cancel config fields are
+// set; otherwise a plain notification is sent.
 func sendNtfyStarted(ctx *RunContext, feedCfg Feed, torrentID int64, meta CancelMetadata, item *gofeed.Item) {
 	if feedCfg.NoNotify {
 		return
@@ -38,7 +39,7 @@ func sendNtfyStarted(ctx *RunContext, feedCfg Feed, torrentID int64, meta Cancel
 	}
 
 	var cancelURL, cancelID string
-	if ctx.PublicListenEnabled &&
+	if ctx.CancelRoutesEnabled &&
 		ctx.Config.Cancel.HMACSecret != "" &&
 		ctx.Config.Cancel.BaseURL != "" &&
 		ctx.CancelStore != nil &&

--- a/cmd/rss4transmission/watch.go
+++ b/cmd/rss4transmission/watch.go
@@ -18,7 +18,7 @@ type WatchCmd struct {
 	Sleep           int      `kong:"short='s',default='300',help='Seconds to sleep between scraping'"`
 	HistoryFile     string   `kong:"help='Path to history JSON file'"`
 	PrivateListen   string   `kong:"help='Address to serve torrent history on (internal only), as host:port or bare port (disabled if empty)'"`
-	PublicListen    string   `kong:"help='Address to serve /cancel and /healthz on (host:port or bare port); splits listeners so history stays on the private listener'"`
+	PublicListen    string   `kong:"help='Address to serve /cancel, /notify-complete, and /healthz on (host:port or bare port); splits listeners so history stays on the private listener'"`
 	TorrentCacheDir string   `kong:"help='Directory to cache fetched .torrent files across runs'"`
 	AccessLog       string   `kong:"help='Path to append-mode HTTP access log for fail2ban integration (disabled if empty)'"`
 }
@@ -152,10 +152,11 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 	accessLog := openAccessLog(cmd.AccessLog)
 
 	if cmd.PublicListen != "" {
-		// Split-listener mode: /cancel and /healthz on the public port, history on a
-		// separate private port. Cancel routes are NOT registered on the private mux.
+		// Split-listener mode: /cancel, /notify-complete, and /healthz on the public
+		// port, history on a separate private port. Cancel routes are NOT registered on
+		// the private mux.
 		if ctx.CancelStore != nil {
-			ctx.PublicListenEnabled = true
+			ctx.CancelRoutesEnabled = true
 		}
 		addr, err := parseListenAddr(cmd.PublicListen)
 		if err != nil {
@@ -187,7 +188,7 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 		mux := newWebMux(ctx.History)
 		if ctx.CancelStore != nil {
 			registerCancelRoutes(mux, ctx.CancelStore, ctx.Config.Cancel, removeT, getProgress, accessLog)
-			ctx.PublicListenEnabled = true
+			ctx.CancelRoutesEnabled = true
 		}
 		registerNotifyCompleteRoute(mux, ctx.Config.Ntfy, ctx.Config.Cancel, accessLog)
 		go startWebServer(mux, addr)

--- a/cmd/rss4transmission/watch.go
+++ b/cmd/rss4transmission/watch.go
@@ -17,8 +17,8 @@ type WatchCmd struct {
 	DownloadPath    string   `kong:"short='p',help='Path to download torrent files to ($PWD)'"`
 	Sleep           int      `kong:"short='s',default='300',help='Seconds to sleep between scraping'"`
 	HistoryFile     string   `kong:"help='Path to history JSON file'"`
-	HistoryListen   string   `kong:"help='Address to serve torrent history on, as host:port or bare port (disabled if empty)'"`
-	CancelListen    string   `kong:"help='Address to serve /cancel and /healthz on (host:port or bare port); splits listeners so history stays internal'"`
+	PrivateListen   string   `kong:"help='Address to serve torrent history on (internal only), as host:port or bare port (disabled if empty)'"`
+	PublicListen    string   `kong:"help='Address to serve /cancel and /healthz on (host:port or bare port); splits listeners so history stays on the private listener'"`
 	TorrentCacheDir string   `kong:"help='Directory to cache fetched .torrent files across runs'"`
 	AccessLog       string   `kong:"help='Path to append-mode HTTP access log for fail2ban integration (disabled if empty)'"`
 }
@@ -151,43 +151,43 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 
 	accessLog := openAccessLog(cmd.AccessLog)
 
-	if cmd.CancelListen != "" {
+	if cmd.PublicListen != "" {
 		// Split-listener mode: /cancel and /healthz on the public port, history on a
-		// separate internal port. Cancel routes are NOT registered on the history mux.
+		// separate private port. Cancel routes are NOT registered on the private mux.
 		if ctx.CancelStore != nil {
-			ctx.CancelListenEnabled = true
+			ctx.PublicListenEnabled = true
 		}
-		addr, err := parseHistoryAddr(cmd.CancelListen)
+		addr, err := parseListenAddr(cmd.PublicListen)
 		if err != nil {
-			log.Fatalf("--cancel-listen: %s", err)
+			log.Fatalf("--public-listen: %s", err)
 		}
 		cancelMux := newCancelMux(ctx.CancelStore, ctx.Config.Cancel, removeT, getProgress, accessLog)
 		registerNotifyCompleteRoute(cancelMux, ctx.Config.Ntfy, ctx.Config.Cancel, accessLog)
 		go startWebServer(cancelMux, addr)
 
-		if cmd.HistoryListen != "" {
-			histAddr, err := parseHistoryAddr(cmd.HistoryListen)
+		if cmd.PrivateListen != "" {
+			histAddr, err := parseListenAddr(cmd.PrivateListen)
 			if err != nil {
-				log.Fatalf("--history-listen: %s", err)
+				log.Fatalf("--private-listen: %s", err)
 			}
 			if ctx.History == nil {
-				log.Warnf("--history-listen is set but --history-file was not provided; history page will return 404")
+				log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
 			}
 			go startWebServer(newWebMux(ctx.History), histAddr)
 		}
-	} else if cmd.HistoryListen != "" {
-		// Single-listener mode (backward compat): history + cancel on the same port.
-		addr, err := parseHistoryAddr(cmd.HistoryListen)
+	} else if cmd.PrivateListen != "" {
+		// Single-listener mode: history + cancel on the same port.
+		addr, err := parseListenAddr(cmd.PrivateListen)
 		if err != nil {
-			log.Fatalf("--history-listen: %s", err)
+			log.Fatalf("--private-listen: %s", err)
 		}
 		if ctx.History == nil {
-			log.Warnf("--history-listen is set but --history-file was not provided; history page will return 404")
+			log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
 		}
 		mux := newWebMux(ctx.History)
 		if ctx.CancelStore != nil {
 			registerCancelRoutes(mux, ctx.CancelStore, ctx.Config.Cancel, removeT, getProgress, accessLog)
-			ctx.CancelListenEnabled = true
+			ctx.PublicListenEnabled = true
 		}
 		registerNotifyCompleteRoute(mux, ctx.Config.Ntfy, ctx.Config.Cancel, accessLog)
 		go startWebServer(mux, addr)

--- a/cmd/rss4transmission/watch_test.go
+++ b/cmd/rss4transmission/watch_test.go
@@ -48,6 +48,20 @@ func TestWatchCmd_NoCancelListenField(t *testing.T) {
 	}
 }
 
+func TestRunContext_HasCancelRoutesEnabledField(t *testing.T) {
+	_, ok := reflect.TypeOf(RunContext{}).FieldByName("CancelRoutesEnabled")
+	if !ok {
+		t.Error("RunContext must have a CancelRoutesEnabled field")
+	}
+}
+
+func TestRunContext_NoPublicListenEnabledField(t *testing.T) {
+	_, ok := reflect.TypeOf(RunContext{}).FieldByName("PublicListenEnabled")
+	if ok {
+		t.Error("RunContext must not have a PublicListenEnabled field; use CancelRoutesEnabled instead")
+	}
+}
+
 func TestConfig_NoHistoryFileField(t *testing.T) {
 	_, ok := reflect.TypeOf(Config{}).FieldByName("HistoryFile")
 	if ok {

--- a/cmd/rss4transmission/watch_test.go
+++ b/cmd/rss4transmission/watch_test.go
@@ -20,6 +20,34 @@ func TestWatchCmd_HasAccessLogField(t *testing.T) {
 	}
 }
 
+func TestWatchCmd_HasPrivateListenField(t *testing.T) {
+	_, ok := reflect.TypeOf(WatchCmd{}).FieldByName("PrivateListen")
+	if !ok {
+		t.Error("WatchCmd must have a PrivateListen field")
+	}
+}
+
+func TestWatchCmd_HasPublicListenField(t *testing.T) {
+	_, ok := reflect.TypeOf(WatchCmd{}).FieldByName("PublicListen")
+	if !ok {
+		t.Error("WatchCmd must have a PublicListen field")
+	}
+}
+
+func TestWatchCmd_NoHistoryListenField(t *testing.T) {
+	_, ok := reflect.TypeOf(WatchCmd{}).FieldByName("HistoryListen")
+	if ok {
+		t.Error("WatchCmd must not have a HistoryListen field; use PrivateListen instead")
+	}
+}
+
+func TestWatchCmd_NoCancelListenField(t *testing.T) {
+	_, ok := reflect.TypeOf(WatchCmd{}).FieldByName("CancelListen")
+	if ok {
+		t.Error("WatchCmd must not have a CancelListen field; use PublicListen instead")
+	}
+}
+
 func TestConfig_NoHistoryFileField(t *testing.T) {
 	_, ok := reflect.TypeOf(Config{}).FieldByName("HistoryFile")
 	if ok {

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -118,10 +118,10 @@ func newAccessLogger(path string) (*logrus.Logger, error) {
 	return lg, nil
 }
 
-// parseHistoryAddr normalises a --history-listen value to a "host:port" address.
+// parseListenAddr normalises a listen address to a "host:port" address.
 // A bare port number is expanded to "127.0.0.1:<port>". Returns an error for
 // invalid or out-of-range values.
-func parseHistoryAddr(s string) (string, error) {
+func parseListenAddr(s string) (string, error) {
 	// If it already contains a colon it is a host:port or [ipv6]:port.
 	if _, portStr, err := net.SplitHostPort(s); err == nil {
 		p, err := strconv.Atoi(portStr)
@@ -178,8 +178,8 @@ func newWebMux(history *HistoryFile) *http.ServeMux {
 }
 
 // newCancelMux builds a public-facing mux serving only GET /cancel, POST /cancel,
-// and GET /healthz. Use this when --cancel-listen is set to expose the cancel
-// endpoint on its own port, keeping the history page on a separate internal listener.
+// and GET /healthz. Use this when --public-listen is set to expose the cancel
+// endpoint on its own port, keeping the history page on a separate private listener.
 // POST /cancel is only registered when both store and remove are non-nil.
 // accessLog is optional; when non-nil each request outcome is written to it.
 func newCancelMux(store *Store, cfg CancelConfig, remove removeFunc, getProgress progressFunc, accessLog *logrus.Logger) *http.ServeMux {

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -802,7 +802,7 @@ func makeTestAccessLogger() (*logrus.Logger, *bytes.Buffer) {
 	return lg, buf
 }
 
-func TestParseHistoryAddr(t *testing.T) {
+func TestParseListenAddr(t *testing.T) {
 	cases := []struct {
 		input   string
 		want    string
@@ -821,7 +821,7 @@ func TestParseHistoryAddr(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.input, func(t *testing.T) {
-			got, err := parseHistoryAddr(tc.input)
+			got, err := parseListenAddr(tc.input)
 			if tc.wantErr {
 				require.Error(t, err)
 			} else {

--- a/docker-compose-gluetun.yaml
+++ b/docker-compose-gluetun.yaml
@@ -21,7 +21,7 @@ services:
       - LOG_LEVEL=info
       - HISTORY_FILE=       # path to history JSON file (e.g. /config/history.json)
       - PRIVATE_LISTEN=     # set to host:port or bare port to enable the history web UI (private)
-      - PUBLIC_LISTEN=      # public-facing /cancel and /healthz only (e.g. 0.0.0.0:8080)
+      - PUBLIC_LISTEN=      # public-facing /cancel, /notify-complete, and /healthz only (e.g. 0.0.0.0:8080)
                             # port-forward from your firewall/NAS to this port
       - TORRENT_CACHE_DIR=  # directory to cache fetched .torrent files (e.g. /config/torrent-cache)
     # Uncomment and set the port to match PUBLIC_LISTEN (and/or PRIVATE_LISTEN).

--- a/docker-compose-gluetun.yaml
+++ b/docker-compose-gluetun.yaml
@@ -20,13 +20,13 @@ services:
       - POLL_SECONDS=120
       - LOG_LEVEL=info
       - HISTORY_FILE=       # path to history JSON file (e.g. /config/history.json)
-      - HISTORY_LISTEN=     # set to host:port or bare port to enable the history web UI
-      - CANCEL_LISTEN=      # public-facing /cancel and /healthz only (e.g. 0.0.0.0:8080)
+      - PRIVATE_LISTEN=     # set to host:port or bare port to enable the history web UI (private)
+      - PUBLIC_LISTEN=      # public-facing /cancel and /healthz only (e.g. 0.0.0.0:8080)
                             # port-forward from your firewall/NAS to this port
       - TORRENT_CACHE_DIR=  # directory to cache fetched .torrent files (e.g. /config/torrent-cache)
-    # Uncomment and set the port to match CANCEL_LISTEN (and/or HISTORY_LISTEN).
+    # Uncomment and set the port to match PUBLIC_LISTEN (and/or PRIVATE_LISTEN).
     # ports:
-    #   - "8080:8080"  # CANCEL_LISTEN port — forward this from your firewall/NAS
+    #   - "8080:8080"  # PUBLIC_LISTEN port — forward this from your firewall/NAS
     volumes:
       - /volume1/docker/transmission/rss4transmission:/config
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,15 +10,15 @@ services:
       - POLL_SECONDS=120
       - LOG_LEVEL=info
       - HISTORY_FILE=       # path to history JSON file (e.g. /config/history.json)
-      - HISTORY_LISTEN=     # host:port or bare port — enables history UI (internal only when CANCEL_LISTEN is set)
-      - CANCEL_LISTEN=      # host:port or bare port — public-facing /cancel and /healthz only
-                            # Set CANCEL_LISTEN and port-forward from your firewall to expose /cancel
-                            # without exposing the history UI. Example: CANCEL_LISTEN=0.0.0.0:8080
-                            # If only HISTORY_LISTEN is set, /cancel is served there too (Traefik mode).
+      - PRIVATE_LISTEN=     # host:port or bare port — enables history UI (private/internal listener)
+      - PUBLIC_LISTEN=      # host:port or bare port — public-facing /cancel and /healthz only
+                            # Set PUBLIC_LISTEN and port-forward from your firewall to expose /cancel
+                            # without exposing the history UI. Example: PUBLIC_LISTEN=0.0.0.0:8080
+                            # If only PRIVATE_LISTEN is set, /cancel is served there too (Traefik mode).
       - TORRENT_CACHE_DIR=  # directory to cache fetched .torrent files (e.g. /config/torrent-cache)
     volumes:
       - /volume1/docker/transmission/rss4transmission:/config
-    # Option A — Traefik routes only /cancel and /healthz externally (CANCEL_LISTEN not needed):
+    # Option A — Traefik routes only /cancel and /healthz externally (PUBLIC_LISTEN not needed):
     networks:
       - internal
       - traefik
@@ -28,8 +28,8 @@ services:
       - "traefik.http.routers.rss4tx.entrypoints=websecure"
       - "traefik.http.routers.rss4tx.tls.certresolver=letsencrypt"
       - "traefik.http.services.rss4tx.loadbalancer.server.port=8080"
-    # Option B — no Traefik; firewall port-forwards directly to CANCEL_LISTEN port:
-    # Set CANCEL_LISTEN=0.0.0.0:8080 and add:
+    # Option B — no Traefik; firewall port-forwards directly to PUBLIC_LISTEN port:
+    # Set PUBLIC_LISTEN=0.0.0.0:8080 and add:
     # ports:
     #   - "8080:8080"
     # Remove the networks/labels above and use network_mode: host or a single internal network.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,9 +11,10 @@ services:
       - LOG_LEVEL=info
       - HISTORY_FILE=       # path to history JSON file (e.g. /config/history.json)
       - PRIVATE_LISTEN=     # host:port or bare port — enables history UI (private/internal listener)
-      - PUBLIC_LISTEN=      # host:port or bare port — public-facing /cancel and /healthz only
-                            # Set PUBLIC_LISTEN and port-forward from your firewall to expose /cancel
-                            # without exposing the history UI. Example: PUBLIC_LISTEN=0.0.0.0:8080
+      - PUBLIC_LISTEN=      # host:port or bare port — public-facing /cancel, /notify-complete,
+                            # and /healthz only. Set PUBLIC_LISTEN and port-forward from your firewall
+                            # to expose /cancel without exposing the history UI.
+                            # Example: PUBLIC_LISTEN=0.0.0.0:8080
                             # If only PRIVATE_LISTEN is set, /cancel is served there too (Traefik mode).
       - TORRENT_CACHE_DIR=  # directory to cache fetched .torrent files (e.g. /config/torrent-cache)
     volumes:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -23,12 +23,12 @@ services:
       - POLL_SECONDS=120
       - LOG_LEVEL=info
       - HISTORY_FILE=       # path to history JSON file (e.g. /config/history.json)
-      - HISTORY_LISTEN=     # host:port or bare port — enables history UI
-      - CANCEL_LISTEN=      # public-facing /cancel and /healthz only
+      - PRIVATE_LISTEN=     # host:port or bare port — enables history UI (private/internal)
+      - PUBLIC_LISTEN=      # public-facing /cancel and /healthz only
       - TORRENT_CACHE_DIR=  # directory to cache .torrent files (e.g. /config/torrent-cache)
     volumes:
       - /volume1/docker/transmission/rss4transmission:/config
-    # Option A — Traefik routes /cancel and /healthz externally (CANCEL_LISTEN not needed):
+    # Option A — Traefik routes /cancel and /healthz externally (PUBLIC_LISTEN not needed):
     networks:
       - internal
       - traefik
@@ -38,8 +38,8 @@ services:
       - "traefik.http.routers.rss4tx.entrypoints=websecure"
       - "traefik.http.routers.rss4tx.tls.certresolver=letsencrypt"
       - "traefik.http.services.rss4tx.loadbalancer.server.port=8080"
-    # Option B — no Traefik; firewall port-forwards directly to CANCEL_LISTEN port:
-    # Set CANCEL_LISTEN=0.0.0.0:8080 and add:
+    # Option B — no Traefik; firewall port-forwards directly to PUBLIC_LISTEN port:
+    # Set PUBLIC_LISTEN=0.0.0.0:8080 and add:
     # ports:
     #   - "8080:8080"
     # Remove the networks/labels above; use network_mode: host or a single internal network.
@@ -100,10 +100,10 @@ services:
       - POLL_SECONDS=120
       - LOG_LEVEL=info
       - HISTORY_FILE=
-      - HISTORY_LISTEN=
-      - CANCEL_LISTEN=      # e.g. 0.0.0.0:8080; port-forward from your firewall to this port
+      - PRIVATE_LISTEN=
+      - PUBLIC_LISTEN=      # e.g. 0.0.0.0:8080; port-forward from your firewall to this port
       - TORRENT_CACHE_DIR=
-    # Uncomment to expose CANCEL_LISTEN externally:
+    # Uncomment to expose PUBLIC_LISTEN externally:
     # ports:
     #   - "8080:8080"
     volumes:
@@ -239,7 +239,7 @@ environment:
 | `POLL_SECONDS` | Seconds between feed scrapes in watch mode (default: `300`) |
 | `LOG_LEVEL` | Log verbosity: `error`, `warn`, `info`, `debug`, `trace` (default: `info`) |
 | `HISTORY_FILE` | Path to the history JSON file; enables history recording when set |
-| `HISTORY_LISTEN` | `host:port` or bare port — starts the history/cancel web UI |
-| `CANCEL_LISTEN` | `host:port` — separate public-facing listener for `/cancel` and `/healthz` |
+| `PRIVATE_LISTEN` | `host:port` or bare port — starts the private history web UI |
+| `PUBLIC_LISTEN` | `host:port` — public-facing listener for `/cancel` and `/healthz` |
 | `TORRENT_CACHE_DIR` | Directory to cache fetched `.torrent` files across runs |
 | `ACCESS_LOG` | Path to the fail2ban-compatible HTTP access log file (append mode); disabled when empty |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -24,7 +24,7 @@ services:
       - LOG_LEVEL=info
       - HISTORY_FILE=       # path to history JSON file (e.g. /config/history.json)
       - PRIVATE_LISTEN=     # host:port or bare port — enables history UI (private/internal)
-      - PUBLIC_LISTEN=      # public-facing /cancel and /healthz only
+      - PUBLIC_LISTEN=      # public-facing /cancel, /notify-complete, and /healthz only
       - TORRENT_CACHE_DIR=  # directory to cache .torrent files (e.g. /config/torrent-cache)
     volumes:
       - /volume1/docker/transmission/rss4transmission:/config
@@ -38,8 +38,8 @@ services:
       - "traefik.http.routers.rss4tx.entrypoints=websecure"
       - "traefik.http.routers.rss4tx.tls.certresolver=letsencrypt"
       - "traefik.http.services.rss4tx.loadbalancer.server.port=8080"
-    # Option B — no Traefik; firewall port-forwards directly to PUBLIC_LISTEN port:
-    # Set PUBLIC_LISTEN=0.0.0.0:8080 and add:
+    # Option B — no Traefik; firewall port-forwards directly to PUBLIC_LISTEN port
+    # (/cancel, /notify-complete, /healthz). Set PUBLIC_LISTEN=0.0.0.0:8080 and add:
     # ports:
     #   - "8080:8080"
     # Remove the networks/labels above; use network_mode: host or a single internal network.
@@ -101,7 +101,7 @@ services:
       - LOG_LEVEL=info
       - HISTORY_FILE=
       - PRIVATE_LISTEN=
-      - PUBLIC_LISTEN=      # e.g. 0.0.0.0:8080; port-forward from your firewall to this port
+      - PUBLIC_LISTEN=      # /cancel, /notify-complete, /healthz (e.g. 0.0.0.0:8080); port-forward from your firewall to this port
       - TORRENT_CACHE_DIR=
     # Uncomment to expose PUBLIC_LISTEN externally:
     # ports:
@@ -240,6 +240,6 @@ environment:
 | `LOG_LEVEL` | Log verbosity: `error`, `warn`, `info`, `debug`, `trace` (default: `info`) |
 | `HISTORY_FILE` | Path to the history JSON file; enables history recording when set |
 | `PRIVATE_LISTEN` | `host:port` or bare port — starts the private history web UI |
-| `PUBLIC_LISTEN` | `host:port` — public-facing listener for `/cancel` and `/healthz` |
+| `PUBLIC_LISTEN` | `host:port` — public-facing listener for `/cancel`, `/notify-complete`, and `/healthz` |
 | `TORRENT_CACHE_DIR` | Directory to cache fetched `.torrent` files across runs |
 | `ACCESS_LOG` | Path to the fail2ban-compatible HTTP access log file (append mode); disabled when empty |

--- a/docs/fail2ban.md
+++ b/docs/fail2ban.md
@@ -21,7 +21,7 @@ is created if it does not exist and opened in append mode so entries survive res
 
 ```bash
 rss4transmission watch \
-  --cancel-listen 0.0.0.0:8080 \
+  --public-listen 0.0.0.0:8080 \
   --access-log /var/log/rss4transmission/access.log \
   ...
 ```

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -120,11 +120,11 @@ There are two deployment models.
 
 **Model 1 — Traefik (or other reverse proxy)**
 
-Use `--history-listen` to start a single web server and let Traefik route only `/cancel` and
+Use `--private-listen` to start a single web server and let Traefik route only `/cancel` and
 `/healthz` externally:
 
 ```bash
-rss4transmission watch --config config.yaml --history-listen :8080
+rss4transmission watch --config config.yaml --private-listen :8080
 ```
 
 The [docker-compose.yaml](../docker-compose.yaml) example defaults to this model. Its Traefik
@@ -132,31 +132,31 @@ labels route only those two paths externally while keeping the history page (`/`
 
 **Model 2 — Direct port-forward (no reverse proxy)**
 
-Use `--cancel-listen` to start a separate public-facing listener that serves only `/cancel`,
-`/notify-complete`, and `/healthz`, keeping the history page on `--history-listen`
+Use `--public-listen` to start a separate public-facing listener that serves only `/cancel`,
+`/notify-complete`, and `/healthz`, keeping the history page on `--private-listen`
 (internal only):
 
 ```bash
 rss4transmission watch --config config.yaml \
-  --cancel-listen 0.0.0.0:8080 \
-  --history-listen 127.0.0.1:9090
+  --public-listen 0.0.0.0:8080 \
+  --private-listen 127.0.0.1:9090
 ```
 
-Port-forward from your firewall directly to the `--cancel-listen` port. The history page is
-never reachable on that port (requests to `/` return 404). `--history-listen` is optional; omit
+Port-forward from your firewall directly to the `--public-listen` port. The history page is
+never reachable on that port (requests to `/` return 404). `--private-listen` is optional; omit
 it if you don't need the history UI.
 
 In Docker:
 
 ```yaml
 environment:
-  - CANCEL_LISTEN=0.0.0.0:8080
-  - HISTORY_LISTEN=127.0.0.1:9090  # optional
+  - PUBLIC_LISTEN=0.0.0.0:8080
+  - PRIVATE_LISTEN=127.0.0.1:9090  # optional
 ports:
   - "8080:8080"
 ```
 
-When using [docker-compose-gluetun.yaml](../docker-compose-gluetun.yaml), set `CANCEL_LISTEN`
+When using [docker-compose-gluetun.yaml](../docker-compose-gluetun.yaml), set `PUBLIC_LISTEN`
 and uncomment the `ports` block to forward the cancel port from your firewall or NAS.
 
 ## History Web UI
@@ -164,20 +164,20 @@ and uncomment the `ports` block to forward the cancel port from your firewall or
 Pass `--history-file` to enable history recording. rss4transmission records the outcome of
 every feed item it processes (dispatched, downloaded, skipped, excluded, error).
 
-Pass `--history-listen` to start the web UI. That flag accepts a bare port number (binds to
+Pass `--private-listen` to start the web UI. That flag accepts a bare port number (binds to
 `127.0.0.1`) or a full `host:port` address (including IPv6 `[::1]:port`).
 
 ```bash
-# Single listener (Traefik routes /cancel externally)
+# Single private listener (Traefik routes /cancel externally)
 rss4transmission watch --config config.yaml \
     --history-file /data/history.json \
-    --history-listen 8080
+    --private-listen 8080
 
-# Split listeners (firewall port-forwards to --cancel-listen)
+# Split listeners (firewall port-forwards to --public-listen)
 rss4transmission watch --config config.yaml \
     --history-file /data/history.json \
-    --history-listen 127.0.0.1:9090 \
-    --cancel-listen 0.0.0.0:8080
+    --private-listen 127.0.0.1:9090 \
+    --public-listen 0.0.0.0:8080
 ```
 
 The history page shows each item's feed name, title, publication date, outcome, and extracted
@@ -188,13 +188,13 @@ In Docker:
 ```yaml
 environment:
   - HISTORY_FILE=/config/history.json
-  - HISTORY_LISTEN=8080             # binds to 127.0.0.1:8080
-  - CANCEL_LISTEN=0.0.0.0:8080     # optional; enables split-listener mode
+  - PRIVATE_LISTEN=8080             # binds to 127.0.0.1:8080
+  - PUBLIC_LISTEN=0.0.0.0:8080     # optional; enables split-listener mode
 ```
 
 ## Routes Overview
 
-| Route | `--history-listen` (single) | `--history-listen` (split) | `--cancel-listen` (split) |
+| Route | `--private-listen` (single) | `--private-listen` (split) | `--public-listen` (split) |
 |---|---|---|---|
 | `/` (history page) | ✓ (requires `--history-file`) | ✓ (requires `--history-file`) | — |
 | `/cancel` | ✓ | — | ✓ |
@@ -208,7 +208,7 @@ details to the `/notify-complete` endpoint, which renders your configured `Compl
 `CompletedBody`, and `CompletedPriority` templates before sending to ntfy.
 
 Set `RSS4TRANSMISSION_URL` to the base URL of your rss4transmission server (same host:port as
-`--cancel-listen` or `--history-listen`). If `Cancel.HMACSecret` is configured, also set
+`--public-listen` or `--private-listen`). If `Cancel.HMACSecret` is configured, also set
 `CANCEL_HMAC_SECRET` to the same value — the endpoint will then require
 `Authorization: Bearer <secret>` and reject unauthenticated requests with `401`.
 


### PR DESCRIPTION
no longer history/cancel, but rather private and public to indicate which need auth tokens