### PR TITLE
Send ntfy notification when watch reloads its config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ Pre-built images are available on [DockerHub](https://hub.docker.com/r/synfinati
   resolution, etc.) from torrent titles and file names; deduplicate by identity key; prefer
   higher-quality versions automatically
 - **[ntfy](https://ntfy.sh) push notifications** — receive a notification when a torrent starts
-  (with a More Info button) and when it completes; notification title, body, and priority are
-  user-defined via `text/template` strings in the config file, with full access to torrent
-  metadata (labels, size, feed name, GUID, and more)
+  (with a More Info button), when it completes, and when `watch` reloads its config file
+  (reporting success or failure, with the error text on failure); notification title, body, and
+  priority are user-defined via `text/template` strings in the config file, with full access to
+  torrent metadata (labels, size, feed name, GUID, and more)
 - **History web UI** — browsable record of every processed feed item with outcome and extracted
   labels; skipped, excluded, and error items can be re-submitted to Transmission with a Torrent
   button

--- a/cmd/rss4transmission/config.go
+++ b/cmd/rss4transmission/config.go
@@ -59,10 +59,22 @@ type NtfyConfig struct {
 	CompletedBody     string `koanf:"CompletedBody"`
 	CompletedPriority string `koanf:"CompletedPriority"`
 
-	startedTitleTmpl   *template.Template
-	startedBodyTmpl    *template.Template
-	completedTitleTmpl *template.Template
-	completedBodyTmpl  *template.Template
+	ConfigTopic            string `koanf:"ConfigTopic"`
+	ConfigReloadedTitle    string `koanf:"ConfigReloadedTitle"`
+	ConfigReloadedBody     string `koanf:"ConfigReloadedBody"`
+	ConfigReloadedPriority string `koanf:"ConfigReloadedPriority"`
+	ConfigFailedTitle      string `koanf:"ConfigFailedTitle"`
+	ConfigFailedBody       string `koanf:"ConfigFailedBody"`
+	ConfigFailedPriority   string `koanf:"ConfigFailedPriority"`
+
+	startedTitleTmpl        *template.Template
+	startedBodyTmpl         *template.Template
+	completedTitleTmpl      *template.Template
+	completedBodyTmpl       *template.Template
+	configReloadedTitleTmpl *template.Template
+	configReloadedBodyTmpl  *template.Template
+	configFailedTitleTmpl   *template.Template
+	configFailedBodyTmpl    *template.Template
 }
 
 type CancelConfig struct {

--- a/cmd/rss4transmission/ntfy.go
+++ b/cmd/rss4transmission/ntfy.go
@@ -11,6 +11,12 @@ import (
 
 const ntfyTimeout = 30 * time.Second
 
+// NtfyConfigContext holds the data available to config-reload notification templates.
+type NtfyConfigContext struct {
+	ConfigFile string
+	Error      string // empty on success
+}
+
 // NtfyTemplateContext holds all torrent data available to notification templates.
 type NtfyTemplateContext struct {
 	Title     string
@@ -31,56 +37,87 @@ var validNtfyPriorities = map[string]struct{}{
 	"min": {}, "low": {}, "default": {}, "high": {}, "max": {},
 }
 
-// Validate applies template defaults and compiles all four notification templates.
-// It also validates that priority fields contain ntfy-accepted values.
-// Returns nil immediately when ntfy is disabled (BaseURL or Topic not set).
+// compileNotificationTemplates applies defaults to title/body/priority in
+// place, validates priority, and compiles title/body as text/template.
+// titleField/bodyField/priorityField name the config fields in error
+// messages, e.g. "StartedTitle".
+func compileNotificationTemplates(title, body, priority *string, titleDefault, bodyDefault, priorityDefault, titleField, bodyField, priorityField string) (*template.Template, *template.Template, error) {
+	if *title == "" {
+		*title = titleDefault
+	}
+	if *body == "" {
+		*body = bodyDefault
+	}
+	if *priority == "" {
+		*priority = priorityDefault
+	}
+
+	if _, ok := validNtfyPriorities[*priority]; !ok {
+		return nil, nil, fmt.Errorf("ntfy %s %q is not valid (min/low/default/high/max)", priorityField, *priority)
+	}
+
+	titleTmpl, err := template.New(titleField).Parse(*title)
+	if err != nil {
+		return nil, nil, fmt.Errorf("ntfy %s template: %w", titleField, err)
+	}
+	bodyTmpl, err := template.New(bodyField).Parse(*body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("ntfy %s template: %w", bodyField, err)
+	}
+	return titleTmpl, bodyTmpl, nil
+}
+
+// Validate applies template defaults and compiles notification templates. It
+// also validates that priority fields contain ntfy-accepted values.
+// Returns nil immediately when ntfy is disabled (BaseURL not set). The
+// Started/Completed (torrent) and ConfigReloaded/ConfigFailed (config-reload)
+// notification groups are independently opt-in, gated by Topic and
+// ConfigTopic respectively, so either can be enabled without the other.
 func (c *NtfyConfig) Validate() error {
-	if c.BaseURL == "" || c.Topic == "" {
+	if c.BaseURL == "" {
 		return nil
 	}
-	if c.StartedTitle == "" {
-		c.StartedTitle = "Torrent Started"
-	}
-	if c.StartedBody == "" {
-		c.StartedBody = "{{.Title}}\n{{.Size}}"
-	}
-	if c.StartedPriority == "" {
-		c.StartedPriority = "default"
-	}
-	if c.CompletedTitle == "" {
-		c.CompletedTitle = "Torrent Complete"
-	}
-	if c.CompletedBody == "" {
-		c.CompletedBody = "{{.Title}}\n{{.Dir}}"
-	}
-	if c.CompletedPriority == "" {
-		c.CompletedPriority = "default"
+
+	if c.Topic != "" {
+		var err error
+		c.startedTitleTmpl, c.startedBodyTmpl, err = compileNotificationTemplates(
+			&c.StartedTitle, &c.StartedBody, &c.StartedPriority,
+			"Torrent Started", "{{.Title}}\n{{.Size}}", "default",
+			"StartedTitle", "StartedBody", "StartedPriority")
+		if err != nil {
+			return err
+		}
+		c.completedTitleTmpl, c.completedBodyTmpl, err = compileNotificationTemplates(
+			&c.CompletedTitle, &c.CompletedBody, &c.CompletedPriority,
+			"Torrent Complete", "{{.Title}}\n{{.Dir}}", "default",
+			"CompletedTitle", "CompletedBody", "CompletedPriority")
+		if err != nil {
+			return err
+		}
 	}
 
-	if _, ok := validNtfyPriorities[c.StartedPriority]; !ok {
-		return fmt.Errorf("ntfy StartedPriority %q is not valid (min/low/default/high/max)", c.StartedPriority)
-	}
-	if _, ok := validNtfyPriorities[c.CompletedPriority]; !ok {
-		return fmt.Errorf("ntfy CompletedPriority %q is not valid (min/low/default/high/max)", c.CompletedPriority)
+	if c.ConfigTopic != "" {
+		var err error
+		c.configReloadedTitleTmpl, c.configReloadedBodyTmpl, err = compileNotificationTemplates(
+			&c.ConfigReloadedTitle, &c.ConfigReloadedBody, &c.ConfigReloadedPriority,
+			"Config Reloaded", "{{.ConfigFile}}", "low",
+			"ConfigReloadedTitle", "ConfigReloadedBody", "ConfigReloadedPriority")
+		if err != nil {
+			return err
+		}
+		c.configFailedTitleTmpl, c.configFailedBodyTmpl, err = compileNotificationTemplates(
+			&c.ConfigFailedTitle, &c.ConfigFailedBody, &c.ConfigFailedPriority,
+			"Config Reload FAILED", "{{.ConfigFile}}\n{{.Error}}", "high",
+			"ConfigFailedTitle", "ConfigFailedBody", "ConfigFailedPriority")
+		if err != nil {
+			return err
+		}
 	}
 
-	var err error
-	if c.startedTitleTmpl, err = template.New("StartedTitle").Parse(c.StartedTitle); err != nil {
-		return fmt.Errorf("ntfy StartedTitle template: %w", err)
-	}
-	if c.startedBodyTmpl, err = template.New("StartedBody").Parse(c.StartedBody); err != nil {
-		return fmt.Errorf("ntfy StartedBody template: %w", err)
-	}
-	if c.completedTitleTmpl, err = template.New("CompletedTitle").Parse(c.CompletedTitle); err != nil {
-		return fmt.Errorf("ntfy CompletedTitle template: %w", err)
-	}
-	if c.completedBodyTmpl, err = template.New("CompletedBody").Parse(c.CompletedBody); err != nil {
-		return fmt.Errorf("ntfy CompletedBody template: %w", err)
-	}
 	return nil
 }
 
-func renderTemplate(tmpl *template.Template, ctx *NtfyTemplateContext) (string, error) {
+func renderTemplate(tmpl *template.Template, ctx any) (string, error) {
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, ctx); err != nil {
 		return "", err
@@ -98,8 +135,8 @@ func NewNtfyClient(cfg NtfyConfig) *NtfyClient {
 	return &NtfyClient{cfg: cfg, client: &http.Client{Timeout: ntfyTimeout}}
 }
 
-func (c *NtfyClient) post(title, body, actions, priority string) error {
-	url := fmt.Sprintf("%s/%s", strings.TrimRight(c.cfg.BaseURL, "/"), c.cfg.Topic)
+func (c *NtfyClient) post(topic, title, body, actions, priority string) error {
+	url := fmt.Sprintf("%s/%s", strings.TrimRight(c.cfg.BaseURL, "/"), topic)
 	req, err := http.NewRequest("POST", url, strings.NewReader(body))
 	if err != nil {
 		return err
@@ -137,7 +174,7 @@ func (c *NtfyClient) SendTorrentStarted(ctx *NtfyTemplateContext) error {
 	if ctx.CancelURL != "" {
 		actions = fmt.Sprintf("view, More Info, %s", ctx.CancelURL)
 	}
-	return c.post(title, body, actions, c.cfg.StartedPriority)
+	return c.post(c.cfg.Topic, title, body, actions, c.cfg.StartedPriority)
 }
 
 func (c *NtfyClient) SendTorrentCompleted(ctx *NtfyTemplateContext) error {
@@ -149,5 +186,54 @@ func (c *NtfyClient) SendTorrentCompleted(ctx *NtfyTemplateContext) error {
 	if err != nil {
 		return err
 	}
-	return c.post(title, body, "", c.cfg.CompletedPriority)
+	return c.post(c.cfg.Topic, title, body, "", c.cfg.CompletedPriority)
+}
+
+func (c *NtfyClient) SendConfigReloadSuccess(ctx *NtfyConfigContext) error {
+	title, err := renderTemplate(c.cfg.configReloadedTitleTmpl, ctx)
+	if err != nil {
+		return err
+	}
+	body, err := renderTemplate(c.cfg.configReloadedBodyTmpl, ctx)
+	if err != nil {
+		return err
+	}
+	return c.post(c.cfg.ConfigTopic, title, body, "", c.cfg.ConfigReloadedPriority)
+}
+
+func (c *NtfyClient) SendConfigReloadFailure(ctx *NtfyConfigContext) error {
+	title, err := renderTemplate(c.cfg.configFailedTitleTmpl, ctx)
+	if err != nil {
+		return err
+	}
+	body, err := renderTemplate(c.cfg.configFailedBodyTmpl, ctx)
+	if err != nil {
+		return err
+	}
+	return c.post(c.cfg.ConfigTopic, title, body, "", c.cfg.ConfigFailedPriority)
+}
+
+// notifyConfigReload sends a config-reload outcome notification to ntfy's
+// ConfigTopic. No-op when BaseURL or ConfigTopic is unset. Send failures are
+// logged as warnings, never fatal — a broken notification channel must not
+// block the config-reload feature itself.
+func notifyConfigReload(cfg NtfyConfig, configFile string, reloadErr error) {
+	if cfg.BaseURL == "" || cfg.ConfigTopic == "" {
+		return
+	}
+
+	ntfyCtx := &NtfyConfigContext{ConfigFile: configFile}
+	client := NewNtfyClient(cfg)
+
+	if reloadErr != nil {
+		ntfyCtx.Error = reloadErr.Error()
+		if err := client.SendConfigReloadFailure(ntfyCtx); err != nil {
+			log.WithError(err).Warn("Failed to send ntfy config-reload-failure notification")
+		}
+		return
+	}
+
+	if err := client.SendConfigReloadSuccess(ntfyCtx); err != nil {
+		log.WithError(err).Warn("Failed to send ntfy config-reload-success notification")
+	}
 }

--- a/cmd/rss4transmission/ntfy_test.go
+++ b/cmd/rss4transmission/ntfy_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -357,4 +358,289 @@ func TestNtfyConfig_Validate_SkipsWhenDisabled(t *testing.T) {
 	// Invalid template should not cause an error when ntfy is disabled (no BaseURL/Topic).
 	cfg := NtfyConfig{StartedTitle: "{{.Unclosed"}
 	require.NoError(t, cfg.Validate(), "invalid template should be ignored when ntfy is disabled")
+}
+
+// --- Config-reload notification: NtfyConfig.Validate() ---
+
+func TestNtfyConfig_Validate_ConfigTopicDefaults(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", ConfigTopic: "cfgtopic"}
+	require.NoError(t, cfg.Validate())
+
+	assert.Equal(t, "Config Reloaded", cfg.ConfigReloadedTitle)
+	assert.Equal(t, "{{.ConfigFile}}", cfg.ConfigReloadedBody)
+	assert.Equal(t, "low", cfg.ConfigReloadedPriority)
+	assert.Equal(t, "Config Reload FAILED", cfg.ConfigFailedTitle)
+	assert.Equal(t, "{{.ConfigFile}}\n{{.Error}}", cfg.ConfigFailedBody)
+	assert.Equal(t, "high", cfg.ConfigFailedPriority)
+
+	// Topic wasn't set, so the Started/Completed block must not have run.
+	assert.Nil(t, cfg.startedTitleTmpl)
+	assert.Nil(t, cfg.completedTitleTmpl)
+	assert.NotNil(t, cfg.configReloadedTitleTmpl)
+	assert.NotNil(t, cfg.configFailedBodyTmpl)
+}
+
+func TestNtfyConfig_Validate_TopicOnlyDoesNotRequireConfigTopic(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", Topic: "t"}
+	require.NoError(t, cfg.Validate())
+
+	assert.Equal(t, "Torrent Started", cfg.StartedTitle)
+	assert.NotNil(t, cfg.startedTitleTmpl)
+	assert.Nil(t, cfg.configReloadedTitleTmpl)
+}
+
+func TestNtfyConfig_Validate_BothTopicsIndependentlyConfigurable(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", Topic: "t", ConfigTopic: "cfgtopic"}
+	require.NoError(t, cfg.Validate())
+
+	assert.NotNil(t, cfg.startedTitleTmpl)
+	assert.NotNil(t, cfg.startedBodyTmpl)
+	assert.NotNil(t, cfg.completedTitleTmpl)
+	assert.NotNil(t, cfg.completedBodyTmpl)
+	assert.NotNil(t, cfg.configReloadedTitleTmpl)
+	assert.NotNil(t, cfg.configReloadedBodyTmpl)
+	assert.NotNil(t, cfg.configFailedTitleTmpl)
+	assert.NotNil(t, cfg.configFailedBodyTmpl)
+}
+
+func TestNtfyConfig_Validate_SkipsConfigBlockWhenConfigTopicEmpty(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", Topic: "t", ConfigReloadedTitle: "{{.Unclosed"}
+	require.NoError(t, cfg.Validate(), "invalid ConfigReloadedTitle should be ignored when ConfigTopic is unset")
+}
+
+func TestNtfyConfig_Validate_InvalidConfigReloadedTemplate(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", ConfigTopic: "cfgtopic", ConfigReloadedTitle: "{{.Unclosed"}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ConfigReloadedTitle")
+}
+
+func TestNtfyConfig_Validate_InvalidConfigFailedTemplate(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", ConfigTopic: "cfgtopic", ConfigFailedBody: "{{.Unclosed"}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ConfigFailedBody")
+}
+
+func TestNtfyConfig_Validate_InvalidConfigReloadedPriority(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", ConfigTopic: "cfgtopic", ConfigReloadedPriority: "urgent"}
+	require.Error(t, cfg.Validate())
+}
+
+func TestNtfyConfig_Validate_InvalidConfigFailedPriority(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", ConfigTopic: "cfgtopic", ConfigFailedPriority: "urgent"}
+	require.Error(t, cfg.Validate())
+}
+
+// --- Config-reload notification: NtfyClient.SendConfigReload{Success,Failure} ---
+
+func TestSendConfigReloadSuccess_Headers(t *testing.T) {
+	var captured *http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, ConfigTopic: "cfgtopic"})
+	c := NewNtfyClient(cfg)
+	require.NoError(t, c.SendConfigReloadSuccess(&NtfyConfigContext{ConfigFile: "config.yaml"}))
+	require.NotNil(t, captured)
+
+	assert.Equal(t, "POST", captured.Method)
+	assert.Equal(t, "/cfgtopic", captured.URL.Path)
+	assert.Equal(t, "Config Reloaded", captured.Header.Get("Title"))
+	assert.Equal(t, "low", captured.Header.Get("Priority"))
+}
+
+func TestSendConfigReloadSuccess_Body(t *testing.T) {
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		body, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, ConfigTopic: "cfgtopic"})
+	c := NewNtfyClient(cfg)
+	require.NoError(t, c.SendConfigReloadSuccess(&NtfyConfigContext{ConfigFile: "/etc/rss4transmission/config.yaml"}))
+	assert.Equal(t, "/etc/rss4transmission/config.yaml", string(body))
+}
+
+func TestSendConfigReloadFailure_Headers(t *testing.T) {
+	var captured *http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, ConfigTopic: "cfgtopic"})
+	c := NewNtfyClient(cfg)
+	require.NoError(t, c.SendConfigReloadFailure(&NtfyConfigContext{ConfigFile: "config.yaml", Error: "boom"}))
+	require.NotNil(t, captured)
+
+	assert.Equal(t, "/cfgtopic", captured.URL.Path)
+	assert.Equal(t, "Config Reload FAILED", captured.Header.Get("Title"))
+	assert.Equal(t, "high", captured.Header.Get("Priority"))
+}
+
+func TestSendConfigReloadFailure_BodyIncludesError(t *testing.T) {
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		body, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, ConfigTopic: "cfgtopic"})
+	c := NewNtfyClient(cfg)
+	wantErr := "yaml: line 4: did not find expected key"
+	require.NoError(t, c.SendConfigReloadFailure(&NtfyConfigContext{ConfigFile: "config.yaml", Error: wantErr}))
+	assert.Contains(t, string(body), wantErr)
+}
+
+func TestSendConfigReloadSuccess_CustomTitleTemplate(t *testing.T) {
+	var captured *http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{
+		BaseURL:             srv.URL,
+		ConfigTopic:         "cfgtopic",
+		ConfigReloadedTitle: "Reloaded: {{.ConfigFile}}",
+	})
+	c := NewNtfyClient(cfg)
+	require.NoError(t, c.SendConfigReloadSuccess(&NtfyConfigContext{ConfigFile: "config.yaml"}))
+	assert.Equal(t, "Reloaded: config.yaml", captured.Header.Get("Title"))
+}
+
+func TestSendConfigReloadFailure_CustomBodyTemplate(t *testing.T) {
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		body, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{
+		BaseURL:          srv.URL,
+		ConfigTopic:      "cfgtopic",
+		ConfigFailedBody: "FAILED {{.ConfigFile}}: {{.Error}}",
+	})
+	c := NewNtfyClient(cfg)
+	require.NoError(t, c.SendConfigReloadFailure(&NtfyConfigContext{ConfigFile: "config.yaml", Error: "boom"}))
+	assert.Equal(t, "FAILED config.yaml: boom", string(body))
+}
+
+func TestSendConfigReload_UsesConfigTopicNotTopic(t *testing.T) {
+	var captured *http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, Topic: "torrents", ConfigTopic: "configevents"})
+	c := NewNtfyClient(cfg)
+	require.NoError(t, c.SendConfigReloadSuccess(&NtfyConfigContext{ConfigFile: "config.yaml"}))
+	require.NotNil(t, captured)
+	assert.Equal(t, "/configevents", captured.URL.Path)
+}
+
+// --- notifyConfigReload ---
+
+func TestNotifyConfigReload_NoopWhenConfigTopicEmpty(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	notifyConfigReload(NtfyConfig{BaseURL: srv.URL}, "config.yaml", nil)
+	assert.Equal(t, 0, requests)
+}
+
+func TestNotifyConfigReload_NoopWhenBaseURLEmpty(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	notifyConfigReload(NtfyConfig{ConfigTopic: "cfgtopic"}, "config.yaml", nil)
+	assert.Equal(t, 0, requests)
+}
+
+func TestNotifyConfigReload_SendsSuccessOnNilError(t *testing.T) {
+	var captured *http.Request
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		captured = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, ConfigTopic: "cfgtopic"})
+	notifyConfigReload(cfg, "config.yaml", nil)
+	assert.Equal(t, 1, requests)
+	require.NotNil(t, captured)
+	assert.Equal(t, "Config Reloaded", captured.Header.Get("Title"))
+}
+
+func TestNotifyConfigReload_SendsFailureWithErrorTextOnNonNilError(t *testing.T) {
+	var body []byte
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		var err error
+		body, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, ConfigTopic: "cfgtopic"})
+	notifyConfigReload(cfg, "config.yaml",
+		fmt.Errorf("yaml: line 4: did not find expected key"))
+	assert.Equal(t, 1, requests)
+	assert.Contains(t, string(body), "yaml: line 4: did not find expected key")
+}
+
+func TestNotifyConfigReload_SendFailureIsNonFatal(t *testing.T) {
+	blocked := make(chan struct{})
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-blocked
+	}))
+	defer func() {
+		close(blocked)
+		slow.Close()
+	}()
+
+	cfg := NtfyConfig{BaseURL: slow.URL, ConfigTopic: "cfgtopic"}
+	require.NoError(t, cfg.Validate())
+
+	done := make(chan struct{})
+	go func() {
+		notifyConfigReload(cfg, "config.yaml", fmt.Errorf("boom"))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(ntfyTimeout + 5*time.Second):
+		t.Fatal("notifyConfigReload should return once the client times out, not hang forever")
+	}
 }

--- a/cmd/rss4transmission/watch.go
+++ b/cmd/rss4transmission/watch.go
@@ -62,15 +62,21 @@ func (r *configReloader) onWatchEvent(event any, err error) {
 		return
 	}
 
-	// don't change the config while we are processing the feed
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	reloadErr := func() error {
+		// don't change the config while we are processing the feed
+		r.mu.Lock()
+		defer r.mu.Unlock()
 
-	log.Infof("config changed. reloading...")
-	reloadErr := r.reload()
+		log.Infof("config changed. reloading...")
+		return r.reload()
+	}()
+
 	if reloadErr != nil {
 		log.WithError(reloadErr).Errorf("failed to reload config file")
 	}
+	// notify outside the lock: notifyConfigReload does a synchronous HTTP
+	// POST with a 30s timeout, and holding r.mu that long would block the
+	// ticker loop's once.Run and the web handlers that also take r.mu.
 	if r.notifyReload != nil {
 		r.notifyReload(reloadErr)
 	}
@@ -80,10 +86,25 @@ func (r *configReloader) onWatchEvent(event any, err error) {
 // blocks (via retryLoadConfig) until the config file is readable again, so
 // callers run it in its own goroutine.
 func (r *configReloader) recover() {
+	notifiedFailure := false
 	attempt := retryLoadConfig(func() error {
-		r.mu.Lock()
-		defer r.mu.Unlock()
-		return r.reload()
+		reloadErr := func() error {
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			return r.reload()
+		}()
+
+		// Report the first failure so a bad edit saved via atomic
+		// rename/replace (which routes through this recovery path rather
+		// than onWatchEvent's direct reload) is still visible, but don't
+		// spam a notification per retry attempt.
+		if reloadErr != nil && !notifiedFailure {
+			notifiedFailure = true
+			if r.notifyReload != nil {
+				r.notifyReload(reloadErr)
+			}
+		}
+		return reloadErr
 	}, r.retryInterval)
 
 	log.Infof("config reloaded after %d attempt(s), re-registering file watcher", attempt)

--- a/cmd/rss4transmission/watch.go
+++ b/cmd/rss4transmission/watch.go
@@ -44,6 +44,7 @@ type configReloader struct {
 	reload        func() error
 	registerWatch func(cb func(event any, err error)) error
 	retryInterval time.Duration
+	notifyReload  func(err error)
 }
 
 // onWatchEvent is the callback registered with the file watcher.
@@ -66,8 +67,12 @@ func (r *configReloader) onWatchEvent(event any, err error) {
 	defer r.mu.Unlock()
 
 	log.Infof("config changed. reloading...")
-	if err := r.reload(); err != nil {
-		log.WithError(err).Errorf("failed to reload config file")
+	reloadErr := r.reload()
+	if reloadErr != nil {
+		log.WithError(reloadErr).Errorf("failed to reload config file")
+	}
+	if r.notifyReload != nil {
+		r.notifyReload(reloadErr)
 	}
 }
 
@@ -82,6 +87,9 @@ func (r *configReloader) recover() {
 	}, r.retryInterval)
 
 	log.Infof("config reloaded after %d attempt(s), re-registering file watcher", attempt)
+	if r.notifyReload != nil {
+		r.notifyReload(nil)
+	}
 	if err := r.registerWatch(r.onWatchEvent); err != nil {
 		log.WithError(err).Errorf("failed to re-register config file watcher")
 	}
@@ -99,6 +107,9 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 		},
 		registerWatch: ctx.Provider.Watch,
 		retryInterval: defaultRetryInterval,
+		notifyReload: func(err error) {
+			notifyConfigReload(ctx.Config.Ntfy, ctx.configFile, err)
+		},
 	}
 	_ = reloader.registerWatch(reloader.onWatchEvent)
 
@@ -162,8 +173,8 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 	}
 
 	retryHistory := func(rec HistoryRecord) (int64, error) {
-		mu.Lock()
-		defer mu.Unlock()
+		reloader.mu.Lock()
+		defer reloader.mu.Unlock()
 		return retryHistoryItem(ctx, rec)
 	}
 
@@ -171,8 +182,8 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 	// the history page's Torrent button reflects the config as it stands at
 	// render time, not as it was when the server started.
 	feedConfigured := func(name string) bool {
-		mu.Lock()
-		defer mu.Unlock()
+		reloader.mu.Lock()
+		defer reloader.mu.Unlock()
 		_, ok := findFeedByName(ctx.Config.Feeds, name)
 		return ok
 	}

--- a/cmd/rss4transmission/watch_test.go
+++ b/cmd/rss4transmission/watch_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 )
@@ -215,4 +216,183 @@ func TestConfigReloader_Recover_ReregisterFailureIsLoggedNotFatal(t *testing.T) 
 
 	// Must not panic even though re-registration itself fails.
 	r.recover()
+}
+
+// --- notifyReload wiring ---
+
+func TestConfigReloader_OnWatchEvent_NilNotifyReload_DoesNotPanic(t *testing.T) {
+	r := &configReloader{
+		reload:        func() error { return nil },
+		registerWatch: func(cb func(event any, err error)) error { return nil },
+	}
+
+	// notifyReload is unset (zero value nil); this must not panic.
+	r.onWatchEvent(nil, nil)
+}
+
+func TestConfigReloader_Recover_NilNotifyReload_DoesNotPanic(t *testing.T) {
+	r := &configReloader{
+		reload:        func() error { return nil },
+		registerWatch: func(cb func(event any, err error)) error { return nil },
+		retryInterval: 0,
+	}
+
+	// notifyReload is unset (zero value nil); this must not panic.
+	r.recover()
+}
+
+func TestConfigReloader_OnWatchEvent_Success_NotifiesWithNilError(t *testing.T) {
+	var notified []error
+	r := &configReloader{
+		reload:        func() error { return nil },
+		registerWatch: func(cb func(event any, err error)) error { return nil },
+		notifyReload: func(err error) {
+			notified = append(notified, err)
+		},
+	}
+
+	r.onWatchEvent(nil, nil)
+
+	if len(notified) != 1 {
+		t.Fatalf("expected notifyReload to be called once, got %d", len(notified))
+	}
+	if notified[0] != nil {
+		t.Errorf("expected notifyReload to be called with nil error, got %v", notified[0])
+	}
+}
+
+func TestConfigReloader_OnWatchEvent_ReloadFailure_NotifiesWithError(t *testing.T) {
+	wantErr := fmt.Errorf("bad yaml")
+	var notified []error
+	r := &configReloader{
+		reload:        func() error { return wantErr },
+		registerWatch: func(cb func(event any, err error)) error { return nil },
+		notifyReload: func(err error) {
+			notified = append(notified, err)
+		},
+	}
+
+	r.onWatchEvent(nil, nil)
+
+	if len(notified) != 1 {
+		t.Fatalf("expected notifyReload to be called once, got %d", len(notified))
+	}
+	if notified[0] == nil || notified[0].Error() != wantErr.Error() {
+		t.Errorf("expected notifyReload to be called with %v, got %v", wantErr, notified[0])
+	}
+}
+
+// TestConfigReloader_OnWatchEvent_WatchError_DoesNotNotify confirms the
+// err != nil (watcher-death) branch itself never calls notifyReload
+// directly/synchronously — any notification only comes from recover(), and
+// only once its reload has actually completed. reload here blocks until the
+// test signals it to proceed, so we can observe the state in between: after
+// recover() has started but before reload returns, notifyReload must still
+// be unfired.
+func TestConfigReloader_OnWatchEvent_WatchError_DoesNotNotify(t *testing.T) {
+	started := make(chan struct{})
+	proceed := make(chan struct{})
+	reregistered := make(chan struct{}, 1)
+	var notifyCount int
+	var mu sync.Mutex
+	r := &configReloader{
+		reload: func() error {
+			close(started)
+			<-proceed
+			return nil
+		},
+		registerWatch: func(cb func(event any, err error)) error {
+			reregistered <- struct{}{}
+			return nil
+		},
+		retryInterval: 0,
+		notifyReload: func(err error) {
+			mu.Lock()
+			notifyCount++
+			mu.Unlock()
+		},
+	}
+
+	r.onWatchEvent(nil, fmt.Errorf("fsnotify watch channel closed"))
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected recover() to invoke reload, but it never started")
+	}
+
+	mu.Lock()
+	got := notifyCount
+	mu.Unlock()
+	if got != 0 {
+		t.Fatalf("notifyReload must not fire before reload completes, got %d calls", got)
+	}
+
+	close(proceed)
+
+	select {
+	case <-reregistered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected watcher to be re-registered after error, but it was not")
+	}
+
+	mu.Lock()
+	got = notifyCount
+	mu.Unlock()
+	if got != 1 {
+		t.Errorf("expected notifyReload to be called once (by recover(), after reload completed), got %d", got)
+	}
+}
+
+func TestConfigReloader_Recover_NotifiesSuccessOnceAfterRetries(t *testing.T) {
+	calls := 0
+	var notified []error
+	r := &configReloader{
+		reload: func() error {
+			calls++
+			if calls < 3 {
+				return fmt.Errorf("not ready")
+			}
+			return nil
+		},
+		registerWatch: func(cb func(event any, err error)) error { return nil },
+		retryInterval: 0,
+		notifyReload: func(err error) {
+			notified = append(notified, err)
+		},
+	}
+
+	r.recover()
+
+	if len(notified) != 1 {
+		t.Fatalf("expected notifyReload to be called exactly once, got %d", len(notified))
+	}
+	if notified[0] != nil {
+		t.Errorf("expected notifyReload to be called with nil error, got %v", notified[0])
+	}
+}
+
+func TestConfigReloader_Recover_DoesNotNotifyPerFailedAttempt(t *testing.T) {
+	calls := 0
+	notifyCalls := 0
+	r := &configReloader{
+		reload: func() error {
+			calls++
+			if calls < 3 {
+				return fmt.Errorf("not ready")
+			}
+			return nil
+		},
+		registerWatch: func(cb func(event any, err error)) error { return nil },
+		retryInterval: 0,
+		notifyReload: func(err error) {
+			notifyCalls++
+		},
+	}
+
+	r.recover()
+
+	if notifyCalls != 1 {
+		t.Errorf("expected notifyReload to be called once (not per retry attempt), got %d", notifyCalls)
+	}
 }

--- a/cmd/rss4transmission/watch_test.go
+++ b/cmd/rss4transmission/watch_test.go
@@ -344,6 +344,28 @@ func TestConfigReloader_OnWatchEvent_WatchError_DoesNotNotify(t *testing.T) {
 	}
 }
 
+// TestConfigReloader_OnWatchEvent_NotifyReload_DoesNotHoldLock is the
+// regression test for the bug where notifyReload was invoked while r.mu
+// was still held (via defer). notifyConfigReload performs a synchronous
+// HTTP POST with a 30s timeout, so calling it under the lock could block
+// the ticker loop's once.Run and the web handlers (which also take
+// reloader.mu) for up to 30s on a slow/unreachable ntfy server. The lock
+// must be released before notifyReload runs.
+func TestConfigReloader_OnWatchEvent_NotifyReload_DoesNotHoldLock(t *testing.T) {
+	r := &configReloader{
+		reload:        func() error { return nil },
+		registerWatch: func(cb func(event any, err error)) error { return nil },
+	}
+	r.notifyReload = func(err error) {
+		if !r.mu.TryLock() {
+			t.Fatal("expected r.mu to be unlocked while notifyReload runs, but it was held")
+		}
+		r.mu.Unlock()
+	}
+
+	r.onWatchEvent(nil, nil)
+}
+
 func TestConfigReloader_Recover_NotifiesSuccessOnceAfterRetries(t *testing.T) {
 	calls := 0
 	var notified []error
@@ -364,21 +386,33 @@ func TestConfigReloader_Recover_NotifiesSuccessOnceAfterRetries(t *testing.T) {
 
 	r.recover()
 
-	if len(notified) != 1 {
-		t.Fatalf("expected notifyReload to be called exactly once, got %d", len(notified))
+	// One failure notice (from the first failed attempt) plus one final
+	// success notice; the last call must report success.
+	if len(notified) != 2 {
+		t.Fatalf("expected notifyReload to be called twice (failure then success), got %d", len(notified))
 	}
-	if notified[0] != nil {
-		t.Errorf("expected notifyReload to be called with nil error, got %v", notified[0])
+	if notified[0] == nil {
+		t.Errorf("expected first notifyReload call to report the failure error, got nil")
+	}
+	if notified[1] != nil {
+		t.Errorf("expected final notifyReload call to report success (nil), got %v", notified[1])
 	}
 }
 
-func TestConfigReloader_Recover_DoesNotNotifyPerFailedAttempt(t *testing.T) {
+// TestConfigReloader_Recover_NotifiesFailureOnceThenSuccess is the
+// regression test for the bug where recover() only ever notified on
+// eventual success. Editors that save via atomic rename/replace make
+// koanf's watcher report an error, which routes through the err != nil
+// branch into recover() — so a bad edit saved that way must still produce
+// a failure notification (once, not per retry attempt), followed by a
+// success notification once the config is valid again.
+func TestConfigReloader_Recover_NotifiesFailureOnceThenSuccess(t *testing.T) {
 	calls := 0
-	notifyCalls := 0
+	var notified []error
 	r := &configReloader{
 		reload: func() error {
 			calls++
-			if calls < 3 {
+			if calls < 4 {
 				return fmt.Errorf("not ready")
 			}
 			return nil
@@ -386,13 +420,19 @@ func TestConfigReloader_Recover_DoesNotNotifyPerFailedAttempt(t *testing.T) {
 		registerWatch: func(cb func(event any, err error)) error { return nil },
 		retryInterval: 0,
 		notifyReload: func(err error) {
-			notifyCalls++
+			notified = append(notified, err)
 		},
 	}
 
 	r.recover()
 
-	if notifyCalls != 1 {
-		t.Errorf("expected notifyReload to be called once (not per retry attempt), got %d", notifyCalls)
+	if len(notified) != 2 {
+		t.Fatalf("expected notifyReload to be called twice (one failure notice, then one success notice), got %d", len(notified))
+	}
+	if notified[0] == nil {
+		t.Errorf("expected first notifyReload call to report the failure error, got nil")
+	}
+	if notified[1] != nil {
+		t.Errorf("expected final notifyReload call to report success (nil), got %v", notified[1])
 	}
 }

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-RSS4Transmission supports two kinds of push notifications via [ntfy](https://ntfy.sh):
+RSS4Transmission supports three kinds of push notifications via [ntfy](https://ntfy.sh):
 
 - **Torrent started** — sent by rss4transmission immediately after submitting a torrent to
   Transmission. Includes a **More Info** action button that opens a browser confirmation
@@ -11,6 +11,10 @@ RSS4Transmission supports two kinds of push notifications via [ntfy](https://ntf
 - **Torrent completed** — sent via the `POST /notify-complete` endpoint, which is called by
   `bin/torrent-complete.sh` running as Transmission's "torrent done" hook. The endpoint renders
   your configured templates and sends the notification to ntfy.
+- **Config reloaded** — sent by `watch` whenever it picks up a change to the config file, to its
+  own `Ntfy.ConfigTopic` (separate from the torrent notifications' `Ntfy.Topic`). Reports whether
+  the reload succeeded or failed; on failure, the notification body includes the actual error
+  (e.g. a YAML parse error), so a bad edit is visible immediately without tailing logs.
 
 ## ntfy and Cancel Configuration
 
@@ -18,9 +22,10 @@ Add `Ntfy` and `Cancel` blocks to your config file:
 
 ```yaml
 Ntfy:
-  BaseURL: https://ntfy.sh              # your ntfy server
-  Topic:   <your-topic-name>            # ntfy topic to publish to
-  Token:   tk_<your-access-token>       # ntfy access token
+  BaseURL:     https://ntfy.sh              # your ntfy server
+  Topic:       <your-topic-name>            # ntfy topic to publish to (torrent notifications)
+  ConfigTopic: <your-config-topic-name>     # ntfy topic to publish to (config-reload notifications)
+  Token:       tk_<your-access-token>       # ntfy access token
 
 Cancel:
   HMACSecret: <random-32-byte-hex>                   # generate: openssl rand -hex 32
@@ -39,13 +44,23 @@ Cancel:
 | `Ntfy.CompletedTitle` | `"Torrent Complete"` | `text/template` string for the completed notification title |
 | `Ntfy.CompletedBody` | `"{{.Title}}\n{{.Dir}}"` | `text/template` string for the completed notification body |
 | `Ntfy.CompletedPriority` | `default` | ntfy priority for completed notifications |
+| `Ntfy.ConfigTopic` | — | ntfy topic to publish config-reload notifications to |
+| `Ntfy.ConfigReloadedTitle` | `"Config Reloaded"` | `text/template` string for the reload-success notification title |
+| `Ntfy.ConfigReloadedBody` | `"{{.ConfigFile}}"` | `text/template` string for the reload-success notification body |
+| `Ntfy.ConfigReloadedPriority` | `low` | ntfy priority for reload-success notifications |
+| `Ntfy.ConfigFailedTitle` | `"Config Reload FAILED"` | `text/template` string for the reload-failure notification title |
+| `Ntfy.ConfigFailedBody` | `"{{.ConfigFile}}\n{{.Error}}"` | `text/template` string for the reload-failure notification body |
+| `Ntfy.ConfigFailedPriority` | `high` | ntfy priority for reload-failure notifications |
 | `Cancel.HMACSecret` | — | Secret key for signing cancel URLs (HMAC-SHA256) |
 | `Cancel.BaseURL` | — | Public base URL of rss4transmission (used in cancel links) |
 | `Cancel.TokenTTLH` | `24` | Hours before a cancel link expires |
 
 Cancel links are omitted from notifications when `Cancel.HMACSecret` or `Cancel.BaseURL` is not
 configured — the torrent started notification is still sent, just without the cancel action.
-Ntfy notifications are entirely disabled when `Ntfy.BaseURL` is not set.
+Ntfy notifications are entirely disabled when `Ntfy.BaseURL` is not set. `Ntfy.Topic` and
+`Ntfy.ConfigTopic` gate their respective notification groups independently: torrent
+started/completed notifications require `Topic`, config-reload notifications require
+`ConfigTopic`, and either can be configured without the other.
 
 ## Notification Templates
 
@@ -109,6 +124,26 @@ Ntfy:
 > **Note:** Multiline template bodies in YAML require a block scalar (`|`). In a
 > double-quoted YAML string, use `\n` for a literal newline:
 > `StartedBody: "{{.Title}}\n{{.Size}}"`.
+
+## Config Reload Notification Context
+
+The `ConfigReloadedTitle`, `ConfigReloadedBody`, `ConfigFailedTitle`, and `ConfigFailedBody`
+fields also accept `text/template` strings, but with their own, smaller context — they do **not**
+have access to `{{.Title}}`, `{{.Size}}`, or any other torrent-notification field:
+
+| Field | Type | Description |
+|---|---|---|
+| `{{.ConfigFile}}` | `string` | Path to the config file that was (re)loaded |
+| `{{.Error}}` | `string` | Reload error text (e.g. a YAML parse error); empty on success |
+
+Include the parse error in the failure body:
+
+```yaml
+Ntfy:
+  ConfigFailedBody: |
+    Failed to reload {{.ConfigFile}}:
+    {{.Error}}
+```
 
 ## Cancel Endpoint
 


### PR DESCRIPTION
## Summary
- Adds a config-reload ntfy notification group (`Ntfy.ConfigTopic`, `ConfigReloaded*`/`ConfigFailed*` title/body/priority templates) that's independently opt-in from the existing torrent `Topic` group
- `watch` now reports whether a live config-file reload succeeded or failed via push notification; the failure notification body includes the actual reload error (e.g. a YAML parse error) so a bad edit is visible immediately without tailing logs
- Fixes a pre-existing `undefined: mu` compile bug on `main` left over from the weblinks/config-reload PR merge (unrelated cleanup required before this work could build)

## Test plan
- [x] `make test` (go vet + full suite, 383 tests)
- [x] `gofmt -l` clean
- [x] `go mod tidy` — no changes
- [x] `golangci-lint run` — 0 issues
- [x] TDD: new tests in `ntfy_test.go` (Validate() gating, SendConfigReload* client methods, notifyConfigReload helper) and `watch_test.go` (notifyReload wiring into configReloader, nil-safety, no-notify-per-retry-attempt)
- [x] `docs/notifications.md` and `README.md` updated for the new config fields and notification type

🤖 Generated with [Claude Code](https://claude.com/claude-code)