### PR TITLE
Process feeds in config order and stop the run after first dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Pre-built images are available on [DockerHub](https://hub.docker.com/r/synfinati
   Transmission when running behind [Gluetun](https://github.com/qdm12/gluetun)
 - **Torrent file cache** — avoids re-fetching `.torrent` files on every watch-loop iteration;
   pruned automatically
+- **Ordered, stop-after-dispatch processing** — feeds are processed in the order they're listed
+  in the config file; as soon as one torrent is dispatched or downloaded, the run stops
+  immediately, resuming with the next feed on the following `once`/`watch` tick
 - **fail2ban integration** — optional access log with timestamps and client IPs lets fail2ban
   detect and ban brute-force attempts against the cancel endpoint
 

--- a/cmd/rss4transmission/cache.go
+++ b/cmd/rss4transmission/cache.go
@@ -104,17 +104,25 @@ func (c *CacheFile) BestRankForKey(key string, prefer []PreferDimension) ([]int,
 // SaveCache updates the cache and removes any entries older than the specified
 // duration.
 // SaveCache prunes records and writes to disk. A record is kept if it is within
-// the retention window d, or if its GUID is still present in activeGUIDs
-// (feed name → set of GUIDs currently in the feed). Pass nil for activeGUIDs
-// to use time-based pruning only.
+// the retention window d, if its GUID is still present in activeGUIDs (feed
+// name → set of GUIDs currently in the feed), or if its feed has a present-but-
+// nil entry in activeGUIDs — meaning the feed is still configured but wasn't
+// actually fetched this run (early stop, --feed filter, or a fetch error), so
+// there's no evidence the GUID is gone and pruning is deferred to a run that
+// actually checks it. A feed name absent from activeGUIDs entirely (no longer
+// configured) falls back to time-based pruning. Pass nil for activeGUIDs to use
+// time-based pruning only.
 func (c *CacheFile) SaveCache(d time.Duration, activeGUIDs map[string]map[string]bool) error {
 	deletedRecord := false
 	newSeen := []CacheRecord{}
 
 	for _, s := range c.Seen {
 		withinWindow := time.Since(s.AddTime).Hours() < d.Hours()
-		stillInFeed := activeGUIDs[s.Feed] != nil && activeGUIDs[s.Feed][s.GUID]
-		if withinWindow || stillInFeed {
+		feedGUIDs, feedConfigured := activeGUIDs[s.Feed]
+		fetchedThisRun := feedGUIDs != nil
+		stillInFeed := fetchedThisRun && feedGUIDs[s.GUID]
+		notCheckedThisRun := feedConfigured && !fetchedThisRun
+		if withinWindow || stillInFeed || notCheckedThisRun {
 			newSeen = append(newSeen, s)
 		} else {
 			deletedRecord = true

--- a/cmd/rss4transmission/cache_test.go
+++ b/cmd/rss4transmission/cache_test.go
@@ -509,6 +509,62 @@ func TestSaveCache_OldAndNotInFeed_Pruned(t *testing.T) {
 	}
 }
 
+func TestSaveCache_FeedConfiguredButNotFetchedThisRun_NotPruned(t *testing.T) {
+	// A feed that is still configured but wasn't fetched this run (early stop,
+	// --feed filter, or a fetch error) is represented in activeGUIDs by a
+	// present key with a nil value. Records for it must not be pruned just
+	// because we have no fresh evidence either way.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache.json")
+
+	old := time.Now().Add(-365 * 24 * time.Hour)
+	c := &CacheFile{
+		Version: CACHE_VERSION,
+		Errors:  map[string]int64{},
+		Seen: []CacheRecord{
+			{Feed: "unvisited", GUID: "guid1", AddTime: old},
+		},
+		filename: path,
+		needSave: true,
+	}
+	activeGUIDs := map[string]map[string]bool{
+		"unvisited": nil, // configured, but not fetched this run
+	}
+	if err := c.SaveCache(30*24*time.Hour, activeGUIDs); err != nil {
+		t.Fatalf("SaveCache returned error: %v", err)
+	}
+	if len(c.Seen) != 1 {
+		t.Errorf("expected record kept (feed not fetched this run), got %d records", len(c.Seen))
+	}
+}
+
+func TestSaveCache_FeedRemovedFromConfig_StillPrunedByTime(t *testing.T) {
+	// A feed no longer present in activeGUIDs at all (removed from config
+	// entirely) must fall back to time-based pruning, not be retained forever.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache.json")
+
+	old := time.Now().Add(-365 * 24 * time.Hour)
+	c := &CacheFile{
+		Version: CACHE_VERSION,
+		Errors:  map[string]int64{},
+		Seen: []CacheRecord{
+			{Feed: "removed", GUID: "guid1", AddTime: old},
+		},
+		filename: path,
+		needSave: true,
+	}
+	activeGUIDs := map[string]map[string]bool{
+		"other": {"guid2": true}, // "removed" isn't a key at all
+	}
+	if err := c.SaveCache(30*24*time.Hour, activeGUIDs); err != nil {
+		t.Fatalf("SaveCache returned error: %v", err)
+	}
+	if len(c.Seen) != 0 {
+		t.Errorf("expected record pruned (feed no longer configured), got %d records", len(c.Seen))
+	}
+}
+
 func TestSaveCache_SkipsWhenUnchanged(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "cache.json")

--- a/cmd/rss4transmission/config.go
+++ b/cmd/rss4transmission/config.go
@@ -38,7 +38,7 @@ var ConfigDefaults = map[string]interface{}{
 }
 
 type Config struct {
-	Feeds         map[string]Feed          `koanf:"Feeds"`
+	Feeds         []Feed                   `koanf:"Feeds"`
 	Extractors    map[string]*ExtractorSet `koanf:"Extractors"`
 	Transmission  Transmission             `koanf:"Transmission"`
 	Gluetun       GluetunConfig            `koanf:"Gluetun"`
@@ -92,6 +92,7 @@ type GluetunConfig struct {
 }
 
 type Feed struct {
+	Name           string   `koanf:"Name"`
 	URL            string   `koanf:"URL"`
 	Exclude        []string `koanf:"Exclude"`
 	DownloadPath   string   `koanf:"DownloadPath"`
@@ -112,6 +113,23 @@ type Feed struct {
 	exclude  []*regexp.Regexp
 	minSize  uint64
 	maxSize  uint64
+}
+
+// validateFeedNames ensures every feed has a non-empty, unique Name. Since
+// Feeds is an ordered list rather than a map, Name is the only identifier
+// tying a feed to its cache records, history entries, and --feed filter.
+func validateFeedNames(feeds []Feed) error {
+	seen := make(map[string]bool, len(feeds))
+	for _, f := range feeds {
+		if f.Name == "" {
+			return fmt.Errorf("feed with URL %q: Name is required", f.URL)
+		}
+		if seen[f.Name] {
+			return fmt.Errorf("duplicate feed name %q", f.Name)
+		}
+		seen[f.Name] = true
+	}
+	return nil
 }
 
 // Validate checks that the feed config is self-consistent.

--- a/cmd/rss4transmission/config_test.go
+++ b/cmd/rss4transmission/config_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/mmcdole/gofeed"
@@ -123,5 +125,147 @@ func TestFeedValidate_Valid(t *testing.T) {
 	}
 	if err := f.Validate("myfeed", map[string]*ExtractorSet{"racing": es}); err != nil {
 		t.Errorf("expected valid feed to pass validation: %v", err)
+	}
+}
+
+func TestValidateFeedNames_Unique(t *testing.T) {
+	feeds := []Feed{{Name: "A", URL: "https://a"}, {Name: "B", URL: "https://b"}}
+	if err := validateFeedNames(feeds); err != nil {
+		t.Errorf("expected no error for unique names, got: %v", err)
+	}
+}
+
+func TestValidateFeedNames_BlankName(t *testing.T) {
+	feeds := []Feed{{Name: "", URL: "https://a"}}
+	if err := validateFeedNames(feeds); err == nil {
+		t.Error("expected error for blank feed name")
+	}
+}
+
+func TestValidateFeedNames_Duplicate(t *testing.T) {
+	feeds := []Feed{{Name: "A", URL: "https://a"}, {Name: "A", URL: "https://b"}}
+	if err := validateFeedNames(feeds); err == nil {
+		t.Error("expected error for duplicate feed name")
+	}
+}
+
+func TestLoadConfig_FeedsPreserveFileOrder(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	yamlContent := `
+Feeds:
+  - Name: Zzz
+    URL: https://example.com/z
+  - Name: Aaa
+    URL: https://example.com/a
+  - Name: Mmm
+    URL: https://example.com/m
+`
+	if err := os.WriteFile(cfgPath, []byte(yamlContent), 0600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	rc := &RunContext{}
+	if _, err := rc.loadConfig(cfgPath); err != nil {
+		t.Fatalf("loadConfig failed: %v", err)
+	}
+
+	want := []string{"Zzz", "Aaa", "Mmm"}
+	if len(rc.Config.Feeds) != len(want) {
+		t.Fatalf("expected %d feeds, got %d", len(want), len(rc.Config.Feeds))
+	}
+	for i, name := range want {
+		if rc.Config.Feeds[i].Name != name {
+			t.Errorf("feed[%d].Name = %q, want %q", i, rc.Config.Feeds[i].Name, name)
+		}
+	}
+}
+
+func TestLoadConfig_RejectsDuplicateFeedNames(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	yamlContent := `
+Feeds:
+  - Name: Dup
+    URL: https://example.com/a
+  - Name: Dup
+    URL: https://example.com/b
+`
+	if err := os.WriteFile(cfgPath, []byte(yamlContent), 0600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	rc := &RunContext{}
+	if _, err := rc.loadConfig(cfgPath); err == nil {
+		t.Error("expected loadConfig to reject duplicate feed names")
+	}
+}
+
+func TestLoadConfig_RejectsBlankFeedName(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	yamlContent := `
+Feeds:
+  - URL: https://example.com/a
+`
+	if err := os.WriteFile(cfgPath, []byte(yamlContent), 0600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	rc := &RunContext{}
+	if _, err := rc.loadConfig(cfgPath); err == nil {
+		t.Error("expected loadConfig to reject a blank feed name")
+	}
+}
+
+func TestLoadConfig_BadReload_KeepsPreviousGoodConfig(t *testing.T) {
+	// Simulates watch's live config-reload path: loadConfig is called again on
+	// the same RunContext. A reload with duplicate/blank feed names must be
+	// rejected without corrupting the already-running, valid config.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	goodYAML := `
+Feeds:
+  - Name: Good1
+    URL: https://example.com/1
+  - Name: Good2
+    URL: https://example.com/2
+`
+	if err := os.WriteFile(cfgPath, []byte(goodYAML), 0600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	rc := &RunContext{}
+	if _, err := rc.loadConfig(cfgPath); err != nil {
+		t.Fatalf("initial loadConfig failed: %v", err)
+	}
+	if len(rc.Config.Feeds) != 2 {
+		t.Fatalf("expected 2 feeds after initial load, got %d", len(rc.Config.Feeds))
+	}
+
+	badYAML := `
+Feeds:
+  - Name: Dup
+    URL: https://example.com/1
+  - Name: Dup
+    URL: https://example.com/2
+`
+	if err := os.WriteFile(cfgPath, []byte(badYAML), 0600); err != nil {
+		t.Fatalf("failed to overwrite config: %v", err)
+	}
+
+	if _, err := rc.loadConfig(cfgPath); err == nil {
+		t.Error("expected reload with duplicate feed names to fail")
+	}
+
+	if len(rc.Config.Feeds) != 2 {
+		t.Fatalf("expected previous config to survive a bad reload, got %d feeds", len(rc.Config.Feeds))
+	}
+	want := []string{"Good1", "Good2"}
+	for i, name := range want {
+		if rc.Config.Feeds[i].Name != name {
+			t.Errorf("feed[%d].Name = %q, want %q (config should be unchanged after bad reload)",
+				i, rc.Config.Feeds[i].Name, name)
+		}
 	}
 }

--- a/cmd/rss4transmission/main.go
+++ b/cmd/rss4transmission/main.go
@@ -142,9 +142,9 @@ func main() {
 		log.WithError(err).Fatalf("Unable to load %s", rc.configFile)
 	}
 
-	for name, feedCfg := range rc.Config.Feeds {
-		if err = feedCfg.Validate(name, rc.Config.Extractors); err != nil {
-			log.WithError(err).Fatalf("Invalid feed %q config", name)
+	for _, feedCfg := range rc.Config.Feeds {
+		if err = feedCfg.Validate(feedCfg.Name, rc.Config.Extractors); err != nil {
+			log.WithError(err).Fatalf("Invalid feed %q config", feedCfg.Name)
 		}
 	}
 
@@ -221,13 +221,23 @@ func (rc *RunContext) loadConfig(configFile string) (*koanf.Koanf, error) {
 		return konf, err
 	}
 
-	if err := konf.Unmarshal("", &rc.Config); err != nil {
+	var cfg Config
+	if err := konf.Unmarshal("", &cfg); err != nil {
 		return konf, err
 	}
 
-	if err := rc.Config.Ntfy.Validate(); err != nil {
+	if err := cfg.Ntfy.Validate(); err != nil {
 		return konf, fmt.Errorf("invalid ntfy template: %w", err)
 	}
+
+	if err := validateFeedNames(cfg.Feeds); err != nil {
+		return konf, fmt.Errorf("invalid feed configuration: %w", err)
+	}
+
+	// Only commit the newly parsed config once every check above has passed,
+	// so a bad reload (e.g. watch.go's live config-reload) leaves the
+	// previously running config fully intact instead of partially applied.
+	rc.Config = cfg
 
 	return konf, nil
 }

--- a/cmd/rss4transmission/once.go
+++ b/cmd/rss4transmission/once.go
@@ -167,7 +167,8 @@ func (cmd *OnceCmd) feedAllowed(feedName string) bool {
 
 // processFeed runs phases 1–4 for a single feed: build candidates, fetch
 // torrent data, select winners, and dispatch. Returns true if the caller
-// should stop processing further feeds (interactive Quit).
+// should stop processing further feeds this run — either a torrent was
+// dispatched/downloaded, or the user selected Quit interactively.
 func (cmd *OnceCmd) processFeed(ctx *RunContext, feedName string, feedCfg Feed, rss *gofeed.Feed, extractor *ExtractorSet) bool {
 	// Phase 1: Pre-filter candidates via Exclude + size, then extract title labels.
 	var candidates []*candidate
@@ -229,20 +230,23 @@ func (cmd *OnceCmd) processFeed(ctx *RunContext, feedName string, feedCfg Feed, 
 }
 
 // collectActiveGUIDs builds a map of feed name → set of GUIDs currently
-// present in the fetched RSS feeds. Used by SaveCache to retain entries whose
-// torrent link is still live.
-func collectActiveGUIDs(feeds Feeds, cfgs map[string]Feed) map[string]map[string]bool {
+// present in the fetched RSS feeds. Every configured feed gets an entry: a
+// populated set if its RSS was fetched this run, or an explicit nil if it
+// wasn't (early stop, --feed filter, or a fetch error) — the nil lets
+// SaveCache tell "not checked this run" apart from "no longer configured".
+func collectActiveGUIDs(feeds Feeds, cfgs []Feed) map[string]map[string]bool {
 	active := make(map[string]map[string]bool, len(cfgs))
-	for feedName, feedCfg := range cfgs {
+	for _, feedCfg := range cfgs {
 		rss := feeds[feedCfg.URL]
 		if rss == nil {
+			active[feedCfg.Name] = nil
 			continue
 		}
 		m := make(map[string]bool, len(rss.Items))
 		for _, item := range rss.Items {
 			m[item.GUID] = true
 		}
-		active[feedName] = m
+		active[feedCfg.Name] = m
 	}
 	return active
 }
@@ -260,17 +264,17 @@ func (cmd *OnceCmd) Run(ctx *RunContext) error {
 	// Cache gofeed results per URL so each RSS endpoint is fetched only once.
 	feeds := Feeds{}
 
-	for feedName, feedCfg := range ctx.Config.Feeds {
-		if !cmd.feedAllowed(feedName) {
+	for _, feedCfg := range ctx.Config.Feeds {
+		if !cmd.feedAllowed(feedCfg.Name) {
 			continue
 		}
 		if feedCfg.Extractor == "" {
-			log.Warnf("Feed %q has no Extractor configured, skipping", feedName)
+			log.Warnf("Feed %q has no Extractor configured, skipping", feedCfg.Name)
 			continue
 		}
 		extractor, ok := ctx.Config.Extractors[feedCfg.Extractor]
 		if !ok {
-			log.Errorf("Feed %q references unknown Extractor %q, skipping", feedName, feedCfg.Extractor)
+			log.Errorf("Feed %q references unknown Extractor %q, skipping", feedCfg.Name, feedCfg.Extractor)
 			continue
 		}
 
@@ -288,7 +292,7 @@ func (cmd *OnceCmd) Run(ctx *RunContext) error {
 			continue
 		}
 
-		if cmd.processFeed(ctx, feedName, feedCfg, feeds[feedCfg.URL], extractor) {
+		if cmd.processFeed(ctx, feedCfg.Name, feedCfg, feeds[feedCfg.URL], extractor) {
 			break
 		}
 	}
@@ -311,7 +315,10 @@ func (cmd *OnceCmd) Run(ctx *RunContext) error {
 }
 
 // dispatch handles a single winner: submits it and records it in the cache.
-// Returns true if the user selected Quit in interactive mode.
+// Returns true if processing should stop for the rest of this run — either
+// because the item was actually dispatched (torrented or downloaded), or the
+// user selected Quit in interactive mode. NoAction, Skip, and error paths
+// never stop processing, since nothing was produced.
 func (cmd *OnceCmd) dispatch(ctx *RunContext, feedCfg Feed, feedName string, w *candidate, keys []string) bool {
 	var err error
 	labels := w.allLabels(feedCfg.Identity)
@@ -361,11 +368,13 @@ func (cmd *OnceCmd) dispatch(ctx *RunContext, feedCfg Feed, feedName string, w *
 		ctx.recordHistory(feedName, w.item.Item, "dispatched", "", labels)
 	}
 	ctx.Cache.AddItem(w.item, labels, keys)
-	return false
+	return true
 }
 
-// dispatchInteractive prompts the user for what to do with a winner.
-// Returns true if the user selected Quit.
+// dispatchInteractive prompts the user for what to do with a winner. Returns
+// true if processing should stop for the rest of this run — either because
+// the item was actually dispatched (torrented or downloaded), or the user
+// selected Quit.
 func (cmd *OnceCmd) dispatchInteractive(ctx *RunContext, feedCfg Feed, feedName string, w *candidate, keys []string) bool {
 	var err error
 	labels := w.allLabels(feedCfg.Identity)
@@ -379,6 +388,7 @@ func (cmd *OnceCmd) dispatchInteractive(ctx *RunContext, feedCfg Feed, feedName 
 		}
 		ctx.Cache.AddItem(w.item, labels, keys)
 		ctx.recordHistory(feedName, w.item.Item, "downloaded", "", labels)
+		return true
 	case Torrent:
 		torrentID, err := w.item.TorrentWithBytes(ctx, feedCfg.DownloadPath, w.torrentBytes)
 		if err != nil {
@@ -396,6 +406,7 @@ func (cmd *OnceCmd) dispatchInteractive(ctx *RunContext, feedCfg Feed, feedName 
 		sendNtfyStarted(ctx, feedCfg, torrentID, meta, w.item.Item)
 		ctx.Cache.AddItem(w.item, labels, keys)
 		ctx.recordHistory(feedName, w.item.Item, "dispatched", "", labels)
+		return true
 	case Skip:
 		ctx.Cache.AddItem(w.item, labels, keys)
 		ctx.recordHistory(feedName, w.item.Item, "skipped", "user skip", labels)

--- a/cmd/rss4transmission/once_test.go
+++ b/cmd/rss4transmission/once_test.go
@@ -1,14 +1,17 @@
 package main
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/hekmon/transmissionrpc/v3"
 	"github.com/mmcdole/gofeed"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -250,6 +253,155 @@ func TestDispatch_Skip_RecordsFileDerivedLabelsInHistory(t *testing.T) {
 	require.Len(t, records, 1)
 	assert.Equal(t, "1080p", records[0].Labels["resolution"],
 		"history record should include the file-derived resolution label, matching what was cached")
+}
+
+// --- dispatch stop-processing semantics ---
+
+// fakeTransmissionServer emulates just enough of Transmission's RPC protocol
+// (the X-Transmission-Session-Id CSRF handshake, then a successful
+// "torrent-add" reply) for transmissionrpc.Client.TorrentAdd to succeed.
+func fakeTransmissionServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	const sessionID = "test-session-id"
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Transmission-Session-Id") != sessionID {
+			w.Header().Set("X-Transmission-Session-Id", sessionID)
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+		var req struct {
+			Tag int `json:"tag"`
+		}
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &req))
+
+		resp := map[string]any{
+			"result": "success",
+			"tag":    req.Tag,
+			"arguments": map[string]any{
+				"torrent-added": map[string]any{"id": 1},
+			},
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
+	}))
+}
+
+func TestDispatch_NoAction_DoesNotStopProcessing(t *testing.T) {
+	c := makeCandidate("guid1", map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race"}, nil)
+	feedCfg := makeFeed([]string{"series", "round", "session"}, nil, nil)
+	keys := []string{"series=MotoGP|round=RD01|session=Race"}
+
+	ctx := &RunContext{Cache: emptyCache(), History: &HistoryFile{guidIndex: map[string]int{}}}
+	cmd := &OnceCmd{NoAction: true}
+	stop := cmd.dispatch(ctx, feedCfg, "testfeed", c, keys)
+
+	assert.False(t, stop, "--no-action must never stop processing")
+}
+
+func TestDispatch_Skip_DoesNotStopProcessing(t *testing.T) {
+	c := makeCandidate("guid1", map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race"}, nil)
+	feedCfg := makeFeed([]string{"series", "round", "session"}, nil, nil)
+	keys := []string{"series=MotoGP|round=RD01|session=Race"}
+
+	ctx := &RunContext{Cache: emptyCache(), History: &HistoryFile{guidIndex: map[string]int{}}}
+	cmd := &OnceCmd{Skip: true}
+	stop := cmd.dispatch(ctx, feedCfg, "testfeed", c, keys)
+
+	assert.False(t, stop, "--skip must never stop processing")
+}
+
+func TestDispatch_Download_StopsProcessing(t *testing.T) {
+	torrentSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("fake torrent content"))
+	}))
+	defer torrentSrv.Close()
+
+	c := &candidate{
+		item: &FeedItem{
+			Feed: "testfeed",
+			Item: &gofeed.Item{
+				Title: "guid1",
+				GUID:  "guid1",
+				Enclosures: []*gofeed.Enclosure{
+					{URL: torrentSrv.URL + "/my.torrent", Type: "application/x-bittorrent"},
+				},
+			},
+		},
+		titleLabels: map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race"},
+	}
+	feedCfg := makeFeed([]string{"series", "round", "session"}, nil, nil)
+	keys := []string{"series=MotoGP|round=RD01|session=Race"}
+
+	ctx := &RunContext{Cache: emptyCache(), History: &HistoryFile{guidIndex: map[string]int{}}}
+	cmd := &OnceCmd{Download: true, DownloadPath: t.TempDir()}
+	stop := cmd.dispatch(ctx, feedCfg, "testfeed", c, keys)
+
+	assert.True(t, stop, "a successful --download must stop processing")
+	records := ctx.History.GetRecords()
+	require.Len(t, records, 1)
+	assert.Equal(t, "downloaded", records[0].Outcome)
+}
+
+func TestDispatch_RealSubmit_StopsProcessing(t *testing.T) {
+	srv := fakeTransmissionServer(t)
+	defer srv.Close()
+	endpoint, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	client, err := transmissionrpc.New(endpoint, nil)
+	require.NoError(t, err)
+
+	c := makeCandidate("guid1", map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race"}, nil)
+	c.torrentBytes = []byte("fake torrent data") // pre-populated so no network fetch is needed
+	feedCfg := makeFeed([]string{"series", "round", "session"}, nil, nil)
+	keys := []string{"series=MotoGP|round=RD01|session=Race"}
+
+	ctx := &RunContext{
+		Cache:        emptyCache(),
+		History:      &HistoryFile{guidIndex: map[string]int{}},
+		Transmission: client,
+	}
+	cmd := &OnceCmd{}
+	stop := cmd.dispatch(ctx, feedCfg, "testfeed", c, keys)
+
+	assert.True(t, stop, "a real Transmission submission must stop processing")
+	records := ctx.History.GetRecords()
+	require.Len(t, records, 1)
+	assert.Equal(t, "dispatched", records[0].Outcome)
+}
+
+// --- collectActiveGUIDs ---
+
+func TestCollectActiveGUIDs_FetchedFeed_ListsItsGUIDs(t *testing.T) {
+	feeds := Feeds{
+		"https://a": {Items: []*gofeed.Item{{GUID: "g1"}, {GUID: "g2"}}},
+	}
+	cfgs := []Feed{{Name: "A", URL: "https://a"}}
+
+	active := collectActiveGUIDs(feeds, cfgs)
+
+	require.Contains(t, active, "A")
+	assert.True(t, active["A"]["g1"])
+	assert.True(t, active["A"]["g2"])
+}
+
+func TestCollectActiveGUIDs_UnfetchedFeed_GetsPresentNilEntry(t *testing.T) {
+	// A configured feed whose URL was never fetched this run (early stop,
+	// --feed filter, or a fetch error) must still get a map entry — present
+	// but nil — so SaveCache can distinguish "not checked" from "no longer
+	// configured".
+	feeds := Feeds{} // nothing fetched
+	cfgs := []Feed{{Name: "B", URL: "https://b"}}
+
+	active := collectActiveGUIDs(feeds, cfgs)
+
+	guids, ok := active["B"]
+	if !ok {
+		t.Fatal("expected an entry for feed B even though it wasn't fetched")
+	}
+	if guids != nil {
+		t.Errorf("expected nil GUID set for unfetched feed, got %v", guids)
+	}
 }
 
 // --- selectWinners ---

--- a/cmd/rss4transmission/simulate.go
+++ b/cmd/rss4transmission/simulate.go
@@ -17,8 +17,19 @@ type SimulateCmd struct {
 	Dir      string `kong:"default='.',name='torrent-dir',help='Directory to write .torrent files'"`
 }
 
+// findFeedByName returns the feed with the given Name, since Feeds is an
+// ordered list rather than a map.
+func findFeedByName(feeds []Feed, name string) (Feed, bool) {
+	for _, f := range feeds {
+		if f.Name == name {
+			return f, true
+		}
+	}
+	return Feed{}, false
+}
+
 func (cmd *SimulateCmd) Run(ctx *RunContext) error {
-	feedCfg, ok := ctx.Config.Feeds[cmd.Feed]
+	feedCfg, ok := findFeedByName(ctx.Config.Feeds, cmd.Feed)
 	if !ok {
 		return fmt.Errorf("feed %q not found in config", cmd.Feed)
 	}

--- a/cmd/rss4transmission/simulate_test.go
+++ b/cmd/rss4transmission/simulate_test.go
@@ -20,6 +20,26 @@ func simTestCmd(t *testing.T) (*SimulateCmd, string) {
 	return &SimulateCmd{Dir: dir}, dir
 }
 
+// --- findFeedByName ---
+
+func TestFindFeedByName_Found(t *testing.T) {
+	feeds := []Feed{{Name: "A", URL: "https://a"}, {Name: "B", URL: "https://b"}}
+	got, ok := findFeedByName(feeds, "B")
+	if !ok {
+		t.Fatal("expected to find feed B")
+	}
+	if got.URL != "https://b" {
+		t.Errorf("got URL %q, want https://b", got.URL)
+	}
+}
+
+func TestFindFeedByName_NotFound(t *testing.T) {
+	feeds := []Feed{{Name: "A", URL: "https://a"}}
+	if _, ok := findFeedByName(feeds, "Missing"); ok {
+		t.Error("expected ok=false for missing feed name")
+	}
+}
+
 // --- sanitizeFilename ---
 
 func TestSanitizeFilename_Clean(t *testing.T) {

--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -8,6 +8,7 @@ All feeds support these options:
 
 | Field | Description |
 |---|---|
+| `Name` | Unique feed name (required). Feeds are processed in the order they're listed. |
 | `URL` | RSS feed URL (required) |
 | `DownloadPath` | Destination directory for torrents added to Transmission |
 | `Exclude` | List of regexes — items whose title matches any are skipped before label extraction |
@@ -15,6 +16,11 @@ All feeds support these options:
 | `NoValidateCert` | Skip TLS certificate validation for this feed's URL |
 | `NoSubmit` | Dry-run: log matches but do not send to Transmission |
 | `NoNotify` | Skip ntfy notifications for this feed (see [Notifications](notifications.md)) |
+
+`Feeds` is a list, so feeds are always processed in the order they appear in the config file. As
+soon as one item is actually dispatched (submitted to Transmission or downloaded to disk with
+`--download`), the current `once`/`watch` run stops immediately — remaining feeds and candidates
+are picked up on the next run.
 
 ## Label-Based Feed Configuration
 
@@ -62,7 +68,7 @@ A feed enters label mode when `Extractor` is set:
 
 ```yaml
 Feeds:
-  MotoGP2024:
+  - Name: MotoGP2024
     URL: https://rss.example.com/feed
     DownloadPath: /torrents/motogp
     Exclude:
@@ -130,7 +136,7 @@ Extractors:
         Regexp: '(\d{3,4}p)'
 
 Feeds:
-  MotoGP2024:
+  - Name: MotoGP2024
     URL: https://rss.example.com/feed
     DownloadPath: /torrents/motogp
     Extractor: motogp


### PR DESCRIPTION
Feeds are now a list (map iteration order was randomized), so config-file order is preserved, and each feed requires a unique Name that becomes the sole identity for cache/history/--feed lookups. As soon as one torrent is dispatched or downloaded, the current once/watch run stops immediately, resuming with the next feed on the following tick.

Also fixes two correctness gaps this introduced: SaveCache no longer prunes cache records for feeds that simply weren't reached this run (previously risked duplicate resubmission once a feed's records aged past SeenCacheDays), and watch's live config reload now re-validates feed names so a bad hot-edit can't silently corrupt the running config.