### PR TITLE
Fix Prefer.order silently ignored when label only appears in file names

### DIFF
--- a/cmd/rss4transmission/once.go
+++ b/cmd/rss4transmission/once.go
@@ -138,17 +138,23 @@ type coverage struct {
 	labels      map[string]string
 }
 
-// allLabels returns titleLabels merged with every file's labels (later files
-// override earlier ones, and file labels override title labels for the same
-// key), with extractor defaults filled in for anything still missing. Unlike
-// coverages(), this is not scoped to a single identity key — it's the full
-// label set used when recording a dispatched candidate in the seen cache, so
-// Prefer dimensions that only appear in file names (e.g. resolution) aren't
-// lost on future preference-rank comparisons.
-func (c *candidate) allLabels() map[string]string {
-	merged := make(map[string]string, len(c.titleLabels))
+// allLabels returns titleLabels merged with the labels of every file that
+// forms a valid coverage for identityLabels (same scoping as coverages()),
+// with extractor defaults filled in for anything still missing. A file that
+// matches only a Prefer-dimension regex but not the identity regexes (a
+// sample clip, an NFO, a stray extra) never wins selection and must not be
+// allowed to overwrite a value that came from the file that did. This is the
+// full label set used when recording a dispatched candidate in the seen
+// cache, so Prefer dimensions that only appear in file names (e.g.
+// resolution) aren't lost on future preference-rank comparisons.
+func (c *candidate) allLabels(identityLabels []string) map[string]string {
+	merged := make(map[string]string, len(c.titleLabels)+len(c.fileLabels))
 	maps.Copy(merged, c.titleLabels)
 	for _, fl := range c.fileLabels {
+		combined := withDefaultLabels(MergeLabels(c.titleLabels, fl), c.defaults)
+		if _, ok := IdentityKey(combined, identityLabels); !ok {
+			continue
+		}
 		maps.Copy(merged, fl)
 	}
 	return withDefaultLabels(merged, c.defaults)
@@ -308,15 +314,16 @@ func (cmd *OnceCmd) Run(ctx *RunContext) error {
 // Returns true if the user selected Quit in interactive mode.
 func (cmd *OnceCmd) dispatch(ctx *RunContext, feedCfg Feed, feedName string, w *candidate, keys []string) bool {
 	var err error
+	labels := w.allLabels(feedCfg.Identity)
 
 	if cmd.NoAction {
 		log.Infof("%s match: %s", feedName, w.item.Item.Title)
-		ctx.recordHistory(feedName, w.item.Item, "skipped", "no-action mode", w.titleLabels)
+		ctx.recordHistory(feedName, w.item.Item, "skipped", "no-action mode", labels)
 		return false
 	}
 	if cmd.Skip {
-		ctx.Cache.AddItem(w.item, w.allLabels(), keys)
-		ctx.recordHistory(feedName, w.item.Item, "skipped", "user skip", w.titleLabels)
+		ctx.Cache.AddItem(w.item, labels, keys)
+		ctx.recordHistory(feedName, w.item.Item, "skipped", "user skip", labels)
 		return false
 	}
 	if cmd.Interactive {
@@ -326,34 +333,34 @@ func (cmd *OnceCmd) dispatch(ctx *RunContext, feedCfg Feed, feedName string, w *
 	if cmd.Download {
 		if _, err = w.item.Download(ctx, cmd.DownloadPath, cmd.TorrentCacheDir); err != nil {
 			log.WithError(err).Errorf("Unable to download: %s", w.item.Item.Title)
-			ctx.recordHistory(feedName, w.item.Item, "error", err.Error(), w.titleLabels)
+			ctx.recordHistory(feedName, w.item.Item, "error", err.Error(), labels)
 			return false
 		}
-		ctx.recordHistory(feedName, w.item.Item, "downloaded", "", w.titleLabels)
+		ctx.recordHistory(feedName, w.item.Item, "downloaded", "", labels)
 	} else {
 		torrentBytes, err := ensureTorrentBytes(w.item, cmd.TorrentCacheDir, w.torrentBytes)
 		if err != nil {
 			log.WithError(err).Errorf("Unable to fetch torrent data for %s", w.item.Item.Title)
-			ctx.recordHistory(feedName, w.item.Item, "error", err.Error(), w.titleLabels)
+			ctx.recordHistory(feedName, w.item.Item, "error", err.Error(), labels)
 			return false
 		}
 		torrentID, err := w.item.TorrentWithBytes(ctx, feedCfg.DownloadPath, torrentBytes)
 		if err != nil {
 			log.WithError(err).Errorf("Unable to torrent: %s", feedName)
-			ctx.recordHistory(feedName, w.item.Item, "error", err.Error(), w.titleLabels)
+			ctx.recordHistory(feedName, w.item.Item, "error", err.Error(), labels)
 			return false
 		}
 		meta := CancelMetadata{
 			Title:     w.item.Item.Title,
 			FeedName:  feedName,
-			Labels:    w.titleLabels,
+			Labels:    labels,
 			Files:     w.fileNames,
 			SizeBytes: extractSize(w.item.Item),
 		}
 		sendNtfyStarted(ctx, feedCfg, torrentID, meta, w.item.Item)
-		ctx.recordHistory(feedName, w.item.Item, "dispatched", "", w.titleLabels)
+		ctx.recordHistory(feedName, w.item.Item, "dispatched", "", labels)
 	}
-	ctx.Cache.AddItem(w.item, w.allLabels(), keys)
+	ctx.Cache.AddItem(w.item, labels, keys)
 	return false
 }
 
@@ -361,36 +368,37 @@ func (cmd *OnceCmd) dispatch(ctx *RunContext, feedCfg Feed, feedName string, w *
 // Returns true if the user selected Quit.
 func (cmd *OnceCmd) dispatchInteractive(ctx *RunContext, feedCfg Feed, feedName string, w *candidate, keys []string) bool {
 	var err error
+	labels := w.allLabels(feedCfg.Identity)
 
 	switch prompt(feedName, w.item.Item.Title) {
 	case Download:
 		if _, err = w.item.Download(ctx, cmd.DownloadPath, cmd.TorrentCacheDir); err != nil {
 			log.WithError(err).Errorf("Unable to download: %s", w.item.Item.Title)
-			ctx.recordHistory(feedName, w.item.Item, "error", err.Error(), w.titleLabels)
+			ctx.recordHistory(feedName, w.item.Item, "error", err.Error(), labels)
 			return false
 		}
-		ctx.Cache.AddItem(w.item, w.allLabels(), keys)
-		ctx.recordHistory(feedName, w.item.Item, "downloaded", "", w.titleLabels)
+		ctx.Cache.AddItem(w.item, labels, keys)
+		ctx.recordHistory(feedName, w.item.Item, "downloaded", "", labels)
 	case Torrent:
 		torrentID, err := w.item.TorrentWithBytes(ctx, feedCfg.DownloadPath, w.torrentBytes)
 		if err != nil {
 			log.WithError(err).Errorf("Unable to torrent: %s", feedName)
-			ctx.recordHistory(feedName, w.item.Item, "error", err.Error(), w.titleLabels)
+			ctx.recordHistory(feedName, w.item.Item, "error", err.Error(), labels)
 			return false
 		}
 		meta := CancelMetadata{
 			Title:     w.item.Item.Title,
 			FeedName:  feedName,
-			Labels:    w.titleLabels,
+			Labels:    labels,
 			Files:     w.fileNames,
 			SizeBytes: extractSize(w.item.Item),
 		}
 		sendNtfyStarted(ctx, feedCfg, torrentID, meta, w.item.Item)
-		ctx.Cache.AddItem(w.item, w.allLabels(), keys)
-		ctx.recordHistory(feedName, w.item.Item, "dispatched", "", w.titleLabels)
+		ctx.Cache.AddItem(w.item, labels, keys)
+		ctx.recordHistory(feedName, w.item.Item, "dispatched", "", labels)
 	case Skip:
-		ctx.Cache.AddItem(w.item, w.allLabels(), keys)
-		ctx.recordHistory(feedName, w.item.Item, "skipped", "user skip", w.titleLabels)
+		ctx.Cache.AddItem(w.item, labels, keys)
+		ctx.recordHistory(feedName, w.item.Item, "skipped", "user skip", labels)
 	case SkipOnce:
 		// don't add to cache
 	case Quit:

--- a/cmd/rss4transmission/once.go
+++ b/cmd/rss4transmission/once.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -135,6 +136,22 @@ func (c *candidate) coverages(identityLabels []string) []coverage {
 type coverage struct {
 	identityKey string
 	labels      map[string]string
+}
+
+// allLabels returns titleLabels merged with every file's labels (later files
+// override earlier ones, and file labels override title labels for the same
+// key), with extractor defaults filled in for anything still missing. Unlike
+// coverages(), this is not scoped to a single identity key — it's the full
+// label set used when recording a dispatched candidate in the seen cache, so
+// Prefer dimensions that only appear in file names (e.g. resolution) aren't
+// lost on future preference-rank comparisons.
+func (c *candidate) allLabels() map[string]string {
+	merged := make(map[string]string, len(c.titleLabels))
+	maps.Copy(merged, c.titleLabels)
+	for _, fl := range c.fileLabels {
+		maps.Copy(merged, fl)
+	}
+	return withDefaultLabels(merged, c.defaults)
 }
 
 // feedAllowed reports whether feedName should be processed given the --feed filter.
@@ -298,7 +315,7 @@ func (cmd *OnceCmd) dispatch(ctx *RunContext, feedCfg Feed, feedName string, w *
 		return false
 	}
 	if cmd.Skip {
-		ctx.Cache.AddItem(w.item, w.titleLabels, keys)
+		ctx.Cache.AddItem(w.item, w.allLabels(), keys)
 		ctx.recordHistory(feedName, w.item.Item, "skipped", "user skip", w.titleLabels)
 		return false
 	}
@@ -336,7 +353,7 @@ func (cmd *OnceCmd) dispatch(ctx *RunContext, feedCfg Feed, feedName string, w *
 		sendNtfyStarted(ctx, feedCfg, torrentID, meta, w.item.Item)
 		ctx.recordHistory(feedName, w.item.Item, "dispatched", "", w.titleLabels)
 	}
-	ctx.Cache.AddItem(w.item, w.titleLabels, keys)
+	ctx.Cache.AddItem(w.item, w.allLabels(), keys)
 	return false
 }
 
@@ -352,7 +369,7 @@ func (cmd *OnceCmd) dispatchInteractive(ctx *RunContext, feedCfg Feed, feedName 
 			ctx.recordHistory(feedName, w.item.Item, "error", err.Error(), w.titleLabels)
 			return false
 		}
-		ctx.Cache.AddItem(w.item, w.titleLabels, keys)
+		ctx.Cache.AddItem(w.item, w.allLabels(), keys)
 		ctx.recordHistory(feedName, w.item.Item, "downloaded", "", w.titleLabels)
 	case Torrent:
 		torrentID, err := w.item.TorrentWithBytes(ctx, feedCfg.DownloadPath, w.torrentBytes)
@@ -369,10 +386,10 @@ func (cmd *OnceCmd) dispatchInteractive(ctx *RunContext, feedCfg Feed, feedName 
 			SizeBytes: extractSize(w.item.Item),
 		}
 		sendNtfyStarted(ctx, feedCfg, torrentID, meta, w.item.Item)
-		ctx.Cache.AddItem(w.item, w.titleLabels, keys)
+		ctx.Cache.AddItem(w.item, w.allLabels(), keys)
 		ctx.recordHistory(feedName, w.item.Item, "dispatched", "", w.titleLabels)
 	case Skip:
-		ctx.Cache.AddItem(w.item, w.titleLabels, keys)
+		ctx.Cache.AddItem(w.item, w.allLabels(), keys)
 		ctx.recordHistory(feedName, w.item.Item, "skipped", "user skip", w.titleLabels)
 	case SkipOnce:
 		// don't add to cache

--- a/cmd/rss4transmission/once_test.go
+++ b/cmd/rss4transmission/once_test.go
@@ -156,7 +156,7 @@ func TestAllLabels_MergesFileLabelsOverTitle(t *testing.T) {
 		map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race"},
 		[]map[string]string{{"resolution": "1080p"}},
 	)
-	got := c.allLabels()
+	got := c.allLabels([]string{"series", "round", "session"})
 	if got["resolution"] != "1080p" {
 		t.Errorf("allLabels()[resolution] = %q, want 1080p (from file label)", got["resolution"])
 	}
@@ -170,7 +170,7 @@ func TestAllLabels_FileLabelOverridesTitleLabel(t *testing.T) {
 		map[string]string{"series": "MotoGP", "resolution": "720p"},
 		[]map[string]string{{"resolution": "1080p"}},
 	)
-	got := c.allLabels()
+	got := c.allLabels([]string{"series"})
 	if got["resolution"] != "1080p" {
 		t.Errorf("allLabels()[resolution] = %q, want 1080p (file label overrides title)", got["resolution"])
 	}
@@ -179,9 +179,26 @@ func TestAllLabels_FileLabelOverridesTitleLabel(t *testing.T) {
 func TestAllLabels_AppliesDefaultsForMissingLabels(t *testing.T) {
 	c := makeCandidate("t1", map[string]string{"series": "MotoGP"}, nil)
 	c.defaults = map[string]string{"language": "English"}
-	got := c.allLabels()
+	got := c.allLabels([]string{"series"})
 	if got["language"] != "English" {
 		t.Errorf("allLabels()[language] = %q, want English (from default)", got["language"])
+	}
+}
+
+func TestAllLabels_ExcludesFileWithoutValidIdentityKey(t *testing.T) {
+	// Regression: a file that matches only the resolution regex (e.g. a
+	// sample clip) but not the identity labels must not be allowed to
+	// overwrite the resolution from the file that actually won selection.
+	c := makeCandidate("bundle",
+		map[string]string{"round": "RD01", "session": "Race"}, // no series in title
+		[]map[string]string{
+			{"series": "MotoGP", "resolution": "1080p"}, // valid coverage
+			{"resolution": "720p"},                      // sample: no series -> no valid coverage
+		},
+	)
+	got := c.allLabels([]string{"series", "round", "session"})
+	if got["resolution"] != "1080p" {
+		t.Errorf("allLabels()[resolution] = %q, want 1080p (sample file's 720p must not override the winning coverage's value)", got["resolution"])
 	}
 }
 
@@ -208,6 +225,31 @@ func TestDispatch_Skip_RecordsFileDerivedLabelsInCache(t *testing.T) {
 	require.Len(t, ctx.Cache.Seen, 1)
 	assert.Equal(t, "1080p", ctx.Cache.Seen[0].Labels["resolution"],
 		"cached labels should include the file-derived resolution label used to rank this candidate")
+}
+
+// Regression: the History UI/ntfy metadata used to be seeded from titleLabels
+// while the cache used the merged labels, so a dispatched item's history
+// record wouldn't show the file-derived label that actually decided its
+// preference rank.
+func TestDispatch_Skip_RecordsFileDerivedLabelsInHistory(t *testing.T) {
+	c := makeCandidate("guid1",
+		map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race"},
+		[]map[string]string{{"resolution": "1080p"}},
+	)
+	feedCfg := makeFeed([]string{"series", "round", "session"}, nil, nil)
+	keys := []string{"series=MotoGP|round=RD01|session=Race"}
+
+	ctx := &RunContext{
+		Cache:   emptyCache(),
+		History: &HistoryFile{guidIndex: map[string]int{}},
+	}
+	cmd := &OnceCmd{Skip: true}
+	cmd.dispatch(ctx, feedCfg, "testfeed", c, keys)
+
+	records := ctx.History.GetRecords()
+	require.Len(t, records, 1)
+	assert.Equal(t, "1080p", records[0].Labels["resolution"],
+		"history record should include the file-derived resolution label, matching what was cached")
 }
 
 // --- selectWinners ---

--- a/cmd/rss4transmission/once_test.go
+++ b/cmd/rss4transmission/once_test.go
@@ -148,6 +148,68 @@ func TestCoverages_DeduplicatesKeys(t *testing.T) {
 	}
 }
 
+// --- candidate.allLabels ---
+
+func TestAllLabels_MergesFileLabelsOverTitle(t *testing.T) {
+	// resolution is only present in the file name, not the RSS title.
+	c := makeCandidate("t1",
+		map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race"},
+		[]map[string]string{{"resolution": "1080p"}},
+	)
+	got := c.allLabels()
+	if got["resolution"] != "1080p" {
+		t.Errorf("allLabels()[resolution] = %q, want 1080p (from file label)", got["resolution"])
+	}
+	if got["series"] != "MotoGP" {
+		t.Errorf("allLabels()[series] = %q, want MotoGP (from title label)", got["series"])
+	}
+}
+
+func TestAllLabels_FileLabelOverridesTitleLabel(t *testing.T) {
+	c := makeCandidate("t1",
+		map[string]string{"series": "MotoGP", "resolution": "720p"},
+		[]map[string]string{{"resolution": "1080p"}},
+	)
+	got := c.allLabels()
+	if got["resolution"] != "1080p" {
+		t.Errorf("allLabels()[resolution] = %q, want 1080p (file label overrides title)", got["resolution"])
+	}
+}
+
+func TestAllLabels_AppliesDefaultsForMissingLabels(t *testing.T) {
+	c := makeCandidate("t1", map[string]string{"series": "MotoGP"}, nil)
+	c.defaults = map[string]string{"language": "English"}
+	got := c.allLabels()
+	if got["language"] != "English" {
+		t.Errorf("allLabels()[language] = %q, want English (from default)", got["language"])
+	}
+}
+
+// --- dispatch cache recording ---
+
+// Regression test: Prefer.order ranking is computed from merged title+file
+// labels (candidate.coverages), but the cache used to be seeded from
+// titleLabels only. When a Prefer dimension (like resolution) is only present
+// in the torrent's file names, the cached record lost that label, so future
+// runs saw a "worst possible" cached rank and would re-dispatch a lower
+// preference candidate, silently ignoring the configured order.
+func TestDispatch_Skip_RecordsFileDerivedLabelsInCache(t *testing.T) {
+	c := makeCandidate("guid1",
+		map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race"},
+		[]map[string]string{{"resolution": "1080p"}},
+	)
+	feedCfg := makeFeed([]string{"series", "round", "session"}, nil, nil)
+	keys := []string{"series=MotoGP|round=RD01|session=Race"}
+
+	ctx := &RunContext{Cache: emptyCache()}
+	cmd := &OnceCmd{Skip: true}
+	cmd.dispatch(ctx, feedCfg, "testfeed", c, keys)
+
+	require.Len(t, ctx.Cache.Seen, 1)
+	assert.Equal(t, "1080p", ctx.Cache.Seen[0].Labels["resolution"],
+		"cached labels should include the file-derived resolution label used to rank this candidate")
+}
+
 // --- selectWinners ---
 
 func TestSelectWinners_SingleCandidate(t *testing.T) {

--- a/cmd/rss4transmission/simulate.go
+++ b/cmd/rss4transmission/simulate.go
@@ -117,8 +117,9 @@ func (cmd *SimulateCmd) dispatchBatch(ctx *RunContext, feedCfg Feed, candidates 
 			for j, cov := range covs {
 				keys[j] = cov.identityKey
 			}
-			log.Infof("WINNER: %s labels=%v", c.item.Item.Title, c.titleLabels)
-			ctx.Cache.AddItem(c.item, c.titleLabels, keys)
+			labels := c.allLabels(feedCfg.Identity)
+			log.Infof("WINNER: %s labels=%v", c.item.Item.Title, labels)
+			ctx.Cache.AddItem(c.item, labels, keys)
 			count++
 		} else {
 			log.Debugf("skipped: %s", c.item.Item.Title)

--- a/cmd/rss4transmission/simulate_test.go
+++ b/cmd/rss4transmission/simulate_test.go
@@ -238,6 +238,30 @@ func TestDispatchBatch_MultiBatch_BetterPreference(t *testing.T) {
 	}
 }
 
+func TestDispatchBatch_CachesFileDerivedLabels(t *testing.T) {
+	// Regression: resolution is only present in file names, not the title.
+	// dispatchBatch must still cache it so a later worse-preference candidate
+	// in a subsequent batch is correctly rejected.
+	cmd, _ := simTestCmd(t)
+	ctx := simTestCtx()
+	feedCfg := testFeedForSim()
+
+	c1 := makeCandidate("batch1",
+		map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race"},
+		[]map[string]string{{"resolution": "1080p"}},
+	)
+	cmd.dispatchBatch(ctx, feedCfg, []*candidate{c1})
+
+	c2 := makeCandidate("batch2",
+		map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race", "resolution": "720p"},
+		nil,
+	)
+	won := cmd.dispatchBatch(ctx, feedCfg, []*candidate{c2})
+	if won != 0 {
+		t.Errorf("expected 0 winners in batch 2 (720p should lose to cached 1080p, even though 1080p only came from a file label), got %d", won)
+	}
+}
+
 func TestDispatchBatch_FileNotOverwritten(t *testing.T) {
 	// If a .torrent file already exists on disk, it should not be overwritten.
 	cmd, dir := simTestCmd(t)


### PR DESCRIPTION
selectWinners ranks candidates using merged title+file labels, but dispatch only cached titleLabels. When a Prefer dimension (e.g. resolution) was extracted solely from torrent file names, the cached record lost that label, so BestRankForKey saw it as worst-possible on future runs and let lower-preference candidates re-dispatch. Cache the full merged label set instead via the new candidate.allLabels().