### PR TITLE
Add Torrent retry button to History web page; rename ntfy Cancel action

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,12 @@ Pre-built images are available on [DockerHub](https://hub.docker.com/r/synfinati
   resolution, etc.) from torrent titles and file names; deduplicate by identity key; prefer
   higher-quality versions automatically
 - **[ntfy](https://ntfy.sh) push notifications** — receive a notification when a torrent starts
-  (with a Cancel button) and when it completes; notification title, body, and priority are
+  (with a More Info button) and when it completes; notification title, body, and priority are
   user-defined via `text/template` strings in the config file, with full access to torrent
   metadata (labels, size, feed name, GUID, and more)
 - **History web UI** — browsable record of every processed feed item with outcome and extracted
-  labels
+  labels; skipped, excluded, and error items can be re-submitted to Transmission with a Torrent
+  button
 - **Gluetun VPN integration** — automatically restarts the VPN and syncs the peer port into
   Transmission when running behind [Gluetun](https://github.com/qdm12/gluetun)
 - **Torrent file cache** — avoids re-fetching `.torrent` files on every watch-loop iteration;

--- a/cmd/rss4transmission/feed.go
+++ b/cmd/rss4transmission/feed.go
@@ -84,6 +84,14 @@ func (fi *FeedItem) fetchTorrent() ([]byte, error) {
 	if err != nil {
 		return []byte{}, err
 	}
+	return fetchTorrentBytes(torrentUrl)
+}
+
+// fetchTorrentBytes downloads the .torrent file at url. It is a standalone
+// function (rather than a FeedItem method) so callers with only a URL — such
+// as a history-page retry that has no live RSS entry to fetch through — can
+// use it directly.
+func fetchTorrentBytes(torrentUrl string) ([]byte, error) {
 	resp, err := http.Get(torrentUrl) //nolint:gosec
 	if err != nil {
 		return []byte{}, fmt.Errorf("unable to download %s: %s", torrentUrl, err)

--- a/cmd/rss4transmission/feed_test.go
+++ b/cmd/rss4transmission/feed_test.go
@@ -180,6 +180,41 @@ func TestGetTorrentContents_HTTPError(t *testing.T) {
 	}
 }
 
+// --- fetchTorrentBytes ---
+
+func TestFetchTorrentBytes_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-bittorrent")
+		w.Write(sentinelTorrent) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	got, err := fetchTorrentBytes(srv.URL + "/my.torrent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(got, sentinelTorrent) {
+		t.Errorf("got %q, want sentinel bytes", got)
+	}
+}
+
+func TestFetchTorrentBytes_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	if _, err := fetchTorrentBytes(srv.URL + "/missing.torrent"); err == nil {
+		t.Error("expected error for non-2xx HTTP response, got nil")
+	}
+}
+
+func TestFetchTorrentBytes_ConnectionError(t *testing.T) {
+	if _, err := fetchTorrentBytes("http://127.0.0.1:1/unreachable"); err == nil {
+		t.Error("expected error for connection failure, got nil")
+	}
+}
+
 func TestIsComplete_False(t *testing.T) {
 	fi := &FeedItem{Complete: false}
 	if fi.IsComplete() {

--- a/cmd/rss4transmission/history.go
+++ b/cmd/rss4transmission/history.go
@@ -47,6 +47,8 @@ type HistoryRecord struct {
 	Outcome     string            `json:"Outcome"`
 	Reason      string            `json:"Reason,omitempty"`
 	Labels      map[string]string `json:"Labels,omitempty"`
+	TorrentURL  string            `json:"TorrentURL,omitempty"`
+	SizeBytes   int64             `json:"SizeBytes,omitempty"`
 }
 
 // outcomeRank returns a rank for dedup: lower is more interesting.
@@ -68,15 +70,21 @@ func historyKey(feedName, guid string) string {
 	return feedName + "|" + guid
 }
 
-// NewHistoryRecord builds a HistoryRecord from a gofeed.Item.
+// NewHistoryRecord builds a HistoryRecord from a gofeed.Item. TorrentURL and
+// SizeBytes are captured from the item's bittorrent enclosure (when present) so
+// a later "torrent this" retry can re-fetch the .torrent without the original
+// RSS entry — dispatch() never persists the .torrent bytes themselves.
 func NewHistoryRecord(feedName string, item *gofeed.Item, outcome, reason string, labels map[string]string) HistoryRecord {
+	torrentURL, _ := (&FeedItem{Item: item}).TorrentURL()
 	rec := HistoryRecord{
-		Feed:    feedName,
-		Title:   item.Title,
-		GUID:    item.GUID,
-		Outcome: outcome,
-		Reason:  reason,
-		Labels:  labels,
+		Feed:       feedName,
+		Title:      item.Title,
+		GUID:       item.GUID,
+		Outcome:    outcome,
+		Reason:     reason,
+		Labels:     labels,
+		TorrentURL: torrentURL,
+		SizeBytes:  extractSize(item),
 	}
 	if item.PublishedParsed != nil {
 		rec.Published = *item.PublishedParsed
@@ -161,6 +169,17 @@ func (ctx *RunContext) recordHistory(feedName string, item *gofeed.Item, outcome
 	if ctx.History != nil {
 		ctx.History.AddOrUpdateRecord(NewHistoryRecord(feedName, item, outcome, reason, labels))
 	}
+}
+
+// FindRecord looks up a single record by feed name and GUID.
+func (h *HistoryFile) FindRecord(feedName, guid string) (HistoryRecord, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	idx, ok := h.guidIndex[historyKey(feedName, guid)]
+	if !ok {
+		return HistoryRecord{}, false
+	}
+	return h.Records[idx], true
 }
 
 // GetRecords returns a copy of all records for safe concurrent reads.

--- a/cmd/rss4transmission/history_test.go
+++ b/cmd/rss4transmission/history_test.go
@@ -107,6 +107,60 @@ func TestNewHistoryRecord_WithPublished(t *testing.T) {
 	}
 }
 
+func TestNewHistoryRecord_CapturesTorrentURLAndSize(t *testing.T) {
+	item := makeGofeedItem("My Show S01E01", "guid1")
+	item.Enclosures = []*gofeed.Enclosure{
+		{URL: "https://example.com/my.torrent", Type: "application/x-bittorrent", Length: "12345"},
+	}
+	rec := NewHistoryRecord("feed", item, "skipped", "outranked", nil)
+
+	if rec.TorrentURL != "https://example.com/my.torrent" {
+		t.Errorf("TorrentURL = %q, want https://example.com/my.torrent", rec.TorrentURL)
+	}
+	if rec.SizeBytes != 12345 {
+		t.Errorf("SizeBytes = %d, want 12345", rec.SizeBytes)
+	}
+}
+
+func TestNewHistoryRecord_NoEnclosure_LeavesTorrentURLAndSizeZero(t *testing.T) {
+	item := makeGofeedItem("title", "guid")
+	rec := NewHistoryRecord("feed", item, "excluded", "", nil)
+
+	if rec.TorrentURL != "" {
+		t.Errorf("TorrentURL = %q, want empty", rec.TorrentURL)
+	}
+	if rec.SizeBytes != 0 {
+		t.Errorf("SizeBytes = %d, want 0", rec.SizeBytes)
+	}
+}
+
+// --- FindRecord ---
+
+func TestFindRecord_Found(t *testing.T) {
+	h := emptyHistory()
+	h.AddOrUpdateRecord(NewHistoryRecord("feed", makeGofeedItem("Show", "guid1"), "skipped", "reason", nil))
+
+	rec, ok := h.FindRecord("feed", "guid1")
+	if !ok {
+		t.Fatal("expected to find record")
+	}
+	if rec.Title != "Show" {
+		t.Errorf("Title = %q, want Show", rec.Title)
+	}
+}
+
+func TestFindRecord_NotFound(t *testing.T) {
+	h := emptyHistory()
+	h.AddOrUpdateRecord(NewHistoryRecord("feed", makeGofeedItem("Show", "guid1"), "skipped", "reason", nil))
+
+	if _, ok := h.FindRecord("feed", "guid-missing"); ok {
+		t.Error("expected not to find record with unknown GUID")
+	}
+	if _, ok := h.FindRecord("other-feed", "guid1"); ok {
+		t.Error("expected not to find record with unknown feed")
+	}
+}
+
 // --- AddOrUpdateRecord ---
 
 func TestAddOrUpdateRecord_NewGUID(t *testing.T) {

--- a/cmd/rss4transmission/ntfy.go
+++ b/cmd/rss4transmission/ntfy.go
@@ -135,7 +135,7 @@ func (c *NtfyClient) SendTorrentStarted(ctx *NtfyTemplateContext) error {
 	}
 	var actions string
 	if ctx.CancelURL != "" {
-		actions = fmt.Sprintf("view, Cancel Download, %s", ctx.CancelURL)
+		actions = fmt.Sprintf("view, More Info, %s", ctx.CancelURL)
 	}
 	return c.post(title, body, actions, c.cfg.StartedPriority)
 }

--- a/cmd/rss4transmission/ntfy_test.go
+++ b/cmd/rss4transmission/ntfy_test.go
@@ -44,7 +44,7 @@ func TestSendTorrentStarted_Headers(t *testing.T) {
 	assert.Equal(t, "Torrent Started", captured.Header.Get("Title"))
 	assert.Equal(t, "default", captured.Header.Get("Priority"))
 
-	wantAction := "view, Cancel Download, https://example.com/cancel?id=x"
+	wantAction := "view, More Info, https://example.com/cancel?id=x"
 	assert.Equal(t, wantAction, captured.Header.Get("Actions"))
 
 	assert.Equal(t, "Bearer tk_testtoken", captured.Header.Get("Authorization"))

--- a/cmd/rss4transmission/once.go
+++ b/cmd/rss4transmission/once.go
@@ -371,6 +371,65 @@ func (cmd *OnceCmd) dispatch(ctx *RunContext, feedCfg Feed, feedName string, w *
 	return true
 }
 
+// retryHistoryItem re-submits a previously skipped/excluded/error history
+// record to Transmission. Unlike dispatch(), which works from a freshly
+// extracted candidate, this fetches the .torrent fresh from rec.TorrentURL
+// since the original bytes are never persisted to history. Cache and history
+// updates here are in-memory only (via AddItem/recordHistory) — persistence to
+// disk is left to the next scheduled once.Run() tick, same as every other
+// mutation dispatch() makes mid-run.
+func retryHistoryItem(ctx *RunContext, rec HistoryRecord) (int64, error) {
+	if rec.TorrentURL == "" {
+		return 0, fmt.Errorf("no torrent URL recorded for %q", rec.Title)
+	}
+	if rec.Outcome == "dispatched" || rec.Outcome == "downloaded" {
+		return 0, fmt.Errorf("%q was already %s", rec.Title, rec.Outcome)
+	}
+	feedCfg, ok := findFeedByName(ctx.Config.Feeds, rec.Feed)
+	if !ok {
+		return 0, fmt.Errorf("feed %q is no longer configured", rec.Feed)
+	}
+
+	torrentBytes, err := fetchTorrentBytes(rec.TorrentURL)
+	if err != nil {
+		return 0, fmt.Errorf("unable to fetch torrent data for %q: %w", rec.Title, err)
+	}
+
+	item := &gofeed.Item{Title: rec.Title, GUID: rec.GUID}
+	if !rec.Published.IsZero() {
+		item.PublishedParsed = &rec.Published
+	}
+	fi := &FeedItem{Feed: rec.Feed, Item: item}
+
+	torrentID, err := fi.TorrentWithBytes(ctx, feedCfg.DownloadPath, torrentBytes)
+	if err != nil {
+		return 0, fmt.Errorf("unable to torrent %q: %w", rec.Title, err)
+	}
+
+	// A bundle candidate can cover several identity keys at once (see
+	// candidate.coverages), but history only ever persists the single merged
+	// label set, so at most one key is recoverable here.
+	var keys []string
+	if key, ok := IdentityKey(rec.Labels, feedCfg.Identity); ok {
+		keys = []string{key}
+	}
+	ctx.Cache.AddItem(fi, rec.Labels, keys)
+
+	fileNames, _ := TorrentFileNames(torrentBytes)
+	meta := CancelMetadata{
+		Title:     rec.Title,
+		FeedName:  rec.Feed,
+		Labels:    rec.Labels,
+		Files:     fileNames,
+		SizeBytes: rec.SizeBytes,
+	}
+	sendNtfyStarted(ctx, feedCfg, torrentID, meta, item)
+
+	ctx.recordHistory(rec.Feed, item, "dispatched", "", rec.Labels)
+
+	return torrentID, nil
+}
+
 // dispatchInteractive prompts the user for what to do with a winner. Returns
 // true if processing should stop for the rest of this run — either because
 // the item was actually dispatched (torrented or downloaded), or the user

--- a/cmd/rss4transmission/once_test.go
+++ b/cmd/rss4transmission/once_test.go
@@ -370,6 +370,98 @@ func TestDispatch_RealSubmit_StopsProcessing(t *testing.T) {
 	assert.Equal(t, "dispatched", records[0].Outcome)
 }
 
+// --- retryHistoryItem ---
+
+func TestRetryHistoryItem_Success(t *testing.T) {
+	transmissionSrv := fakeTransmissionServer(t)
+	defer transmissionSrv.Close()
+	endpoint, err := url.Parse(transmissionSrv.URL)
+	require.NoError(t, err)
+	client, err := transmissionrpc.New(endpoint, nil)
+	require.NoError(t, err)
+
+	torrentSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("fake torrent content"))
+	}))
+	defer torrentSrv.Close()
+
+	feedCfg := makeFeed([]string{"series", "round", "session"}, nil, nil)
+	feedCfg.Name = "testfeed"
+	feedCfg.DownloadPath = t.TempDir()
+
+	ctx := &RunContext{
+		Cache:        emptyCache(),
+		History:      &HistoryFile{guidIndex: map[string]int{}},
+		Transmission: client,
+		Config:       Config{Feeds: []Feed{feedCfg}},
+	}
+	ctx.History.AddOrUpdateRecord(NewHistoryRecord("testfeed",
+		&gofeed.Item{Title: "guid1", GUID: "guid1"}, "skipped", "outranked", nil))
+
+	rec := HistoryRecord{
+		Feed:       "testfeed",
+		Title:      "guid1",
+		GUID:       "guid1",
+		Outcome:    "skipped",
+		Labels:     map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race"},
+		TorrentURL: torrentSrv.URL + "/my.torrent",
+	}
+
+	torrentID, err := retryHistoryItem(ctx, rec)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, torrentID)
+
+	assert.True(t, ctx.Cache.Exists("testfeed", &FeedItem{Feed: "testfeed", Item: &gofeed.Item{GUID: "guid1"}}),
+		"cache should record the manually-retried GUID")
+
+	updated, ok := ctx.History.FindRecord("testfeed", "guid1")
+	require.True(t, ok)
+	assert.Equal(t, "dispatched", updated.Outcome)
+}
+
+func TestRetryHistoryItem_NoTorrentURL(t *testing.T) {
+	ctx := &RunContext{Cache: emptyCache(), History: &HistoryFile{guidIndex: map[string]int{}}}
+	rec := HistoryRecord{Feed: "testfeed", GUID: "guid1", Outcome: "skipped"}
+
+	_, err := retryHistoryItem(ctx, rec)
+	assert.Error(t, err)
+	assert.Empty(t, ctx.Cache.Seen)
+}
+
+func TestRetryHistoryItem_UnknownFeed(t *testing.T) {
+	ctx := &RunContext{Cache: emptyCache(), History: &HistoryFile{guidIndex: map[string]int{}}}
+	rec := HistoryRecord{
+		Feed:       "no-such-feed",
+		GUID:       "guid1",
+		Outcome:    "skipped",
+		TorrentURL: "https://example.com/my.torrent",
+	}
+
+	_, err := retryHistoryItem(ctx, rec)
+	assert.Error(t, err)
+	assert.Empty(t, ctx.Cache.Seen)
+}
+
+func TestRetryHistoryItem_AlreadyDispatched(t *testing.T) {
+	feedCfg := makeFeed([]string{"series"}, nil, nil)
+	feedCfg.Name = "testfeed"
+	ctx := &RunContext{
+		Cache:   emptyCache(),
+		History: &HistoryFile{guidIndex: map[string]int{}},
+		Config:  Config{Feeds: []Feed{feedCfg}},
+	}
+	rec := HistoryRecord{
+		Feed:       "testfeed",
+		GUID:       "guid1",
+		Outcome:    "dispatched",
+		TorrentURL: "https://example.com/my.torrent",
+	}
+
+	_, err := retryHistoryItem(ctx, rec)
+	assert.Error(t, err)
+	assert.Empty(t, ctx.Cache.Seen)
+}
+
 // --- collectActiveGUIDs ---
 
 func TestCollectActiveGUIDs_FetchedFeed_ListsItsGUIDs(t *testing.T) {

--- a/cmd/rss4transmission/watch.go
+++ b/cmd/rss4transmission/watch.go
@@ -155,6 +155,16 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 		return retryHistoryItem(ctx, rec)
 	}
 
+	// feedConfigured checks against the live (possibly reloaded) config, so
+	// the history page's Torrent button reflects the config as it stands at
+	// render time, not as it was when the server started.
+	feedConfigured := func(name string) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		_, ok := findFeedByName(ctx.Config.Feeds, name)
+		return ok
+	}
+
 	accessLog := openAccessLog(cmd.AccessLog)
 
 	if cmd.PublicListen != "" {
@@ -180,7 +190,7 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 			if ctx.History == nil {
 				log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
 			}
-			go startWebServer("private", newWebMux(ctx.History, retryHistory), histAddr)
+			go startWebServer("private", newWebMux(ctx.History, retryHistory, feedConfigured), histAddr)
 		}
 	} else if cmd.PrivateListen != "" {
 		// Single-listener mode: history + cancel on the same port.
@@ -191,7 +201,7 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 		if ctx.History == nil {
 			log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
 		}
-		mux := newWebMux(ctx.History, retryHistory)
+		mux := newWebMux(ctx.History, retryHistory, feedConfigured)
 		if ctx.CancelStore != nil {
 			registerCancelRoutes(mux, ctx.CancelStore, ctx.Config.Cancel, removeT, getProgress, accessLog)
 			ctx.CancelRoutesEnabled = true

--- a/cmd/rss4transmission/watch.go
+++ b/cmd/rss4transmission/watch.go
@@ -149,6 +149,12 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 		}
 	}
 
+	retryHistory := func(rec HistoryRecord) (int64, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		return retryHistoryItem(ctx, rec)
+	}
+
 	accessLog := openAccessLog(cmd.AccessLog)
 
 	if cmd.PublicListen != "" {
@@ -174,7 +180,7 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 			if ctx.History == nil {
 				log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
 			}
-			go startWebServer("private", newWebMux(ctx.History), histAddr)
+			go startWebServer("private", newWebMux(ctx.History, retryHistory), histAddr)
 		}
 	} else if cmd.PrivateListen != "" {
 		// Single-listener mode: history + cancel on the same port.
@@ -185,7 +191,7 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 		if ctx.History == nil {
 			log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
 		}
-		mux := newWebMux(ctx.History)
+		mux := newWebMux(ctx.History, retryHistory)
 		if ctx.CancelStore != nil {
 			registerCancelRoutes(mux, ctx.CancelStore, ctx.Config.Cancel, removeT, getProgress, accessLog)
 			ctx.CancelRoutesEnabled = true

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -144,9 +144,16 @@ func parseListenAddr(s string) (string, error) {
 
 // newWebMux builds the shared HTTP mux. If history is non-nil, the history
 // page is served at "/". When history and retry are both non-nil, POST /torrent
-// is also registered to re-submit a past skipped/excluded/error item. The
-// /healthz route is always registered.
-func newWebMux(history *HistoryFile, retry retryFunc) *http.ServeMux {
+// is also registered to re-submit a past skipped/excluded/error item.
+// feedConfigured reports whether a feed name is still present in the live
+// config; the Torrent button is hidden on the history page for records whose
+// feed no longer exists, since retrying one always fails with "feed ... is no
+// longer configured". A nil feedConfigured shows the button unconditionally.
+// The /healthz route is always registered.
+func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name string) bool) *http.ServeMux {
+	if feedConfigured == nil {
+		feedConfigured = func(string) bool { return true }
+	}
 	funcMap := template.FuncMap{
 		"outcomeClass": func(outcome string) string {
 			switch outcome {
@@ -158,6 +165,7 @@ func newWebMux(history *HistoryFile, retry retryFunc) *http.ServeMux {
 				return "skipped"
 			}
 		},
+		"feedConfigured": feedConfigured,
 	}
 	tmpl := template.Must(template.New("history").Funcs(funcMap).Parse(historyTmpl))
 

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -49,6 +49,10 @@ type removeFunc func(ctx context.Context, ids []int64) error
 // should show "Unknown" rather than failing the request.
 type progressFunc func(ctx context.Context, torrentID int64) (downloadedBytes int64, percentDone float64, err error)
 
+// retryFunc re-submits a previously skipped/excluded/error history record to
+// Transmission. Returns the new Transmission torrent ID.
+type retryFunc func(rec HistoryRecord) (int64, error)
+
 // cancelPageData is passed to the cancel confirmation template.
 type cancelPageData struct {
 	Title         string
@@ -139,8 +143,10 @@ func parseListenAddr(s string) (string, error) {
 }
 
 // newWebMux builds the shared HTTP mux. If history is non-nil, the history
-// page is served at "/". The /healthz route is always registered.
-func newWebMux(history *HistoryFile) *http.ServeMux {
+// page is served at "/". When history and retry are both non-nil, POST /torrent
+// is also registered to re-submit a past skipped/excluded/error item. The
+// /healthz route is always registered.
+func newWebMux(history *HistoryFile, retry retryFunc) *http.ServeMux {
 	funcMap := template.FuncMap{
 		"outcomeClass": func(outcome string) string {
 			switch outcome {
@@ -158,7 +164,7 @@ func newWebMux(history *HistoryFile) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	if history != nil {
-		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
 			records := history.GetRecords()
 			for i, j := 0, len(records)-1; i < j; i, j = i+1, j-1 {
 				records[i], records[j] = records[j], records[i]
@@ -170,11 +176,46 @@ func newWebMux(history *HistoryFile) *http.ServeMux {
 		})
 	}
 
+	if history != nil && retry != nil {
+		mux.HandleFunc("POST /torrent", makePostTorrentHandler(history, retry))
+	}
+
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
 	return mux
+}
+
+// makePostTorrentHandler processes a manual "torrent this" request from the
+// history page. It resolves feed+guid to a HistoryRecord and delegates the
+// actual re-submission to retry.
+func makePostTorrentHandler(history *HistoryFile, retry retryFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "invalid form body", http.StatusBadRequest)
+			return
+		}
+
+		feed := r.FormValue("feed")
+		guid := r.FormValue("guid")
+		rec, ok := history.FindRecord(feed, guid)
+		if !ok {
+			http.Error(w, "history record not found", http.StatusNotFound)
+			return
+		}
+
+		if _, err := retry(rec); err != nil {
+			log.WithError(err).Warnf("Failed to retry torrent for %q", rec.Title)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		log.Infof("Manually torrented %q from history page", rec.Title)
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "Torrent submitted.") //nolint:errcheck
+	}
 }
 
 // newCancelMux builds a public-facing mux serving only GET /cancel, POST /cancel,

--- a/cmd/rss4transmission/web/history.html
+++ b/cmd/rss4transmission/web/history.html
@@ -64,6 +64,19 @@
         th:nth-child(2), td:nth-child(2) { width: 9em; }
         th:nth-child(4), td:nth-child(4) { width: 8em; }
         th:nth-child(5), td:nth-child(5) { width: 18em; }
+        th:nth-child(6), td:nth-child(6) { width: 7em; }
+
+        .btn-torrent {
+            background: #06c;
+            color: #fff;
+            border: none;
+            padding: 0.3em 0.9em;
+            font-family: monospace;
+            font-size: 0.85em;
+            cursor: pointer;
+        }
+        .btn-torrent:hover { background: #08e; }
+        .btn-torrent:disabled { background: #444; color: #888; cursor: default; }
     </style>
 </head>
 <body>
@@ -116,6 +129,7 @@
                 <th>Title</th>
                 <th>Outcome</th>
                 <th>Reason</th>
+                <th>Action</th>
             </tr>
         </thead>
         <tbody id="rows">
@@ -127,8 +141,13 @@
                     {{ if .GUID }}<a href="{{ .GUID }}" target="_blank" rel="noopener">{{ .Title }}</a>{{ else }}{{ .Title }}{{ end }}
                     {{ if .Labels }}<div class="labels">{{ range $k, $v := .Labels }}{{ $k }}={{ $v }} {{ end }}</div>{{ end }}
                 </td>
-                <td class="{{ outcomeClass .Outcome }}">{{ .Outcome }}</td>
+                <td class="outcome {{ outcomeClass .Outcome }}">{{ .Outcome }}</td>
                 <td>{{ .Reason }}</td>
+                <td class="action">
+                    {{ if and .TorrentURL (ne .Outcome "dispatched") (ne .Outcome "downloaded") }}
+                    <button class="btn-torrent" data-feed="{{ .Feed }}" data-guid="{{ .GUID }}">Torrent</button>
+                    {{ end }}
+                </td>
             </tr>
             {{ end }}
         </tbody>
@@ -219,6 +238,45 @@
         labelIn.addEventListener('input', apply);
         outcomeCheckboxes().forEach(function (cb) { cb.addEventListener('change', apply); });
         resetBtn.addEventListener('click', reset);
+
+        var rowsEl = document.getElementById('rows');
+        rowsEl.addEventListener('click', function (e) {
+            var btn = e.target.closest('.btn-torrent');
+            if (!btn) return;
+
+            var feed = btn.dataset.feed;
+            var guid = btn.dataset.guid;
+            var row  = btn.closest('tr');
+
+            btn.disabled = true;
+            btn.textContent = 'Torrenting…';
+
+            var body = new URLSearchParams();
+            body.set('feed', feed);
+            body.set('guid', guid);
+
+            fetch('/torrent', { method: 'POST', body: body }).then(function (resp) {
+                if (!resp.ok) {
+                    return resp.text().then(function (msg) { throw new Error(msg || resp.statusText); });
+                }
+                row.dataset.outcome = 'dispatched';
+                var outcomeCell = row.querySelector('.outcome');
+                outcomeCell.textContent = 'dispatched';
+                outcomeCell.className = 'outcome ' + outcomeClass('dispatched');
+                btn.remove();
+                apply();
+            }).catch(function (err) {
+                btn.disabled = false;
+                btn.textContent = 'Torrent';
+                alert('Failed to torrent: ' + err.message);
+            });
+        });
+
+        function outcomeClass(outcome) {
+            if (outcome === 'dispatched' || outcome === 'downloaded') return 'dispatched';
+            if (outcome === 'error') return 'error';
+            return 'skipped';
+        }
 
         apply();
 

--- a/cmd/rss4transmission/web/history.html
+++ b/cmd/rss4transmission/web/history.html
@@ -144,7 +144,7 @@
                 <td class="outcome {{ outcomeClass .Outcome }}">{{ .Outcome }}</td>
                 <td>{{ .Reason }}</td>
                 <td class="action">
-                    {{ if and .TorrentURL (ne .Outcome "dispatched") (ne .Outcome "downloaded") }}
+                    {{ if and .TorrentURL (ne .Outcome "dispatched") (ne .Outcome "downloaded") (feedConfigured .Feed) }}
                     <button class="btn-torrent" data-feed="{{ .Feed }}" data-guid="{{ .GUID }}">Torrent</button>
                     {{ end }}
                 </td>

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mmcdole/gofeed"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,7 +23,7 @@ import (
 // --- /healthz ---
 
 func TestHealthzHandler(t *testing.T) {
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	req := httptest.NewRequest("GET", "/healthz", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -77,7 +78,7 @@ func TestGetCancelHandler_RendersForm(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -102,7 +103,7 @@ func TestGetCancelHandler_RendersProgress(t *testing.T) {
 	// 2.5 GiB downloaded, 25% done
 	getProgress := makeProgressFunc(int64(2.5*float64(1<<30)), 0.25)
 
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), getProgress, nil)
 
 	req := httptest.NewRequest("GET",
@@ -127,7 +128,7 @@ func TestGetCancelHandler_ProgressUnknownOnError(t *testing.T) {
 		return 0, 0, fmt.Errorf("transmission unavailable")
 	}
 
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), errProgress, nil)
 
 	req := httptest.NewRequest("GET",
@@ -142,7 +143,7 @@ func TestGetCancelHandler_ProgressUnknownOnError(t *testing.T) {
 func TestGetCancelHandler_MissingParams(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET", "/cancel?id=test-id", nil)
@@ -158,7 +159,7 @@ func TestGetCancelHandler_BadSignature(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -175,7 +176,7 @@ func TestGetCancelHandler_Expired(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -191,7 +192,7 @@ func TestGetCancelHandler_NotFound(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -209,7 +210,7 @@ func TestGetCancelHandler_DoesNotConsumeEntry(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	removed := false
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), nil)
 
@@ -236,7 +237,7 @@ func TestPostCancelHandler_Valid(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	removed := false
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -252,7 +253,7 @@ func TestPostCancelHandler_Valid(t *testing.T) {
 func TestPostCancelHandler_MissingParams(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := strings.NewReader("id=test-id") // missing expires and sig
@@ -270,7 +271,7 @@ func TestPostCancelHandler_BadSignature(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, "badsig")
@@ -288,7 +289,7 @@ func TestPostCancelHandler_Expired(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -305,7 +306,7 @@ func TestPostCancelHandler_NotFound(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("ghost-id", expires, sig)
@@ -386,7 +387,7 @@ func TestPostCancelHandler_RemoveErrorPreservesStoreEntry(t *testing.T) {
 	failRemove := func(_ context.Context, _ []int64) error {
 		return fmt.Errorf("transmission unreachable")
 	}
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, failRemove, noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -407,7 +408,7 @@ func TestGetCancelHandler_ZeroBytesProgressBothUnknown(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	// brand-new torrent: 0 bytes downloaded, 0% done
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), makeProgressFunc(0, 0.0), nil)
 
 	req := httptest.NewRequest("GET",
@@ -438,6 +439,168 @@ func TestNewCancelMux_NilRemovePostReturns404(t *testing.T) {
 		"POST /cancel must not be registered when remove is nil")
 }
 
+// --- GET / (history page torrent button) ---
+
+func makeGofeedItemWithEnclosure(title, guid, torrentURL string) *gofeed.Item {
+	return &gofeed.Item{
+		Title: title,
+		GUID:  guid,
+		Enclosures: []*gofeed.Enclosure{
+			{URL: torrentURL, Type: "application/x-bittorrent"},
+		},
+	}
+}
+
+func TestHistoryPage_RendersTorrentButtonForSkippedWithURL(t *testing.T) {
+	h := emptyHistory()
+	rec := NewHistoryRecord("myfeed",
+		makeGofeedItemWithEnclosure("My Title", "guid-1", "https://example.com/my.torrent"),
+		"skipped", "lost preference contest", nil)
+	h.AddOrUpdateRecord(rec)
+
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil))
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	assert.Contains(t, body, `class="btn-torrent"`)
+	assert.Contains(t, body, `data-feed="myfeed"`)
+	assert.Contains(t, body, `data-guid="guid-1"`)
+}
+
+func TestHistoryPage_NoTorrentButtonWithoutURL(t *testing.T) {
+	h := emptyHistory()
+	rec := NewHistoryRecord("myfeed", makeGofeedItem("No Enclosure", "guid-2"), "excluded", "matched exclude", nil)
+	h.AddOrUpdateRecord(rec)
+
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil))
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.NotContains(t, rr.Body.String(), `class="btn-torrent"`)
+}
+
+func TestHistoryPage_NoTorrentButtonForDispatched(t *testing.T) {
+	h := emptyHistory()
+	rec := NewHistoryRecord("myfeed",
+		makeGofeedItemWithEnclosure("Already Dispatched", "guid-3", "https://example.com/my.torrent"),
+		"dispatched", "", nil)
+	h.AddOrUpdateRecord(rec)
+
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil))
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.NotContains(t, rr.Body.String(), `class="btn-torrent"`)
+}
+
+// --- POST /torrent ---
+
+func makeRetryFunc(called *bool, gotRec *HistoryRecord, id int64, err error) retryFunc {
+	return func(rec HistoryRecord) (int64, error) {
+		*called = true
+		if gotRec != nil {
+			*gotRec = rec
+		}
+		return id, err
+	}
+}
+
+func makeTorrentFormBody(feed, guid string) *strings.Reader {
+	v := url.Values{}
+	v.Set("feed", feed)
+	v.Set("guid", guid)
+	return strings.NewReader(v.Encode())
+}
+
+func TestPostTorrentHandler_Success(t *testing.T) {
+	h := emptyHistory()
+	rec := NewHistoryRecord("myfeed", makeGofeedItem("My Title", "guid-1"), "skipped", "", nil)
+	h.AddOrUpdateRecord(rec)
+
+	called := false
+	var gotRec HistoryRecord
+	mux := newWebMux(h, makeRetryFunc(&called, &gotRec, 7, nil))
+
+	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.True(t, called, "retry should have been invoked")
+	assert.Equal(t, "myfeed", gotRec.Feed)
+	assert.Equal(t, "guid-1", gotRec.GUID)
+}
+
+func TestPostTorrentHandler_UnknownRecord(t *testing.T) {
+	h := emptyHistory()
+	called := false
+	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, nil))
+
+	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("ghost-feed", "ghost-guid"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	assert.False(t, called, "retry must not be called for an unknown record")
+}
+
+func TestPostTorrentHandler_RetryError(t *testing.T) {
+	h := emptyHistory()
+	rec := NewHistoryRecord("myfeed", makeGofeedItem("My Title", "guid-1"), "skipped", "", nil)
+	h.AddOrUpdateRecord(rec)
+
+	called := false
+	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, fmt.Errorf("boom: no torrent URL")))
+
+	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.True(t, called)
+	assert.NotEqual(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "boom: no torrent URL")
+}
+
+func TestPostTorrentHandler_NotRegisteredWhenRetryNil(t *testing.T) {
+	h := emptyHistory()
+	rec := NewHistoryRecord("myfeed", makeGofeedItem("My Title", "guid-1"), "skipped", "", nil)
+	h.AddOrUpdateRecord(rec)
+
+	mux := newWebMux(h, nil)
+
+	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	// Go's mux returns 405 (path only registered for GET /) rather than 404 — safe, not a panic.
+	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code,
+		"POST /torrent must not be registered when retry is nil")
+}
+
+func TestPostTorrentHandler_NotRegisteredOnCancelMux(t *testing.T) {
+	store := NewStore(time.Hour)
+	cfg := makeCancelCfg("secret", "https://example.com")
+	mux := newCancelMux(store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
+
+	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
 // --- access log behavioral tests ---
 
 func TestGetCancelHandler_AccessLog_InvalidToken(t *testing.T) {
@@ -446,7 +609,7 @@ func TestGetCancelHandler_AccessLog_InvalidToken(t *testing.T) {
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -466,7 +629,7 @@ func TestGetCancelHandler_AccessLog_MissingParams(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET", "/cancel?id=test-id", nil)
@@ -486,7 +649,7 @@ func TestGetCancelHandler_AccessLog_Expired(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -507,7 +670,7 @@ func TestGetCancelHandler_AccessLog_NotFound(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -529,7 +692,7 @@ func TestGetCancelHandler_AccessLog_Success(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -550,7 +713,7 @@ func TestGetCancelHandler_AccessLog_NilNoOp(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -569,7 +732,7 @@ func TestPostCancelHandler_AccessLog_InvalidToken(t *testing.T) {
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, "badsig")
@@ -592,7 +755,7 @@ func TestPostCancelHandler_AccessLog_Expired(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -614,7 +777,7 @@ func TestPostCancelHandler_AccessLog_NotFound(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("ghost-id", expires, sig)
@@ -638,7 +801,7 @@ func TestPostCancelHandler_AccessLog_Success(t *testing.T) {
 
 	lg, buf := makeTestAccessLogger()
 	removed := false
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -665,7 +828,7 @@ func TestPostCancelHandler_AccessLog_TransmissionError(t *testing.T) {
 	failRemove2 := func(_ context.Context, _ []int64) error {
 		return fmt.Errorf("transmission unreachable")
 	}
-	mux := newWebMux(nil)
+	mux := newWebMux(nil, nil)
 	registerCancelRoutes(mux, store, cfg, failRemove2, noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, sig)

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -23,7 +23,7 @@ import (
 // --- /healthz ---
 
 func TestHealthzHandler(t *testing.T) {
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	req := httptest.NewRequest("GET", "/healthz", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -78,7 +78,7 @@ func TestGetCancelHandler_RendersForm(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -103,7 +103,7 @@ func TestGetCancelHandler_RendersProgress(t *testing.T) {
 	// 2.5 GiB downloaded, 25% done
 	getProgress := makeProgressFunc(int64(2.5*float64(1<<30)), 0.25)
 
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), getProgress, nil)
 
 	req := httptest.NewRequest("GET",
@@ -128,7 +128,7 @@ func TestGetCancelHandler_ProgressUnknownOnError(t *testing.T) {
 		return 0, 0, fmt.Errorf("transmission unavailable")
 	}
 
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), errProgress, nil)
 
 	req := httptest.NewRequest("GET",
@@ -143,7 +143,7 @@ func TestGetCancelHandler_ProgressUnknownOnError(t *testing.T) {
 func TestGetCancelHandler_MissingParams(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET", "/cancel?id=test-id", nil)
@@ -159,7 +159,7 @@ func TestGetCancelHandler_BadSignature(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -176,7 +176,7 @@ func TestGetCancelHandler_Expired(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -192,7 +192,7 @@ func TestGetCancelHandler_NotFound(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -210,7 +210,7 @@ func TestGetCancelHandler_DoesNotConsumeEntry(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	removed := false
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), nil)
 
@@ -237,7 +237,7 @@ func TestPostCancelHandler_Valid(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	removed := false
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -253,7 +253,7 @@ func TestPostCancelHandler_Valid(t *testing.T) {
 func TestPostCancelHandler_MissingParams(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := strings.NewReader("id=test-id") // missing expires and sig
@@ -271,7 +271,7 @@ func TestPostCancelHandler_BadSignature(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, "badsig")
@@ -289,7 +289,7 @@ func TestPostCancelHandler_Expired(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -306,7 +306,7 @@ func TestPostCancelHandler_NotFound(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("ghost-id", expires, sig)
@@ -387,7 +387,7 @@ func TestPostCancelHandler_RemoveErrorPreservesStoreEntry(t *testing.T) {
 	failRemove := func(_ context.Context, _ []int64) error {
 		return fmt.Errorf("transmission unreachable")
 	}
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, failRemove, noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -408,7 +408,7 @@ func TestGetCancelHandler_ZeroBytesProgressBothUnknown(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	// brand-new torrent: 0 bytes downloaded, 0% done
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), makeProgressFunc(0, 0.0), nil)
 
 	req := httptest.NewRequest("GET",
@@ -458,7 +458,7 @@ func TestHistoryPage_RendersTorrentButtonForSkippedWithURL(t *testing.T) {
 		"skipped", "lost preference contest", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil))
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -475,7 +475,7 @@ func TestHistoryPage_NoTorrentButtonWithoutURL(t *testing.T) {
 	rec := NewHistoryRecord("myfeed", makeGofeedItem("No Enclosure", "guid-2"), "excluded", "matched exclude", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil))
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -491,13 +491,66 @@ func TestHistoryPage_NoTorrentButtonForDispatched(t *testing.T) {
 		"dispatched", "", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil))
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
 	assert.NotContains(t, rr.Body.String(), `class="btn-torrent"`)
+}
+
+func TestHistoryPage_TorrentButtonShownWhenFeedConfiguredNil(t *testing.T) {
+	h := emptyHistory()
+	rec := NewHistoryRecord("myfeed",
+		makeGofeedItemWithEnclosure("My Title", "guid-1", "https://example.com/my.torrent"),
+		"skipped", "lost preference contest", nil)
+	h.AddOrUpdateRecord(rec)
+
+	// A nil feedConfigured means "no filter" — button shows unconditionally,
+	// matching every existing caller that doesn't care about live config.
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `class="btn-torrent"`)
+}
+
+func TestHistoryPage_TorrentButtonHiddenWhenFeedNotConfigured(t *testing.T) {
+	h := emptyHistory()
+	rec := NewHistoryRecord("gone-feed",
+		makeGofeedItemWithEnclosure("My Title", "guid-1", "https://example.com/my.torrent"),
+		"skipped", "lost preference contest", nil)
+	h.AddOrUpdateRecord(rec)
+
+	feedConfigured := func(name string) bool { return name == "still-here" }
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), feedConfigured)
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.NotContains(t, rr.Body.String(), `class="btn-torrent"`,
+		"button must be hidden when the record's feed is no longer configured")
+}
+
+func TestHistoryPage_TorrentButtonShownWhenFeedStillConfigured(t *testing.T) {
+	h := emptyHistory()
+	rec := NewHistoryRecord("still-here",
+		makeGofeedItemWithEnclosure("My Title", "guid-1", "https://example.com/my.torrent"),
+		"skipped", "lost preference contest", nil)
+	h.AddOrUpdateRecord(rec)
+
+	feedConfigured := func(name string) bool { return name == "still-here" }
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), feedConfigured)
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `class="btn-torrent"`)
 }
 
 // --- POST /torrent ---
@@ -526,7 +579,7 @@ func TestPostTorrentHandler_Success(t *testing.T) {
 
 	called := false
 	var gotRec HistoryRecord
-	mux := newWebMux(h, makeRetryFunc(&called, &gotRec, 7, nil))
+	mux := newWebMux(h, makeRetryFunc(&called, &gotRec, 7, nil), nil)
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -542,7 +595,7 @@ func TestPostTorrentHandler_Success(t *testing.T) {
 func TestPostTorrentHandler_UnknownRecord(t *testing.T) {
 	h := emptyHistory()
 	called := false
-	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, nil))
+	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, nil), nil)
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("ghost-feed", "ghost-guid"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -559,7 +612,7 @@ func TestPostTorrentHandler_RetryError(t *testing.T) {
 	h.AddOrUpdateRecord(rec)
 
 	called := false
-	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, fmt.Errorf("boom: no torrent URL")))
+	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, fmt.Errorf("boom: no torrent URL")), nil)
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -576,7 +629,7 @@ func TestPostTorrentHandler_NotRegisteredWhenRetryNil(t *testing.T) {
 	rec := NewHistoryRecord("myfeed", makeGofeedItem("My Title", "guid-1"), "skipped", "", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, nil)
+	mux := newWebMux(h, nil, nil)
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -609,7 +662,7 @@ func TestGetCancelHandler_AccessLog_InvalidToken(t *testing.T) {
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -629,7 +682,7 @@ func TestGetCancelHandler_AccessLog_MissingParams(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET", "/cancel?id=test-id", nil)
@@ -649,7 +702,7 @@ func TestGetCancelHandler_AccessLog_Expired(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -670,7 +723,7 @@ func TestGetCancelHandler_AccessLog_NotFound(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -692,7 +745,7 @@ func TestGetCancelHandler_AccessLog_Success(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -713,7 +766,7 @@ func TestGetCancelHandler_AccessLog_NilNoOp(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -732,7 +785,7 @@ func TestPostCancelHandler_AccessLog_InvalidToken(t *testing.T) {
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, "badsig")
@@ -755,7 +808,7 @@ func TestPostCancelHandler_AccessLog_Expired(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -777,7 +830,7 @@ func TestPostCancelHandler_AccessLog_NotFound(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("ghost-id", expires, sig)
@@ -801,7 +854,7 @@ func TestPostCancelHandler_AccessLog_Success(t *testing.T) {
 
 	lg, buf := makeTestAccessLogger()
 	removed := false
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -828,7 +881,7 @@ func TestPostCancelHandler_AccessLog_TransmissionError(t *testing.T) {
 	failRemove2 := func(_ context.Context, _ []int64) error {
 		return fmt.Errorf("transmission unreachable")
 	}
-	mux := newWebMux(nil, nil)
+	mux := newWebMux(nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, failRemove2, noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, sig)

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -5,7 +5,7 @@
 RSS4Transmission supports two kinds of push notifications via [ntfy](https://ntfy.sh):
 
 - **Torrent started** — sent by rss4transmission immediately after submitting a torrent to
-  Transmission. Includes a **Cancel Download** action button that opens a browser confirmation
+  Transmission. Includes a **More Info** action button that opens a browser confirmation
   page showing torrent details and live download progress. Confirming removes the torrent from
   Transmission.
 - **Torrent completed** — sent via the `POST /notify-complete` endpoint, which is called by
@@ -183,6 +183,15 @@ rss4transmission watch --config config.yaml \
 The history page shows each item's feed name, title, publication date, outcome, and extracted
 labels. Records are pruned on the same schedule as the seen cache (`SeenCacheDays`).
 
+Rows with outcome `skipped`, `excluded`, or `error` show a **Torrent** button when a `.torrent`
+URL was captured for that item, letting you manually re-submit it to Transmission without waiting
+for the feed to re-offer it. Clicking it re-fetches the `.torrent` fresh, submits it exactly like
+an automatic dispatch, and sends the normal "torrent started" ntfy notification (including a
+working Cancel link) on success. The button requires the item's feed to still be present in the
+config — it's hidden or fails with an error otherwise — and disappears once an item is
+successfully torrented. The action lives at `POST /torrent`, served only alongside the history
+page (`--private-listen`); it is never reachable on `--public-listen`.
+
 In Docker:
 
 ```yaml
@@ -197,6 +206,7 @@ environment:
 | Route | `--private-listen` (single) | `--private-listen` (split) | `--public-listen` (split) |
 |---|---|---|---|
 | `/` (history page) | ✓ (requires `--history-file`) | ✓ (requires `--history-file`) | — |
+| `/torrent` | ✓ (requires `--history-file`) | ✓ (requires `--history-file`) | — |
 | `/cancel` | ✓ | — | ✓ |
 | `/notify-complete` | ✓ | — | ✓ |
 | `/healthz` | ✓ | ✓ | ✓ |


### PR DESCRIPTION
## Summary
- Add a **Torrent** button to the History web page for `skipped`/`excluded`/`error` rows that captured a `.torrent` URL, letting the user manually re-submit a past item to Transmission (`POST /torrent`, wired only to the private history listener, never `--public-listen`).
- A successful manual retry sends the same ntfy "torrent started" push notification (with cancel link) as an automatic dispatch.
- Rename the ntfy started-notification action button from **Cancel Download** to **More Info**, since it opens a details/confirmation page rather than immediately cancelling.
- Update README.md and docs/notifications.md accordingly.

## Test plan
- [x] `make test` — full unit test suite passes (TDD: history.go, feed.go, once.go, web.go, watch.go, template rendering)
- [x] `make lint` — 0 issues
- [x] `make test-tidy` — clean
- [x] `make` — builds successfully
- [x] End-to-end smoke test (temporary, not committed): real HTTP loopback server against fake Transmission + torrent-file servers verifying click → `POST /torrent` → Transmission submit → cache/history update → button disappears → double-click rejected
- [ ] Manual click-through against a live Transmission instance (not performed in this environment; recommended before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)