### PR TITLE
Fix config-reload watcher resilience and validation gaps

### DIFF
--- a/cmd/rss4transmission/config_test.go
+++ b/cmd/rss4transmission/config_test.go
@@ -149,17 +149,40 @@ func TestValidateFeedNames_Duplicate(t *testing.T) {
 	}
 }
 
+const validExtractorYAML = `
+Extractors:
+  demo:
+    Labels:
+      series:
+        Regexp: '(.+)'
+`
+
 func TestLoadConfig_FeedsPreserveFileOrder(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
-	yamlContent := `
+	yamlContent := validExtractorYAML + `
 Feeds:
   - Name: Zzz
     URL: https://example.com/z
+    Extractor: demo
+    Identity: [series]
+    Groups:
+      - Require:
+          series: [X]
   - Name: Aaa
     URL: https://example.com/a
+    Extractor: demo
+    Identity: [series]
+    Groups:
+      - Require:
+          series: [X]
   - Name: Mmm
     URL: https://example.com/m
+    Extractor: demo
+    Identity: [series]
+    Groups:
+      - Require:
+          series: [X]
 `
 	if err := os.WriteFile(cfgPath, []byte(yamlContent), 0600); err != nil {
 		t.Fatalf("failed to write config: %v", err)
@@ -224,12 +247,22 @@ func TestLoadConfig_BadReload_KeepsPreviousGoodConfig(t *testing.T) {
 	// rejected without corrupting the already-running, valid config.
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
-	goodYAML := `
+	goodYAML := validExtractorYAML + `
 Feeds:
   - Name: Good1
     URL: https://example.com/1
+    Extractor: demo
+    Identity: [series]
+    Groups:
+      - Require:
+          series: [X]
   - Name: Good2
     URL: https://example.com/2
+    Extractor: demo
+    Identity: [series]
+    Groups:
+      - Require:
+          series: [Y]
 `
 	if err := os.WriteFile(cfgPath, []byte(goodYAML), 0600); err != nil {
 		t.Fatalf("failed to write config: %v", err)
@@ -267,5 +300,100 @@ Feeds:
 			t.Errorf("feed[%d].Name = %q, want %q (config should be unchanged after bad reload)",
 				i, rc.Config.Feeds[i].Name, name)
 		}
+	}
+}
+
+// TestLoadConfig_ReloadRejectsStructurallyInvalidFeed guards against a live
+// config-reload silently accepting a feed that is missing required
+// label-mode fields (Extractor/Identity/Groups). validateFeedNames alone
+// only checks name uniqueness and would let this through; loadConfig must
+// also run the same Feed.Validate() checks main.go used to run only once,
+// at startup, so a bad reload is rejected exactly like a bad initial load.
+func TestLoadConfig_ReloadRejectsStructurallyInvalidFeed(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	goodYAML := validExtractorYAML + `
+Feeds:
+  - Name: Good1
+    URL: https://example.com/1
+    Extractor: demo
+    Identity: [series]
+    Groups:
+      - Require:
+          series: [X]
+`
+	if err := os.WriteFile(cfgPath, []byte(goodYAML), 0600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	rc := &RunContext{}
+	if _, err := rc.loadConfig(cfgPath); err != nil {
+		t.Fatalf("initial loadConfig failed: %v", err)
+	}
+
+	// Missing Identity/Groups; unique name, so validateFeedNames alone
+	// would accept it.
+	badYAML := validExtractorYAML + `
+Feeds:
+  - Name: Good1
+    URL: https://example.com/1
+    Extractor: demo
+`
+	if err := os.WriteFile(cfgPath, []byte(badYAML), 0600); err != nil {
+		t.Fatalf("failed to overwrite config: %v", err)
+	}
+
+	if _, err := rc.loadConfig(cfgPath); err == nil {
+		t.Error("expected reload with a feed missing Identity/Groups to fail")
+	}
+	if len(rc.Config.Feeds[0].Groups) == 0 || len(rc.Config.Feeds[0].Identity) == 0 {
+		t.Error("expected previous config (with Identity/Groups) to survive a bad reload")
+	}
+}
+
+// TestLoadConfig_ReloadRejectsUnknownExtractor guards the same gap for a
+// feed whose Extractor no longer refers to a defined ExtractorSet (e.g. it
+// was renamed elsewhere in the same reload).
+func TestLoadConfig_ReloadRejectsUnknownExtractor(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	goodYAML := validExtractorYAML + `
+Feeds:
+  - Name: Good1
+    URL: https://example.com/1
+    Extractor: demo
+    Identity: [series]
+    Groups:
+      - Require:
+          series: [X]
+`
+	if err := os.WriteFile(cfgPath, []byte(goodYAML), 0600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	rc := &RunContext{}
+	if _, err := rc.loadConfig(cfgPath); err != nil {
+		t.Fatalf("initial loadConfig failed: %v", err)
+	}
+
+	badYAML := `
+Feeds:
+  - Name: Good1
+    URL: https://example.com/1
+    Extractor: renamed-away
+    Identity: [series]
+    Groups:
+      - Require:
+          series: [X]
+`
+	if err := os.WriteFile(cfgPath, []byte(badYAML), 0600); err != nil {
+		t.Fatalf("failed to overwrite config: %v", err)
+	}
+
+	if _, err := rc.loadConfig(cfgPath); err == nil {
+		t.Error("expected reload referencing an unknown Extractor to fail")
+	}
+	if rc.Config.Feeds[0].Extractor != "demo" {
+		t.Errorf("expected previous config to survive a bad reload, got Extractor=%q", rc.Config.Feeds[0].Extractor)
 	}
 }

--- a/cmd/rss4transmission/main.go
+++ b/cmd/rss4transmission/main.go
@@ -142,12 +142,6 @@ func main() {
 		log.WithError(err).Fatalf("Unable to load %s", rc.configFile)
 	}
 
-	for _, feedCfg := range rc.Config.Feeds {
-		if err = feedCfg.Validate(feedCfg.Name, rc.Config.Extractors); err != nil {
-			log.WithError(err).Fatalf("Invalid feed %q config", feedCfg.Name)
-		}
-	}
-
 	// use our SeenFile
 	seenFileName := rc.Konf.String("SeenFile")
 	if cli.SeenFile != "" {
@@ -232,6 +226,12 @@ func (rc *RunContext) loadConfig(configFile string) (*koanf.Koanf, error) {
 
 	if err := validateFeedNames(cfg.Feeds); err != nil {
 		return konf, fmt.Errorf("invalid feed configuration: %w", err)
+	}
+
+	for _, feedCfg := range cfg.Feeds {
+		if err := feedCfg.Validate(feedCfg.Name, cfg.Extractors); err != nil {
+			return konf, fmt.Errorf("invalid feed %q config: %w", feedCfg.Name, err)
+		}
 	}
 
 	// Only commit the newly parsed config once every check above has passed,

--- a/cmd/rss4transmission/watch.go
+++ b/cmd/rss4transmission/watch.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"time"
 
@@ -36,59 +35,72 @@ func retryLoadConfig(tryLoad func() error, interval time.Duration) int {
 	}
 }
 
-func (cmd *WatchCmd) Run(ctx *RunContext) error {
-	mu := sync.Mutex{}
+// configReloader owns the live config-reload watch loop: reloading on file
+// change, and recovering when the underlying fsnotify watch dies. It's
+// factored out of WatchCmd.Run so the recovery behavior can be exercised
+// without spinning up tickers, web servers, or a Transmission client.
+type configReloader struct {
+	mu            sync.Mutex
+	reload        func() error
+	registerWatch func(cb func(event any, err error)) error
+	retryInterval time.Duration
+}
 
-	// watchCallback and retryWatch reference each other via closures.
-	var watchCallback func(event interface{}, err error)
-	var retryWatch func()
-
-	watchCallback = func(event interface{}, err error) {
-		if err != nil {
-			// Editors often save by deleting then recreating the file, which
-			// causes fsnotify to fire a remove event and stop watching.
-			// Retry loading and re-register the watcher once the file is back.
-			if strings.Contains(err.Error(), "was removed") {
-				log.Warnf("config file temporarily removed (editor save?), retrying reload...")
-				go retryWatch()
-				return
-			}
-			log.Errorf("watch error: %s", err)
-			return
-		}
-
-		// don't change the config while we are processing the feed
-		mu.Lock()
-		defer mu.Unlock()
-
-		log.Infof("config changed. reloading...")
-		konf, err := ctx.loadConfig(ctx.configFile)
-		if err != nil {
-			log.WithError(err).Errorf("failed to reload config file")
-			return
-		}
-		ctx.Konf = konf
+// onWatchEvent is the callback registered with the file watcher.
+//
+// koanf's file provider watch goroutine exits after calling back with ANY
+// error, not just when the file is removed (which is merely the common
+// case editors trigger on save) — see providers/file/file.go: every branch
+// that invokes cb(nil, err) is immediately followed by `break loop`. So
+// every error, not only a "was removed" one, must trigger recovery, or the
+// watcher dies permanently and silently and no further reload ever happens.
+func (r *configReloader) onWatchEvent(event any, err error) {
+	if err != nil {
+		log.Warnf("config file watcher stopped (%s); reloading and re-registering", err)
+		go r.recover()
+		return
 	}
 
-	retryWatch = func() {
-		attempt := retryLoadConfig(func() error {
-			mu.Lock()
-			defer mu.Unlock()
+	// don't change the config while we are processing the feed
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	log.Infof("config changed. reloading...")
+	if err := r.reload(); err != nil {
+		log.WithError(err).Errorf("failed to reload config file")
+	}
+}
+
+// recover retries reload until it succeeds, then re-registers the watch. It
+// blocks (via retryLoadConfig) until the config file is readable again, so
+// callers run it in its own goroutine.
+func (r *configReloader) recover() {
+	attempt := retryLoadConfig(func() error {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		return r.reload()
+	}, r.retryInterval)
+
+	log.Infof("config reloaded after %d attempt(s), re-registering file watcher", attempt)
+	if err := r.registerWatch(r.onWatchEvent); err != nil {
+		log.WithError(err).Errorf("failed to re-register config file watcher")
+	}
+}
+
+func (cmd *WatchCmd) Run(ctx *RunContext) error {
+	reloader := &configReloader{
+		reload: func() error {
 			konf, err := ctx.loadConfig(ctx.configFile)
 			if err != nil {
 				return err
 			}
 			ctx.Konf = konf
 			return nil
-		}, defaultRetryInterval)
-
-		log.Infof("config reloaded after %d attempt(s), re-registering file watcher", attempt)
-		if err := ctx.Provider.Watch(watchCallback); err != nil {
-			log.WithError(err).Errorf("failed to re-register config file watcher")
-		}
+		},
+		registerWatch: ctx.Provider.Watch,
+		retryInterval: defaultRetryInterval,
 	}
-
-	_ = ctx.Provider.Watch(watchCallback)
+	_ = reloader.registerWatch(reloader.onWatchEvent)
 
 	ticker := time.NewTicker(time.Duration(ctx.Cli.Watch.Sleep) * time.Second)
 
@@ -201,11 +213,11 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 
 	// Run once and then sleep between later runs...
 	for ; true; <-ticker.C {
-		mu.Lock()
+		reloader.mu.Lock()
 		if err := once.Run(ctx); err != nil {
 			return err
 		}
-		mu.Unlock()
+		reloader.mu.Unlock()
 		if g != nil {
 			g.CheckVpnTunnel()
 		}

--- a/cmd/rss4transmission/watch_test.go
+++ b/cmd/rss4transmission/watch_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestWatchCmd_HasHistoryFileField(t *testing.T) {
@@ -100,4 +101,118 @@ func TestRetryLoadConfig_SuccessAfterFailures(t *testing.T) {
 	if calls != 3 {
 		t.Errorf("expected 3 calls, got %d", calls)
 	}
+}
+
+func TestConfigReloader_OnWatchEvent_Success_CallsReload(t *testing.T) {
+	calls := 0
+	r := &configReloader{
+		reload: func() error {
+			calls++
+			return nil
+		},
+		registerWatch: func(cb func(event any, err error)) error { return nil },
+	}
+
+	r.onWatchEvent(nil, nil)
+
+	if calls != 1 {
+		t.Errorf("expected reload to be called once, got %d", calls)
+	}
+}
+
+func TestConfigReloader_OnWatchEvent_ReloadFailure_DoesNotReregister(t *testing.T) {
+	registered := 0
+	r := &configReloader{
+		reload: func() error { return fmt.Errorf("bad yaml") },
+		registerWatch: func(cb func(event any, err error)) error {
+			registered++
+			return nil
+		},
+	}
+
+	// A bad edit on a live watch event (err == nil, reload itself fails)
+	// should just be logged and left for the next edit — the underlying
+	// watcher is still alive in this case, so no re-registration is needed.
+	r.onWatchEvent(nil, nil)
+
+	if registered != 0 {
+		t.Errorf("a failed reload from a live watch event should not re-register the watcher, got %d calls", registered)
+	}
+}
+
+// TestConfigReloader_OnWatchEvent_AnyWatchError_Recovers is the regression
+// test for the bug where only a "file was removed" error triggered
+// recovery. koanf's file provider goroutine exits after calling back with
+// ANY error (not just removal), so any error must trigger the same
+// reload-and-re-register recovery or the watcher dies permanently and
+// silently.
+func TestConfigReloader_OnWatchEvent_AnyWatchError_Recovers(t *testing.T) {
+	errs := []string{
+		"file /etc/rss4transmission/config.yaml was removed",
+		"fsnotify watch channel closed",
+		"fsnotify err channel closed",
+		"some other transient watch error",
+	}
+	for _, errMsg := range errs {
+		t.Run(errMsg, func(t *testing.T) {
+			reregistered := make(chan struct{}, 1)
+			r := &configReloader{
+				reload: func() error { return nil },
+				registerWatch: func(cb func(event any, err error)) error {
+					reregistered <- struct{}{}
+					return nil
+				},
+				retryInterval: 0,
+			}
+
+			r.onWatchEvent(nil, fmt.Errorf("%s", errMsg))
+
+			select {
+			case <-reregistered:
+			case <-time.After(2 * time.Second):
+				t.Fatalf("expected watcher to be re-registered after error %q, but it was not", errMsg)
+			}
+		})
+	}
+}
+
+func TestConfigReloader_Recover_RetriesUntilReloadSucceeds(t *testing.T) {
+	calls := 0
+	registered := 0
+	r := &configReloader{
+		reload: func() error {
+			calls++
+			if calls < 3 {
+				return fmt.Errorf("not ready")
+			}
+			return nil
+		},
+		registerWatch: func(cb func(event any, err error)) error {
+			registered++
+			return nil
+		},
+		retryInterval: 0,
+	}
+
+	r.recover()
+
+	if calls != 3 {
+		t.Errorf("expected 3 reload attempts, got %d", calls)
+	}
+	if registered != 1 {
+		t.Errorf("expected watcher to be re-registered once after recovery, got %d", registered)
+	}
+}
+
+func TestConfigReloader_Recover_ReregisterFailureIsLoggedNotFatal(t *testing.T) {
+	r := &configReloader{
+		reload: func() error { return nil },
+		registerWatch: func(cb func(event any, err error)) error {
+			return fmt.Errorf("watch registration failed")
+		},
+		retryInterval: 0,
+	}
+
+	// Must not panic even though re-registration itself fails.
+	r.recover()
 }


### PR DESCRIPTION
## Summary
- Fix the live config-reload file watcher so it recovers from *any* watch error, not just "file was removed". koanf's `file.Provider.Watch` goroutine exits after calling back with any error (`providers/file/file.go`: every `cb(nil, err)` branch is followed by `break loop`), so only handling the removal case left the watcher permanently and silently dead after other transient errors (channel-closed errors, `EvalSymlinks` failures, etc.).
- Fix `loadConfig()` to run full per-feed structural validation (`Feed.Validate()` — `Extractor`/`Identity`/`Groups`) on every reload, not just once at startup in `main()`. Previously a live config reload could silently accept a structurally invalid feed since only `validateFeedNames` (uniqueness) ran on reload.

Both fixes preserve the existing "commit config only after all validation passes" behavior, so a bad reload leaves the previously running config fully intact.

## Test plan
- [x] `make test` (go vet + full test suite) passes
- [x] `make fmt` — no changes needed
- [x] `make lint` — 0 issues
- [x] New table-driven regression test (`TestConfigReloader_OnWatchEvent_AnyWatchError_Recovers`) covers both "was removed" and non-"removed" watch error strings
- [x] New tests (`TestLoadConfig_ReloadRejectsStructurallyInvalidFeed`, `TestLoadConfig_ReloadRejectsUnknownExtractor`) confirm a bad reload is rejected and the previous good config survives