### PR TITLE
Fix undefined mu reference in watch.go

### DIFF
--- a/cmd/rss4transmission/watch.go
+++ b/cmd/rss4transmission/watch.go
@@ -162,8 +162,8 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 	}
 
 	retryHistory := func(rec HistoryRecord) (int64, error) {
-		mu.Lock()
-		defer mu.Unlock()
+		reloader.mu.Lock()
+		defer reloader.mu.Unlock()
 		return retryHistoryItem(ctx, rec)
 	}
 
@@ -171,8 +171,8 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 	// the history page's Torrent button reflects the config as it stands at
 	// render time, not as it was when the server started.
 	feedConfigured := func(name string) bool {
-		mu.Lock()
-		defer mu.Unlock()
+		reloader.mu.Lock()
+		defer reloader.mu.Unlock()
 		_, ok := findFeedByName(ctx.Config.Feeds, name)
 		return ok
 	}


### PR DESCRIPTION
## Summary
- The config-reload refactor moved the watch-loop mutex into `configReloader.mu`, but two call sites in `WatchCmd.Run` (`retryHistory`, `feedConfigured`) still referenced the old local `mu` variable, which no longer exists — breaking `go vet`/typecheck and `make lint`.
- Updated both to lock `reloader.mu` instead.

## Test plan
- [x] `make test` passes
- [x] `make lint` passes (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)