### PR TITLE
Sync Gluetun port to Transmission even when port-test errors

### DIFF
--- a/cmd/rss4transmission/gluetun.go
+++ b/cmd/rss4transmission/gluetun.go
@@ -41,6 +41,8 @@ type Gluetun struct {
 	AuthUsername     string
 	AuthPassword     string
 	AuthAPIKey       string
+	retryAttempts    int
+	retryDelay       time.Duration
 }
 
 func NewGluetun(g GluetunConfig, t *transmissionrpc.Client) *Gluetun {
@@ -70,6 +72,8 @@ func NewGluetun(g GluetunConfig, t *transmissionrpc.Client) *Gluetun {
 		AuthUsername:     g.AuthUsername,
 		AuthPassword:     g.AuthPassword,
 		AuthAPIKey:       g.AuthAPIKey,
+		retryAttempts:    5,
+		retryDelay:       3 * time.Second,
 	}
 }
 
@@ -105,25 +109,30 @@ func (g *Gluetun) CheckVpnTunnel() {
 	ForceRotate = false
 
 	var open bool
-	for i := 0; i < 5; i++ {
+	for range g.retryAttempts {
 		open, err = g.isPortOpen()
 		if err == nil {
 			break
 		}
-		time.Sleep(3 * time.Second)
+		time.Sleep(g.retryDelay)
 	}
 	if err != nil {
-		log.WithError(err).Errorf("Unable to check IsPortOpen()")
-		return
+		// We couldn't determine whether the port is open (e.g. Transmission's
+		// port-test call to its external checker failed/timed out). Don't treat
+		// that as "closed" for rotation purposes, but still make sure Transmission
+		// has the latest port Gluetun is forwarding -- otherwise a persistently
+		// failing port-test would mean the port is never synced at all.
+		log.WithError(err).Warnf("Unable to check IsPortOpen(); syncing port with Gluetun anyway")
+		open = false
 	}
 
 	if !open {
-		for i := 0; i < 5; i++ {
+		for range g.retryAttempts {
 			err = g.updatePort()
 			if err == nil {
 				break
 			}
-			time.Sleep(3 * time.Second)
+			time.Sleep(g.retryDelay)
 		}
 		if err != nil {
 			log.WithError(err).Errorf("Unable to UpdatePort()")

--- a/cmd/rss4transmission/gluetun_test.go
+++ b/cmd/rss4transmission/gluetun_test.go
@@ -2,11 +2,17 @@ package main
 
 import (
 	"encoding/base64"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/hekmon/transmissionrpc/v3"
 )
 
 func newTestGluetun(url string) *Gluetun {
@@ -183,5 +189,85 @@ func TestNewRequest_NoAuth(t *testing.T) {
 	}
 	if req.Header.Get("X-API-Key") != "" {
 		t.Error("X-API-Key header should not be set when no API key configured")
+	}
+}
+
+// portTestFailingTransmissionServer simulates Transmission where the "port-test"
+// RPC method always fails (e.g. because it can't reach the external port checker
+// service), but records the peer-port set via "session-set".
+func portTestFailingTransmissionServer(t *testing.T, gotPeerPort *int64) *httptest.Server {
+	t.Helper()
+	const sessionID = "test-session-id"
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Transmission-Session-Id") != sessionID {
+			w.Header().Set("X-Transmission-Session-Id", sessionID)
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		var req struct {
+			Method    string `json:"method"`
+			Tag       int    `json:"tag"`
+			Arguments struct {
+				PeerPort int64 `json:"peer-port"`
+			} `json:"arguments"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("unmarshal body: %v", err)
+		}
+
+		resp := map[string]any{"tag": req.Tag}
+		switch req.Method {
+		case "port-test":
+			resp["result"] = "Couldn't test port: No Response (0)"
+		case "session-set":
+			atomic.StoreInt64(gotPeerPort, req.Arguments.PeerPort)
+			resp["result"] = "success"
+		default:
+			t.Fatalf("unexpected method: %s", req.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func TestCheckVpnTunnel_PortTestErrors_StillSyncsPort(t *testing.T) {
+	var gotPeerPort int64
+	transmissionSrv := portTestFailingTransmissionServer(t, &gotPeerPort)
+	defer transmissionSrv.Close()
+	endpoint, err := url.Parse(transmissionSrv.URL)
+	if err != nil {
+		t.Fatalf("parse transmission url: %v", err)
+	}
+	client, err := transmissionrpc.New(endpoint, nil)
+	if err != nil {
+		t.Fatalf("new transmission client: %v", err)
+	}
+
+	gluetunSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ports":[12345]}`))
+	}))
+	defer gluetunSrv.Close()
+
+	g := &Gluetun{
+		URL:           gluetunSrv.URL,
+		Transmission:  client,
+		lastRotate:    time.Now(),
+		peerPort:      -1,
+		retryAttempts: 1,
+		retryDelay:    time.Millisecond,
+	}
+
+	g.CheckVpnTunnel()
+
+	if got := atomic.LoadInt64(&gotPeerPort); got != 12345 {
+		t.Errorf("transmission peer port = %d, want 12345 (port-test errors must not block syncing the known Gluetun port)", got)
+	}
+	if g.peerPort != 12345 {
+		t.Errorf("g.peerPort = %d, want 12345", g.peerPort)
 	}
 }


### PR DESCRIPTION
## Summary
- `Gluetun.isPortOpen()` errors (e.g. Transmission's port-test call to its external checker failing with "No Response") caused `CheckVpnTunnel()` to log and bail without ever syncing the peer port, so a persistently-failing port-test meant Transmission was never told the correct Gluetun-forwarded port for the life of the container.
- `CheckVpnTunnel()` now treats an inconclusive port-test as "not open" and falls through to `updatePort()`, so Transmission's peer port stays in sync with Gluetun regardless of whether the port-test itself succeeds. Port-test errors still don't count toward the `ClosedPortChecks` rotation threshold.
- Retry count/delay (previously hardcoded 5 attempts / 3s) are now fields on `Gluetun` so tests can run fast.

## Test plan
- [x] Added `TestCheckVpnTunnel_PortTestErrors_StillSyncsPort`, which fails against the old code and passes with the fix
- [x] `make test`
- [x] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)