### PR TITLE
Add periodic Transmission port-open monitor with ntfy alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,18 @@ Pre-built images are available on [DockerHub](https://hub.docker.com/r/synfinati
   resolution, etc.) from torrent titles and file names; deduplicate by identity key; prefer
   higher-quality versions automatically
 - **[ntfy](https://ntfy.sh) push notifications** — receive a notification when a torrent starts
-  (with a More Info button), when it completes, and when `watch` reloads its config file
-  (reporting success or failure, with the error text on failure); notification title, body, and
+  (with a More Info button), when it completes, when `watch` reloads its config file (reporting
+  success or failure, with the error text on failure), and when Transmission's peer port
+  transitions open/closed or is still closed 60s after startup; notification title, body, and
   priority are user-defined via `text/template` strings in the config file, with full access to
   torrent metadata (labels, size, feed name, GUID, and more)
 - **History web UI** — browsable record of every processed feed item with outcome and extracted
   labels; skipped, excluded, and error items can be re-submitted to Transmission with a Torrent
   button
 - **Gluetun VPN integration** — automatically restarts the VPN and syncs the peer port into
-  Transmission when running behind [Gluetun](https://github.com/qdm12/gluetun)
+  Transmission when running behind [Gluetun](https://github.com/qdm12/gluetun); port state is
+  polled every 5 minutes and logged/alerted on (also available without Gluetun via
+  `PortCheck.Enabled`)
 - **Torrent file cache** — avoids re-fetching `.torrent` files on every watch-loop iteration;
   pruned automatically
 - **Ordered, stop-after-dispatch processing** — feeds are processed in the order they're listed

--- a/cmd/rss4transmission/config.go
+++ b/cmd/rss4transmission/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	Gluetun       GluetunConfig            `koanf:"Gluetun"`
 	Ntfy          NtfyConfig               `koanf:"Ntfy"`
 	Cancel        CancelConfig             `koanf:"Cancel"`
+	PortCheck     PortCheckConfig          `koanf:"PortCheck"`
 	SeenFile      string                   `koanf:"SeenFile"`
 	SeenCacheDays int                      `koanf:"SeenCacheDays"`
 }
@@ -59,13 +60,19 @@ type NtfyConfig struct {
 	CompletedBody     string `koanf:"CompletedBody"`
 	CompletedPriority string `koanf:"CompletedPriority"`
 
-	ConfigTopic            string `koanf:"ConfigTopic"`
+	AlertTopic             string `koanf:"AlertTopic"`
 	ConfigReloadedTitle    string `koanf:"ConfigReloadedTitle"`
 	ConfigReloadedBody     string `koanf:"ConfigReloadedBody"`
 	ConfigReloadedPriority string `koanf:"ConfigReloadedPriority"`
 	ConfigFailedTitle      string `koanf:"ConfigFailedTitle"`
 	ConfigFailedBody       string `koanf:"ConfigFailedBody"`
 	ConfigFailedPriority   string `koanf:"ConfigFailedPriority"`
+	PortClosedTitle        string `koanf:"PortClosedTitle"`
+	PortClosedBody         string `koanf:"PortClosedBody"`
+	PortClosedPriority     string `koanf:"PortClosedPriority"`
+	PortOpenedTitle        string `koanf:"PortOpenedTitle"`
+	PortOpenedBody         string `koanf:"PortOpenedBody"`
+	PortOpenedPriority     string `koanf:"PortOpenedPriority"`
 
 	startedTitleTmpl        *template.Template
 	startedBodyTmpl         *template.Template
@@ -75,6 +82,14 @@ type NtfyConfig struct {
 	configReloadedBodyTmpl  *template.Template
 	configFailedTitleTmpl   *template.Template
 	configFailedBodyTmpl    *template.Template
+	portClosedTitleTmpl     *template.Template
+	portClosedBodyTmpl      *template.Template
+	portOpenedTitleTmpl     *template.Template
+	portOpenedBodyTmpl      *template.Template
+}
+
+type PortCheckConfig struct {
+	Enabled bool `koanf:"Enabled"`
 }
 
 type CancelConfig struct {

--- a/cmd/rss4transmission/config_test.go
+++ b/cmd/rss4transmission/config_test.go
@@ -204,6 +204,23 @@ Feeds:
 	}
 }
 
+func TestLoadConfig_PortCheckEnabledDefaultsFalse(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(validExtractorYAML), 0600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	rc := &RunContext{}
+	if _, err := rc.loadConfig(cfgPath); err != nil {
+		t.Fatalf("loadConfig failed: %v", err)
+	}
+
+	if rc.Config.PortCheck.Enabled {
+		t.Error("PortCheck.Enabled should default to false when unset")
+	}
+}
+
 func TestLoadConfig_RejectsDuplicateFeedNames(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")

--- a/cmd/rss4transmission/gluetun.go
+++ b/cmd/rss4transmission/gluetun.go
@@ -93,51 +93,58 @@ func (g *Gluetun) newRequest(method, url string, body io.Reader) (*http.Request,
 
 var ForceRotate bool // flag to force rotation again due to failure
 
-// checkVpnTunnel restarts / rotates the VPN tunnel as necessary
-func (g *Gluetun) CheckVpnTunnel() {
-	var err error
-
+// checkVpnTunnel restarts / rotates the VPN tunnel as necessary. It returns
+// the observed port-open state and whether the port-test itself succeeded --
+// callers use this to distinguish "confirmed closed" from "couldn't tell"
+// (e.g. a flaky port-test), which the internal sync-below logic deliberately
+// collapses into "sync defensively either way".
+func (g *Gluetun) CheckVpnTunnel() (bool, error) {
 	if g.rotateNow() || ForceRotate {
-		err = g.rotate()
-		if err != nil {
+		if err := g.rotate(); err != nil {
 			log.WithError(err).Errorf("Rotate() failed")
 			ForceRotate = true
-			return
+			return false, err
 		}
 		time.Sleep(15 * time.Second) // let things settle down
 	}
 	ForceRotate = false
 
 	var open bool
+	var checkErr error
 	for range g.retryAttempts {
-		open, err = g.isPortOpen()
-		if err == nil {
+		open, checkErr = g.isPortOpen()
+		if checkErr == nil {
 			break
 		}
 		time.Sleep(g.retryDelay)
 	}
-	if err != nil {
+
+	syncOpen := open
+	if checkErr != nil {
 		// We couldn't determine whether the port is open (e.g. Transmission's
 		// port-test call to its external checker failed/timed out). Don't treat
 		// that as "closed" for rotation purposes, but still make sure Transmission
 		// has the latest port Gluetun is forwarding -- otherwise a persistently
 		// failing port-test would mean the port is never synced at all.
-		log.WithError(err).Warnf("Unable to check IsPortOpen(); syncing port with Gluetun anyway")
-		open = false
+		log.WithError(checkErr).Warnf("Unable to check IsPortOpen(); syncing port with Gluetun anyway")
+		syncOpen = false
 	}
 
-	if !open {
+	if !syncOpen {
+		var updateErr error
 		for range g.retryAttempts {
-			err = g.updatePort()
-			if err == nil {
+			updateErr = g.updatePort()
+			if updateErr == nil {
 				break
 			}
 			time.Sleep(g.retryDelay)
 		}
-		if err != nil {
-			log.WithError(err).Errorf("Unable to UpdatePort()")
+		if updateErr != nil {
+			log.WithError(updateErr).Errorf("Unable to UpdatePort()")
 		}
 	}
+
+	return open, checkErr
 }
 
 type VPNStatus bool

--- a/cmd/rss4transmission/gluetun_test.go
+++ b/cmd/rss4transmission/gluetun_test.go
@@ -262,7 +262,13 @@ func TestCheckVpnTunnel_PortTestErrors_StillSyncsPort(t *testing.T) {
 		retryDelay:    time.Millisecond,
 	}
 
-	g.CheckVpnTunnel()
+	open, err := g.CheckVpnTunnel()
+	if err == nil {
+		t.Errorf("CheckVpnTunnel() err = nil, want non-nil (port-test failure must be reported to the caller)")
+	}
+	if open {
+		t.Errorf("CheckVpnTunnel() open = true, want false")
+	}
 
 	if got := atomic.LoadInt64(&gotPeerPort); got != 12345 {
 		t.Errorf("transmission peer port = %d, want 12345 (port-test errors must not block syncing the known Gluetun port)", got)

--- a/cmd/rss4transmission/history_test.go
+++ b/cmd/rss4transmission/history_test.go
@@ -449,6 +449,7 @@ func TestOpenHistory_NewFile(t *testing.T) {
 	}
 	if h == nil {
 		t.Fatal("expected non-nil HistoryFile")
+		return
 	}
 	if len(h.Records) != 0 {
 		t.Errorf("expected 0 records for new file, got %d", len(h.Records))

--- a/cmd/rss4transmission/ntfy.go
+++ b/cmd/rss4transmission/ntfy.go
@@ -17,6 +17,11 @@ type NtfyConfigContext struct {
 	Error      string // empty on success
 }
 
+// NtfyPortContext holds the data available to port-closed notification templates.
+type NtfyPortContext struct {
+	Reason string
+}
+
 // NtfyTemplateContext holds all torrent data available to notification templates.
 type NtfyTemplateContext struct {
 	Title     string
@@ -70,9 +75,10 @@ func compileNotificationTemplates(title, body, priority *string, titleDefault, b
 // Validate applies template defaults and compiles notification templates. It
 // also validates that priority fields contain ntfy-accepted values.
 // Returns nil immediately when ntfy is disabled (BaseURL not set). The
-// Started/Completed (torrent) and ConfigReloaded/ConfigFailed (config-reload)
-// notification groups are independently opt-in, gated by Topic and
-// ConfigTopic respectively, so either can be enabled without the other.
+// Started/Completed (torrent) and ConfigReloaded/ConfigFailed/PortClosed/
+// PortOpened (alert) notification groups are independently opt-in, gated by
+// Topic and AlertTopic respectively, so either can be enabled without the
+// other.
 func (c *NtfyConfig) Validate() error {
 	if c.BaseURL == "" {
 		return nil
@@ -96,7 +102,7 @@ func (c *NtfyConfig) Validate() error {
 		}
 	}
 
-	if c.ConfigTopic != "" {
+	if c.AlertTopic != "" {
 		var err error
 		c.configReloadedTitleTmpl, c.configReloadedBodyTmpl, err = compileNotificationTemplates(
 			&c.ConfigReloadedTitle, &c.ConfigReloadedBody, &c.ConfigReloadedPriority,
@@ -109,6 +115,20 @@ func (c *NtfyConfig) Validate() error {
 			&c.ConfigFailedTitle, &c.ConfigFailedBody, &c.ConfigFailedPriority,
 			"Config Reload FAILED", "{{.ConfigFile}}\n{{.Error}}", "high",
 			"ConfigFailedTitle", "ConfigFailedBody", "ConfigFailedPriority")
+		if err != nil {
+			return err
+		}
+		c.portClosedTitleTmpl, c.portClosedBodyTmpl, err = compileNotificationTemplates(
+			&c.PortClosedTitle, &c.PortClosedBody, &c.PortClosedPriority,
+			"Transmission Port Closed", "{{.Reason}}", "high",
+			"PortClosedTitle", "PortClosedBody", "PortClosedPriority")
+		if err != nil {
+			return err
+		}
+		c.portOpenedTitleTmpl, c.portOpenedBodyTmpl, err = compileNotificationTemplates(
+			&c.PortOpenedTitle, &c.PortOpenedBody, &c.PortOpenedPriority,
+			"Transmission Port Open", "{{.Reason}}", "default",
+			"PortOpenedTitle", "PortOpenedBody", "PortOpenedPriority")
 		if err != nil {
 			return err
 		}
@@ -198,7 +218,7 @@ func (c *NtfyClient) SendConfigReloadSuccess(ctx *NtfyConfigContext) error {
 	if err != nil {
 		return err
 	}
-	return c.post(c.cfg.ConfigTopic, title, body, "", c.cfg.ConfigReloadedPriority)
+	return c.post(c.cfg.AlertTopic, title, body, "", c.cfg.ConfigReloadedPriority)
 }
 
 func (c *NtfyClient) SendConfigReloadFailure(ctx *NtfyConfigContext) error {
@@ -210,15 +230,39 @@ func (c *NtfyClient) SendConfigReloadFailure(ctx *NtfyConfigContext) error {
 	if err != nil {
 		return err
 	}
-	return c.post(c.cfg.ConfigTopic, title, body, "", c.cfg.ConfigFailedPriority)
+	return c.post(c.cfg.AlertTopic, title, body, "", c.cfg.ConfigFailedPriority)
+}
+
+func (c *NtfyClient) SendPortClosed(ctx *NtfyPortContext) error {
+	title, err := renderTemplate(c.cfg.portClosedTitleTmpl, ctx)
+	if err != nil {
+		return err
+	}
+	body, err := renderTemplate(c.cfg.portClosedBodyTmpl, ctx)
+	if err != nil {
+		return err
+	}
+	return c.post(c.cfg.AlertTopic, title, body, "", c.cfg.PortClosedPriority)
+}
+
+func (c *NtfyClient) SendPortOpened(ctx *NtfyPortContext) error {
+	title, err := renderTemplate(c.cfg.portOpenedTitleTmpl, ctx)
+	if err != nil {
+		return err
+	}
+	body, err := renderTemplate(c.cfg.portOpenedBodyTmpl, ctx)
+	if err != nil {
+		return err
+	}
+	return c.post(c.cfg.AlertTopic, title, body, "", c.cfg.PortOpenedPriority)
 }
 
 // notifyConfigReload sends a config-reload outcome notification to ntfy's
-// ConfigTopic. No-op when BaseURL or ConfigTopic is unset. Send failures are
+// AlertTopic. No-op when BaseURL or AlertTopic is unset. Send failures are
 // logged as warnings, never fatal — a broken notification channel must not
 // block the config-reload feature itself.
 func notifyConfigReload(cfg NtfyConfig, configFile string, reloadErr error) {
-	if cfg.BaseURL == "" || cfg.ConfigTopic == "" {
+	if cfg.BaseURL == "" || cfg.AlertTopic == "" {
 		return
 	}
 
@@ -235,5 +279,33 @@ func notifyConfigReload(cfg NtfyConfig, configFile string, reloadErr error) {
 
 	if err := client.SendConfigReloadSuccess(ntfyCtx); err != nil {
 		log.WithError(err).Warn("Failed to send ntfy config-reload-success notification")
+	}
+}
+
+// notifyPortClosed sends a port-closed alert to ntfy's AlertTopic. No-op when
+// BaseURL or AlertTopic is unset. Send failures are logged as warnings, never
+// fatal — a broken notification channel must not block port monitoring.
+func notifyPortClosed(cfg NtfyConfig, reason string) {
+	if cfg.BaseURL == "" || cfg.AlertTopic == "" {
+		return
+	}
+
+	client := NewNtfyClient(cfg)
+	if err := client.SendPortClosed(&NtfyPortContext{Reason: reason}); err != nil {
+		log.WithError(err).Warn("Failed to send ntfy port-closed notification")
+	}
+}
+
+// notifyPortOpened sends a port-reopened alert to ntfy's AlertTopic. No-op when
+// BaseURL or AlertTopic is unset. Send failures are logged as warnings, never
+// fatal — a broken notification channel must not block port monitoring.
+func notifyPortOpened(cfg NtfyConfig, reason string) {
+	if cfg.BaseURL == "" || cfg.AlertTopic == "" {
+		return
+	}
+
+	client := NewNtfyClient(cfg)
+	if err := client.SendPortOpened(&NtfyPortContext{Reason: reason}); err != nil {
+		log.WithError(err).Warn("Failed to send ntfy port-opened notification")
 	}
 }

--- a/cmd/rss4transmission/ntfy_test.go
+++ b/cmd/rss4transmission/ntfy_test.go
@@ -18,6 +18,23 @@ func mustValidateNtfyConfig(t *testing.T, cfg NtfyConfig) NtfyConfig {
 	return cfg
 }
 
+// captureNtfyRequest spins up a stub ntfy server, sends a notification via
+// send, and returns the captured request for header assertions.
+func captureNtfyRequest(t *testing.T, alertTopic string, send func(*NtfyClient) error) *http.Request {
+	t.Helper()
+	var captured *http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, AlertTopic: alertTopic})
+	require.NoError(t, send(NewNtfyClient(cfg)))
+	require.NotNil(t, captured)
+	return captured
+}
+
 func TestSendTorrentStarted_Headers(t *testing.T) {
 	var captured *http.Request
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -362,8 +379,8 @@ func TestNtfyConfig_Validate_SkipsWhenDisabled(t *testing.T) {
 
 // --- Config-reload notification: NtfyConfig.Validate() ---
 
-func TestNtfyConfig_Validate_ConfigTopicDefaults(t *testing.T) {
-	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", ConfigTopic: "cfgtopic"}
+func TestNtfyConfig_Validate_AlertTopicDefaults(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", AlertTopic: "cfgtopic"}
 	require.NoError(t, cfg.Validate())
 
 	assert.Equal(t, "Config Reloaded", cfg.ConfigReloadedTitle)
@@ -372,15 +389,25 @@ func TestNtfyConfig_Validate_ConfigTopicDefaults(t *testing.T) {
 	assert.Equal(t, "Config Reload FAILED", cfg.ConfigFailedTitle)
 	assert.Equal(t, "{{.ConfigFile}}\n{{.Error}}", cfg.ConfigFailedBody)
 	assert.Equal(t, "high", cfg.ConfigFailedPriority)
+	assert.Equal(t, "Transmission Port Closed", cfg.PortClosedTitle)
+	assert.Equal(t, "{{.Reason}}", cfg.PortClosedBody)
+	assert.Equal(t, "high", cfg.PortClosedPriority)
+	assert.Equal(t, "Transmission Port Open", cfg.PortOpenedTitle)
+	assert.Equal(t, "{{.Reason}}", cfg.PortOpenedBody)
+	assert.Equal(t, "default", cfg.PortOpenedPriority)
 
 	// Topic wasn't set, so the Started/Completed block must not have run.
 	assert.Nil(t, cfg.startedTitleTmpl)
 	assert.Nil(t, cfg.completedTitleTmpl)
 	assert.NotNil(t, cfg.configReloadedTitleTmpl)
 	assert.NotNil(t, cfg.configFailedBodyTmpl)
+	assert.NotNil(t, cfg.portClosedTitleTmpl)
+	assert.NotNil(t, cfg.portClosedBodyTmpl)
+	assert.NotNil(t, cfg.portOpenedTitleTmpl)
+	assert.NotNil(t, cfg.portOpenedBodyTmpl)
 }
 
-func TestNtfyConfig_Validate_TopicOnlyDoesNotRequireConfigTopic(t *testing.T) {
+func TestNtfyConfig_Validate_TopicOnlyDoesNotRequireAlertTopic(t *testing.T) {
 	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", Topic: "t"}
 	require.NoError(t, cfg.Validate())
 
@@ -390,7 +417,7 @@ func TestNtfyConfig_Validate_TopicOnlyDoesNotRequireConfigTopic(t *testing.T) {
 }
 
 func TestNtfyConfig_Validate_BothTopicsIndependentlyConfigurable(t *testing.T) {
-	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", Topic: "t", ConfigTopic: "cfgtopic"}
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", Topic: "t", AlertTopic: "cfgtopic"}
 	require.NoError(t, cfg.Validate())
 
 	assert.NotNil(t, cfg.startedTitleTmpl)
@@ -403,38 +430,99 @@ func TestNtfyConfig_Validate_BothTopicsIndependentlyConfigurable(t *testing.T) {
 	assert.NotNil(t, cfg.configFailedBodyTmpl)
 }
 
-func TestNtfyConfig_Validate_SkipsConfigBlockWhenConfigTopicEmpty(t *testing.T) {
+func TestNtfyConfig_Validate_SkipsConfigBlockWhenAlertTopicEmpty(t *testing.T) {
 	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", Topic: "t", ConfigReloadedTitle: "{{.Unclosed"}
-	require.NoError(t, cfg.Validate(), "invalid ConfigReloadedTitle should be ignored when ConfigTopic is unset")
+	require.NoError(t, cfg.Validate(), "invalid ConfigReloadedTitle should be ignored when AlertTopic is unset")
 }
 
 func TestNtfyConfig_Validate_InvalidConfigReloadedTemplate(t *testing.T) {
-	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", ConfigTopic: "cfgtopic", ConfigReloadedTitle: "{{.Unclosed"}
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", AlertTopic: "cfgtopic", ConfigReloadedTitle: "{{.Unclosed"}
 	err := cfg.Validate()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ConfigReloadedTitle")
 }
 
 func TestNtfyConfig_Validate_InvalidConfigFailedTemplate(t *testing.T) {
-	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", ConfigTopic: "cfgtopic", ConfigFailedBody: "{{.Unclosed"}
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", AlertTopic: "cfgtopic", ConfigFailedBody: "{{.Unclosed"}
 	err := cfg.Validate()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ConfigFailedBody")
 }
 
 func TestNtfyConfig_Validate_InvalidConfigReloadedPriority(t *testing.T) {
-	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", ConfigTopic: "cfgtopic", ConfigReloadedPriority: "urgent"}
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", AlertTopic: "cfgtopic", ConfigReloadedPriority: "urgent"}
 	require.Error(t, cfg.Validate())
 }
 
 func TestNtfyConfig_Validate_InvalidConfigFailedPriority(t *testing.T) {
-	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", ConfigTopic: "cfgtopic", ConfigFailedPriority: "urgent"}
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", AlertTopic: "cfgtopic", ConfigFailedPriority: "urgent"}
 	require.Error(t, cfg.Validate())
 }
 
-// --- Config-reload notification: NtfyClient.SendConfigReload{Success,Failure} ---
+func TestNtfyConfig_Validate_InvalidPortClosedTemplate(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", AlertTopic: "cfgtopic", PortClosedBody: "{{.Unclosed"}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "PortClosedBody")
+}
 
-func TestSendConfigReloadSuccess_Headers(t *testing.T) {
+func TestNtfyConfig_Validate_InvalidPortClosedPriority(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", AlertTopic: "cfgtopic", PortClosedPriority: "urgent"}
+	require.Error(t, cfg.Validate())
+}
+
+func TestNtfyConfig_Validate_SkipsPortClosedBlockWhenAlertTopicEmpty(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", Topic: "t", PortClosedBody: "{{.Unclosed"}
+	require.NoError(t, cfg.Validate(), "invalid PortClosedBody should be ignored when AlertTopic is unset")
+}
+
+func TestNtfyConfig_Validate_InvalidPortOpenedTemplate(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", AlertTopic: "cfgtopic", PortOpenedBody: "{{.Unclosed"}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "PortOpenedBody")
+}
+
+func TestNtfyConfig_Validate_InvalidPortOpenedPriority(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", AlertTopic: "cfgtopic", PortOpenedPriority: "urgent"}
+	require.Error(t, cfg.Validate())
+}
+
+func TestNtfyConfig_Validate_SkipsPortOpenedBlockWhenAlertTopicEmpty(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", Topic: "t", PortOpenedBody: "{{.Unclosed"}
+	require.NoError(t, cfg.Validate(), "invalid PortOpenedBody should be ignored when AlertTopic is unset")
+}
+
+// --- Port-closed notification: NtfyClient.SendPortClosed ---
+
+func TestSendPortClosed_Headers(t *testing.T) {
+	captured := captureNtfyRequest(t, "alerts", func(c *NtfyClient) error {
+		return c.SendPortClosed(&NtfyPortContext{Reason: "port closed"})
+	})
+
+	assert.Equal(t, "POST", captured.Method)
+	assert.Equal(t, "/alerts", captured.URL.Path)
+	assert.Equal(t, "Transmission Port Closed", captured.Header.Get("Title"))
+	assert.Equal(t, "high", captured.Header.Get("Priority"))
+}
+
+func TestSendPortClosed_BodyIncludesReason(t *testing.T) {
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		body, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, AlertTopic: "alerts"})
+	c := NewNtfyClient(cfg)
+	require.NoError(t, c.SendPortClosed(&NtfyPortContext{Reason: "port not open 60s after startup"}))
+	assert.Equal(t, "port not open 60s after startup", string(body))
+}
+
+func TestSendPortClosed_CustomTemplate(t *testing.T) {
 	var captured *http.Request
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		captured = r
@@ -442,10 +530,179 @@ func TestSendConfigReloadSuccess_Headers(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, ConfigTopic: "cfgtopic"})
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{
+		BaseURL:         srv.URL,
+		AlertTopic:      "alerts",
+		PortClosedTitle: "Peer port down: {{.Reason}}",
+	})
 	c := NewNtfyClient(cfg)
-	require.NoError(t, c.SendConfigReloadSuccess(&NtfyConfigContext{ConfigFile: "config.yaml"}))
+	require.NoError(t, c.SendPortClosed(&NtfyPortContext{Reason: "closed"}))
+	assert.Equal(t, "Peer port down: closed", captured.Header.Get("Title"))
+}
+
+// --- Port-reopened notification: NtfyClient.SendPortOpened ---
+
+func TestSendPortOpened_Headers(t *testing.T) {
+	captured := captureNtfyRequest(t, "alerts", func(c *NtfyClient) error {
+		return c.SendPortOpened(&NtfyPortContext{Reason: "port reopened"})
+	})
+
+	assert.Equal(t, "POST", captured.Method)
+	assert.Equal(t, "/alerts", captured.URL.Path)
+	assert.Equal(t, "Transmission Port Open", captured.Header.Get("Title"))
+	assert.Equal(t, "default", captured.Header.Get("Priority"))
+}
+
+func TestSendPortOpened_BodyIncludesReason(t *testing.T) {
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		body, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, AlertTopic: "alerts"})
+	c := NewNtfyClient(cfg)
+	require.NoError(t, c.SendPortOpened(&NtfyPortContext{Reason: "port reopened"}))
+	assert.Equal(t, "port reopened", string(body))
+}
+
+func TestSendPortOpened_CustomTemplate(t *testing.T) {
+	var captured *http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{
+		BaseURL:         srv.URL,
+		AlertTopic:      "alerts",
+		PortOpenedTitle: "Peer port back up: {{.Reason}}",
+	})
+	c := NewNtfyClient(cfg)
+	require.NoError(t, c.SendPortOpened(&NtfyPortContext{Reason: "open"}))
+	assert.Equal(t, "Peer port back up: open", captured.Header.Get("Title"))
+}
+
+// --- notifyPortOpened ---
+
+func TestNotifyPortOpened_NoopWhenAlertTopicEmpty(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	notifyPortOpened(NtfyConfig{BaseURL: srv.URL}, "port reopened")
+	assert.Equal(t, 0, requests)
+}
+
+func TestNotifyPortOpened_NoopWhenBaseURLEmpty(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	notifyPortOpened(NtfyConfig{AlertTopic: "alerts"}, "port reopened")
+	assert.Equal(t, 0, requests)
+}
+
+func TestNotifyPortOpened_Sends(t *testing.T) {
+	var captured *http.Request
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		captured = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, AlertTopic: "alerts"})
+	notifyPortOpened(cfg, "port reopened")
+	assert.Equal(t, 1, requests)
 	require.NotNil(t, captured)
+	assert.Equal(t, "Transmission Port Open", captured.Header.Get("Title"))
+}
+
+func TestNotifyPortOpened_SendFailureIsNonFatal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, AlertTopic: "alerts"})
+	assert.NotPanics(t, func() {
+		notifyPortOpened(cfg, "port reopened")
+	})
+}
+
+// --- notifyPortClosed ---
+
+func TestNotifyPortClosed_NoopWhenAlertTopicEmpty(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	notifyPortClosed(NtfyConfig{BaseURL: srv.URL}, "port closed")
+	assert.Equal(t, 0, requests)
+}
+
+func TestNotifyPortClosed_NoopWhenBaseURLEmpty(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	notifyPortClosed(NtfyConfig{AlertTopic: "alerts"}, "port closed")
+	assert.Equal(t, 0, requests)
+}
+
+func TestNotifyPortClosed_Sends(t *testing.T) {
+	var captured *http.Request
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		captured = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, AlertTopic: "alerts"})
+	notifyPortClosed(cfg, "port not open 60s after startup")
+	assert.Equal(t, 1, requests)
+	require.NotNil(t, captured)
+	assert.Equal(t, "Transmission Port Closed", captured.Header.Get("Title"))
+}
+
+func TestNotifyPortClosed_SendFailureIsNonFatal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, AlertTopic: "alerts"})
+	assert.NotPanics(t, func() {
+		notifyPortClosed(cfg, "port closed")
+	})
+}
+
+// --- Config-reload notification: NtfyClient.SendConfigReload{Success,Failure} ---
+
+func TestSendConfigReloadSuccess_Headers(t *testing.T) {
+	captured := captureNtfyRequest(t, "cfgtopic", func(c *NtfyClient) error {
+		return c.SendConfigReloadSuccess(&NtfyConfigContext{ConfigFile: "config.yaml"})
+	})
 
 	assert.Equal(t, "POST", captured.Method)
 	assert.Equal(t, "/cfgtopic", captured.URL.Path)
@@ -463,7 +720,7 @@ func TestSendConfigReloadSuccess_Body(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, ConfigTopic: "cfgtopic"})
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, AlertTopic: "cfgtopic"})
 	c := NewNtfyClient(cfg)
 	require.NoError(t, c.SendConfigReloadSuccess(&NtfyConfigContext{ConfigFile: "/etc/rss4transmission/config.yaml"}))
 	assert.Equal(t, "/etc/rss4transmission/config.yaml", string(body))
@@ -477,7 +734,7 @@ func TestSendConfigReloadFailure_Headers(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, ConfigTopic: "cfgtopic"})
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, AlertTopic: "cfgtopic"})
 	c := NewNtfyClient(cfg)
 	require.NoError(t, c.SendConfigReloadFailure(&NtfyConfigContext{ConfigFile: "config.yaml", Error: "boom"}))
 	require.NotNil(t, captured)
@@ -497,7 +754,7 @@ func TestSendConfigReloadFailure_BodyIncludesError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, ConfigTopic: "cfgtopic"})
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, AlertTopic: "cfgtopic"})
 	c := NewNtfyClient(cfg)
 	wantErr := "yaml: line 4: did not find expected key"
 	require.NoError(t, c.SendConfigReloadFailure(&NtfyConfigContext{ConfigFile: "config.yaml", Error: wantErr}))
@@ -514,7 +771,7 @@ func TestSendConfigReloadSuccess_CustomTitleTemplate(t *testing.T) {
 
 	cfg := mustValidateNtfyConfig(t, NtfyConfig{
 		BaseURL:             srv.URL,
-		ConfigTopic:         "cfgtopic",
+		AlertTopic:          "cfgtopic",
 		ConfigReloadedTitle: "Reloaded: {{.ConfigFile}}",
 	})
 	c := NewNtfyClient(cfg)
@@ -534,7 +791,7 @@ func TestSendConfigReloadFailure_CustomBodyTemplate(t *testing.T) {
 
 	cfg := mustValidateNtfyConfig(t, NtfyConfig{
 		BaseURL:          srv.URL,
-		ConfigTopic:      "cfgtopic",
+		AlertTopic:       "cfgtopic",
 		ConfigFailedBody: "FAILED {{.ConfigFile}}: {{.Error}}",
 	})
 	c := NewNtfyClient(cfg)
@@ -542,7 +799,7 @@ func TestSendConfigReloadFailure_CustomBodyTemplate(t *testing.T) {
 	assert.Equal(t, "FAILED config.yaml: boom", string(body))
 }
 
-func TestSendConfigReload_UsesConfigTopicNotTopic(t *testing.T) {
+func TestSendConfigReload_UsesAlertTopicNotTopic(t *testing.T) {
 	var captured *http.Request
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		captured = r
@@ -550,7 +807,7 @@ func TestSendConfigReload_UsesConfigTopicNotTopic(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, Topic: "torrents", ConfigTopic: "configevents"})
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, Topic: "torrents", AlertTopic: "configevents"})
 	c := NewNtfyClient(cfg)
 	require.NoError(t, c.SendConfigReloadSuccess(&NtfyConfigContext{ConfigFile: "config.yaml"}))
 	require.NotNil(t, captured)
@@ -559,7 +816,7 @@ func TestSendConfigReload_UsesConfigTopicNotTopic(t *testing.T) {
 
 // --- notifyConfigReload ---
 
-func TestNotifyConfigReload_NoopWhenConfigTopicEmpty(t *testing.T) {
+func TestNotifyConfigReload_NoopWhenAlertTopicEmpty(t *testing.T) {
 	requests := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
@@ -579,7 +836,7 @@ func TestNotifyConfigReload_NoopWhenBaseURLEmpty(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	notifyConfigReload(NtfyConfig{ConfigTopic: "cfgtopic"}, "config.yaml", nil)
+	notifyConfigReload(NtfyConfig{AlertTopic: "cfgtopic"}, "config.yaml", nil)
 	assert.Equal(t, 0, requests)
 }
 
@@ -593,7 +850,7 @@ func TestNotifyConfigReload_SendsSuccessOnNilError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, ConfigTopic: "cfgtopic"})
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, AlertTopic: "cfgtopic"})
 	notifyConfigReload(cfg, "config.yaml", nil)
 	assert.Equal(t, 1, requests)
 	require.NotNil(t, captured)
@@ -612,7 +869,7 @@ func TestNotifyConfigReload_SendsFailureWithErrorTextOnNonNilError(t *testing.T)
 	}))
 	defer srv.Close()
 
-	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, ConfigTopic: "cfgtopic"})
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, AlertTopic: "cfgtopic"})
 	notifyConfigReload(cfg, "config.yaml",
 		fmt.Errorf("yaml: line 4: did not find expected key"))
 	assert.Equal(t, 1, requests)
@@ -629,7 +886,7 @@ func TestNotifyConfigReload_SendFailureIsNonFatal(t *testing.T) {
 		slow.Close()
 	}()
 
-	cfg := NtfyConfig{BaseURL: slow.URL, ConfigTopic: "cfgtopic"}
+	cfg := NtfyConfig{BaseURL: slow.URL, AlertTopic: "cfgtopic"}
 	require.NoError(t, cfg.Validate())
 
 	done := make(chan struct{})

--- a/cmd/rss4transmission/portcheck.go
+++ b/cmd/rss4transmission/portcheck.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/hekmon/transmissionrpc/v3"
+)
+
+const (
+	portCheckInterval     = 5 * time.Minute
+	portCheckStartupGrace = 60 * time.Second
+)
+
+// PortMonitor periodically checks whether Transmission's peer port is
+// reachable, logging every check and sending ntfy alerts on open<->closed
+// transitions and on a still-closed port 60s after startup. When Gluetun is
+// configured, the check is delegated to Gluetun.CheckVpnTunnel() so rotation
+// and peer-port sync keep happening exactly as before; otherwise it calls
+// Transmission.PortTest() directly.
+type PortMonitor struct {
+	Transmission *transmissionrpc.Client
+	Gluetun      *Gluetun // nil when Gluetun isn't configured
+	Ntfy         NtfyConfig
+
+	mu       sync.Mutex // serializes check() (incl. Gluetun struct access) and lastOpen
+	lastOpen *bool      // nil until the first check
+}
+
+func NewPortMonitor(t *transmissionrpc.Client, g *Gluetun, ntfyCfg NtfyConfig) *PortMonitor {
+	return &PortMonitor{
+		Transmission: t,
+		Gluetun:      g,
+		Ntfy:         ntfyCfg,
+	}
+}
+
+// Run blocks forever, checking the port every portCheckInterval and once
+// more, separately, after portCheckStartupGrace. Call it in its own
+// goroutine.
+func (m *PortMonitor) Run() {
+	time.AfterFunc(portCheckStartupGrace, m.checkStartup)
+
+	ticker := time.NewTicker(portCheckInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		if _, err := m.check(); err != nil {
+			log.WithError(err).Warn("Unable to check Transmission port state")
+		}
+	}
+}
+
+// checkStartup runs the first-ever check and, if the port is still closed,
+// sends the startup-specific ntfy alert (separate from the transition alert,
+// since lastOpen starts nil and can't itself trigger a transition).
+func (m *PortMonitor) checkStartup() {
+	open, err := m.check()
+	if err != nil {
+		log.WithError(err).Warn("Unable to check Transmission port state")
+		return
+	}
+	if !open {
+		notifyPortClosed(m.Ntfy, "port not open 60s after startup")
+	}
+}
+
+// check performs a single port-open check, logs the result, and fires a
+// transition notification when the state changed since the previous check.
+// It holds m.mu for its entire body: Gluetun.CheckVpnTunnel mutates
+// unexported Gluetun fields with no locking of its own, and time.AfterFunc's
+// callback runs in its own goroutine, so the startup check and the ticker
+// loop's periodic checks could otherwise overlap.
+func (m *PortMonitor) check() (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var open bool
+	var err error
+	if m.Gluetun != nil {
+		open, err = m.Gluetun.CheckVpnTunnel()
+	} else {
+		open, err = m.Transmission.PortTest(context.TODO())
+	}
+	if err != nil {
+		return false, err
+	}
+
+	if open {
+		log.Debug("Transmission peer port is open")
+	} else {
+		log.Warn("Transmission peer port is closed")
+	}
+
+	if m.lastOpen != nil {
+		if *m.lastOpen && !open {
+			notifyPortClosed(m.Ntfy, "port closed")
+		} else if !*m.lastOpen && open {
+			notifyPortOpened(m.Ntfy, "port reopened")
+		}
+	}
+	m.lastOpen = &open
+
+	return open, nil
+}

--- a/cmd/rss4transmission/portcheck_test.go
+++ b/cmd/rss4transmission/portcheck_test.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/hekmon/transmissionrpc/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// portTestTransmissionServer simulates Transmission's "port-test" and
+// "session-set" RPC methods. open controls the reported port-is-open value;
+// swap it (via a pointer) between check() calls to simulate a transition.
+func portTestTransmissionServer(t *testing.T, open *bool) *httptest.Server {
+	t.Helper()
+	const sessionID = "test-session-id"
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Transmission-Session-Id") != sessionID {
+			w.Header().Set("X-Transmission-Session-Id", sessionID)
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+		var req struct {
+			Method string `json:"method"`
+			Tag    int    `json:"tag"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+
+		resp := map[string]any{"tag": req.Tag}
+		switch req.Method {
+		case "port-test":
+			resp["result"] = "success"
+			resp["arguments"] = map[string]any{"port-is-open": *open}
+		case "session-set":
+			resp["result"] = "success"
+		default:
+			t.Fatalf("unexpected method: %s", req.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
+	}))
+}
+
+func newTestTransmissionClient(t *testing.T, srvURL string) *transmissionrpc.Client {
+	t.Helper()
+	endpoint, err := url.Parse(srvURL)
+	require.NoError(t, err)
+	client, err := transmissionrpc.New(endpoint, nil)
+	require.NoError(t, err)
+	return client
+}
+
+func newTestNtfyServer(t *testing.T) (*httptest.Server, *[]string) {
+	t.Helper()
+	var titles []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		titles = append(titles, r.Header.Get("Title"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	return srv, &titles
+}
+
+func TestPortMonitor_Check_NoGluetun_Open(t *testing.T) {
+	open := true
+	transmissionSrv := portTestTransmissionServer(t, &open)
+	defer transmissionSrv.Close()
+	ntfySrv, titles := newTestNtfyServer(t)
+	defer ntfySrv.Close()
+
+	m := NewPortMonitor(newTestTransmissionClient(t, transmissionSrv.URL), nil,
+		mustValidateNtfyConfig(t, NtfyConfig{BaseURL: ntfySrv.URL, AlertTopic: "alerts"}))
+
+	gotOpen, err := m.check()
+	require.NoError(t, err)
+	assert.True(t, gotOpen)
+	assert.Empty(t, *titles, "no notification expected on first-ever check")
+	require.NotNil(t, m.lastOpen)
+	assert.True(t, *m.lastOpen)
+}
+
+func TestPortMonitor_Check_NoGluetun_Closed(t *testing.T) {
+	open := false
+	transmissionSrv := portTestTransmissionServer(t, &open)
+	defer transmissionSrv.Close()
+	ntfySrv, titles := newTestNtfyServer(t)
+	defer ntfySrv.Close()
+
+	m := NewPortMonitor(newTestTransmissionClient(t, transmissionSrv.URL), nil,
+		mustValidateNtfyConfig(t, NtfyConfig{BaseURL: ntfySrv.URL, AlertTopic: "alerts"}))
+
+	gotOpen, err := m.check()
+	require.NoError(t, err)
+	assert.False(t, gotOpen)
+	assert.Empty(t, *titles, "no notification expected without a prior 'open' state")
+	require.NotNil(t, m.lastOpen)
+	assert.False(t, *m.lastOpen)
+}
+
+func TestPortMonitor_Check_OpenToClosed_NotifiesOnce(t *testing.T) {
+	open := true
+	transmissionSrv := portTestTransmissionServer(t, &open)
+	defer transmissionSrv.Close()
+	ntfySrv, titles := newTestNtfyServer(t)
+	defer ntfySrv.Close()
+
+	m := NewPortMonitor(newTestTransmissionClient(t, transmissionSrv.URL), nil,
+		mustValidateNtfyConfig(t, NtfyConfig{BaseURL: ntfySrv.URL, AlertTopic: "alerts"}))
+
+	_, err := m.check()
+	require.NoError(t, err)
+	assert.Empty(t, *titles)
+
+	open = false
+	_, err = m.check()
+	require.NoError(t, err)
+	require.Len(t, *titles, 1)
+	assert.Equal(t, "Transmission Port Closed", (*titles)[0])
+
+	// Closed -> closed again must not re-notify.
+	_, err = m.check()
+	require.NoError(t, err)
+	assert.Len(t, *titles, 1)
+}
+
+func TestPortMonitor_Check_ClosedToOpen_NotifiesOnce(t *testing.T) {
+	open := false
+	transmissionSrv := portTestTransmissionServer(t, &open)
+	defer transmissionSrv.Close()
+	ntfySrv, titles := newTestNtfyServer(t)
+	defer ntfySrv.Close()
+
+	m := NewPortMonitor(newTestTransmissionClient(t, transmissionSrv.URL), nil,
+		mustValidateNtfyConfig(t, NtfyConfig{BaseURL: ntfySrv.URL, AlertTopic: "alerts"}))
+
+	_, err := m.check()
+	require.NoError(t, err)
+	assert.Empty(t, *titles, "no prior state, so closed on first check must not notify")
+
+	open = true
+	_, err = m.check()
+	require.NoError(t, err)
+	require.Len(t, *titles, 1)
+	assert.Equal(t, "Transmission Port Open", (*titles)[0])
+
+	// Open -> open again must not re-notify.
+	_, err = m.check()
+	require.NoError(t, err)
+	assert.Len(t, *titles, 1)
+}
+
+func TestPortMonitor_Check_PortTestError_LeavesStateUnchangedAndDoesNotNotify(t *testing.T) {
+	open := true
+	transmissionSrv := portTestFailingTransmissionServer(t, new(int64))
+	defer transmissionSrv.Close()
+	ntfySrv, titles := newTestNtfyServer(t)
+	defer ntfySrv.Close()
+
+	m := NewPortMonitor(newTestTransmissionClient(t, transmissionSrv.URL), nil,
+		mustValidateNtfyConfig(t, NtfyConfig{BaseURL: ntfySrv.URL, AlertTopic: "alerts"}))
+	// Seed a known "open" state directly (bypassing the failing server), then
+	// verify a port-test error neither flips lastOpen nor notifies.
+	trueVal := true
+	m.lastOpen = &trueVal
+
+	_, err := m.check()
+	require.Error(t, err)
+	assert.Empty(t, *titles)
+	require.NotNil(t, m.lastOpen)
+	assert.True(t, *m.lastOpen, "lastOpen must be left unchanged on a port-test error")
+
+	// A later real transition must still be correctly detected as open->closed.
+	realSrv := portTestTransmissionServer(t, &open)
+	defer realSrv.Close()
+	m.Transmission = newTestTransmissionClient(t, realSrv.URL)
+	open = false
+	_, err = m.check()
+	require.NoError(t, err)
+	require.Len(t, *titles, 1)
+	assert.Equal(t, "Transmission Port Closed", (*titles)[0])
+}
+
+func TestPortMonitor_Check_WithGluetun_UsesCheckVpnTunnel(t *testing.T) {
+	open := true
+	transmissionSrv := portTestTransmissionServer(t, &open)
+	defer transmissionSrv.Close()
+	ntfySrv, titles := newTestNtfyServer(t)
+	defer ntfySrv.Close()
+
+	gluetunSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ports":[54321]}`))
+	}))
+	defer gluetunSrv.Close()
+
+	client := newTestTransmissionClient(t, transmissionSrv.URL)
+	g := &Gluetun{
+		URL:           gluetunSrv.URL,
+		Transmission:  client,
+		lastRotate:    time.Now(),
+		peerPort:      -1,
+		retryAttempts: 1,
+		retryDelay:    time.Millisecond,
+	}
+
+	m := NewPortMonitor(client, g, mustValidateNtfyConfig(t, NtfyConfig{BaseURL: ntfySrv.URL, AlertTopic: "alerts"}))
+
+	gotOpen, err := m.check()
+	require.NoError(t, err)
+	assert.True(t, gotOpen)
+	assert.Empty(t, *titles)
+
+	open = false
+	gotOpen, err = m.check()
+	require.NoError(t, err)
+	assert.False(t, gotOpen)
+	require.Len(t, *titles, 1)
+	assert.Equal(t, "Transmission Port Closed", (*titles)[0])
+	// Gluetun's port-sync side effect (session-set on a closed port) should
+	// still have run through CheckVpnTunnel().
+	assert.Equal(t, int64(54321), g.peerPort)
+}
+
+func TestPortMonitor_CheckStartup_StillClosed_Notifies(t *testing.T) {
+	open := false
+	transmissionSrv := portTestTransmissionServer(t, &open)
+	defer transmissionSrv.Close()
+	ntfySrv, titles := newTestNtfyServer(t)
+	defer ntfySrv.Close()
+
+	m := NewPortMonitor(newTestTransmissionClient(t, transmissionSrv.URL), nil,
+		mustValidateNtfyConfig(t, NtfyConfig{BaseURL: ntfySrv.URL, AlertTopic: "alerts"}))
+
+	m.checkStartup()
+	require.Len(t, *titles, 1)
+	assert.Equal(t, "Transmission Port Closed", (*titles)[0])
+}
+
+func TestPortMonitor_CheckStartup_Open_DoesNotNotify(t *testing.T) {
+	open := true
+	transmissionSrv := portTestTransmissionServer(t, &open)
+	defer transmissionSrv.Close()
+	ntfySrv, titles := newTestNtfyServer(t)
+	defer ntfySrv.Close()
+
+	m := NewPortMonitor(newTestTransmissionClient(t, transmissionSrv.URL), nil,
+		mustValidateNtfyConfig(t, NtfyConfig{BaseURL: ntfySrv.URL, AlertTopic: "alerts"}))
+
+	m.checkStartup()
+	assert.Empty(t, *titles)
+}

--- a/cmd/rss4transmission/watch.go
+++ b/cmd/rss4transmission/watch.go
@@ -258,6 +258,9 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 	if ctx.Config.Gluetun.Host != "" && ctx.Config.Gluetun.Port != 0 {
 		g = NewGluetun(ctx.Config.Gluetun, ctx.Transmission)
 	}
+	if g != nil || ctx.Config.PortCheck.Enabled {
+		go NewPortMonitor(ctx.Transmission, g, ctx.Config.Ntfy).Run()
+	}
 
 	// Run once and then sleep between later runs...
 	for ; true; <-ticker.C {
@@ -266,9 +269,6 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 			return err
 		}
 		reloader.mu.Unlock()
-		if g != nil {
-			g.CheckVpnTunnel()
-		}
 	}
 	return nil
 }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -173,6 +173,13 @@ When using Gluetun, add a `Gluetun` block to enable automatic VPN rotation and p
 forwarding. rss4transmission will restart the VPN when the peer port closes or after
 `RotateTime` elapses, then update Transmission with the new peer port.
 
+This check runs on its own fixed 5-minute cadence, independent of `--sleep` (the feed-scrape
+interval). Previously it ran once per feed-scrape iteration, so `RotateTime` and
+`ClosedPortChecks` were silently throttled by whatever `--sleep` value was configured; that
+coupling is now removed. For the default `--sleep 300` this is a no-op, but if you run a
+non-default `--sleep`, rotation/port-sync timing will now follow the 5-minute cadence instead.
+See [Port Notifications](notifications.md#port-notifications) for the accompanying ntfy alerts.
+
 ```yaml
 # When using Gluetun, Docker service networking changes the hostname
 Transmission:

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-RSS4Transmission supports three kinds of push notifications via [ntfy](https://ntfy.sh):
+RSS4Transmission supports four kinds of push notifications via [ntfy](https://ntfy.sh):
 
 - **Torrent started** — sent by rss4transmission immediately after submitting a torrent to
   Transmission. Includes a **More Info** action button that opens a browser confirmation
@@ -12,9 +12,10 @@ RSS4Transmission supports three kinds of push notifications via [ntfy](https://n
   `bin/torrent-complete.sh` running as Transmission's "torrent done" hook. The endpoint renders
   your configured templates and sends the notification to ntfy.
 - **Config reloaded** — sent by `watch` whenever it picks up a change to the config file, to its
-  own `Ntfy.ConfigTopic` (separate from the torrent notifications' `Ntfy.Topic`). Reports whether
+  own `Ntfy.AlertTopic` (separate from the torrent notifications' `Ntfy.Topic`). Reports whether
   the reload succeeded or failed; on failure, the notification body includes the actual error
   (e.g. a YAML parse error), so a bad edit is visible immediately without tailing logs.
+- **Port closed / reopened** — see [Port Notifications](#port-notifications) below.
 
 ## ntfy and Cancel Configuration
 
@@ -22,15 +23,20 @@ Add `Ntfy` and `Cancel` blocks to your config file:
 
 ```yaml
 Ntfy:
-  BaseURL:     https://ntfy.sh              # your ntfy server
-  Topic:       <your-topic-name>            # ntfy topic to publish to (torrent notifications)
-  ConfigTopic: <your-config-topic-name>     # ntfy topic to publish to (config-reload notifications)
-  Token:       tk_<your-access-token>       # ntfy access token
+  BaseURL:    https://ntfy.sh              # your ntfy server
+  Topic:      <your-topic-name>            # ntfy topic to publish to (torrent notifications)
+  AlertTopic: <your-alert-topic-name>      # ntfy topic to publish to (config-reload / port alerts)
+  Token:      tk_<your-access-token>       # ntfy access token
 
 Cancel:
   HMACSecret: <random-32-byte-hex>                   # generate: openssl rand -hex 32
   BaseURL:    https://rss4transmission.yourdomain.com # externally reachable URL
   TokenTTLH:  24                                     # cancel link TTL in hours (default: 24)
+
+# Only needed to enable the port-open check/alerts when Gluetun is NOT configured
+# (with Gluetun configured, the check runs automatically). See Port Notifications below.
+PortCheck:
+  Enabled: true
 ```
 
 | Field | Default | Description |
@@ -44,13 +50,20 @@ Cancel:
 | `Ntfy.CompletedTitle` | `"Torrent Complete"` | `text/template` string for the completed notification title |
 | `Ntfy.CompletedBody` | `"{{.Title}}\n{{.Dir}}"` | `text/template` string for the completed notification body |
 | `Ntfy.CompletedPriority` | `default` | ntfy priority for completed notifications |
-| `Ntfy.ConfigTopic` | — | ntfy topic to publish config-reload notifications to |
+| `Ntfy.AlertTopic` | — | ntfy topic to publish config-reload and port-state notifications to |
 | `Ntfy.ConfigReloadedTitle` | `"Config Reloaded"` | `text/template` string for the reload-success notification title |
 | `Ntfy.ConfigReloadedBody` | `"{{.ConfigFile}}"` | `text/template` string for the reload-success notification body |
 | `Ntfy.ConfigReloadedPriority` | `low` | ntfy priority for reload-success notifications |
 | `Ntfy.ConfigFailedTitle` | `"Config Reload FAILED"` | `text/template` string for the reload-failure notification title |
 | `Ntfy.ConfigFailedBody` | `"{{.ConfigFile}}\n{{.Error}}"` | `text/template` string for the reload-failure notification body |
 | `Ntfy.ConfigFailedPriority` | `high` | ntfy priority for reload-failure notifications |
+| `Ntfy.PortClosedTitle` | `"Transmission Port Closed"` | `text/template` string for the port-closed notification title |
+| `Ntfy.PortClosedBody` | `"{{.Reason}}"` | `text/template` string for the port-closed notification body |
+| `Ntfy.PortClosedPriority` | `high` | ntfy priority for port-closed notifications |
+| `Ntfy.PortOpenedTitle` | `"Transmission Port Open"` | `text/template` string for the port-reopened notification title |
+| `Ntfy.PortOpenedBody` | `"{{.Reason}}"` | `text/template` string for the port-reopened notification body |
+| `Ntfy.PortOpenedPriority` | `default` | ntfy priority for port-reopened notifications |
+| `PortCheck.Enabled` | `false` | Enables the periodic port-open check when Gluetun is **not** configured (see [Port Notifications](#port-notifications)) |
 | `Cancel.HMACSecret` | — | Secret key for signing cancel URLs (HMAC-SHA256) |
 | `Cancel.BaseURL` | — | Public base URL of rss4transmission (used in cancel links) |
 | `Cancel.TokenTTLH` | `24` | Hours before a cancel link expires |
@@ -58,9 +71,13 @@ Cancel:
 Cancel links are omitted from notifications when `Cancel.HMACSecret` or `Cancel.BaseURL` is not
 configured — the torrent started notification is still sent, just without the cancel action.
 Ntfy notifications are entirely disabled when `Ntfy.BaseURL` is not set. `Ntfy.Topic` and
-`Ntfy.ConfigTopic` gate their respective notification groups independently: torrent
-started/completed notifications require `Topic`, config-reload notifications require
-`ConfigTopic`, and either can be configured without the other.
+`Ntfy.AlertTopic` gate their respective notification groups independently: torrent
+started/completed notifications require `Topic`, config-reload and port-state notifications
+require `AlertTopic`, and either can be configured without the other.
+
+> **Breaking rename:** `Ntfy.ConfigTopic` was renamed to `Ntfy.AlertTopic`. If your config sets
+> `ConfigTopic`, rename it to `AlertTopic` — it now gates both config-reload and port-state
+> notifications together.
 
 ## Notification Templates
 
@@ -144,6 +161,32 @@ Ntfy:
     Failed to reload {{.ConfigFile}}:
     {{.Error}}
 ```
+
+## Port Notifications
+
+`watch` periodically checks whether Transmission's peer port is reachable, on a fixed 5-minute
+interval (not configurable). Every check is logged — `debug` when open, `warn` when closed. Two
+ntfy alerts can fire, both to `Ntfy.AlertTopic`:
+
+- **Transition alerts** — sent the moment the port's state changes: open → closed sends
+  `PortClosedTitle`/`PortClosedBody`, closed → open sends `PortOpenedTitle`/`PortOpenedBody`.
+- **Startup alert** — if the port is still closed 60 seconds (fixed, not configurable) after
+  `watch` starts, `PortClosedTitle`/`PortClosedBody` is sent once, independent of the transition
+  alert above.
+
+The check runs automatically whenever `Gluetun.Host`/`Gluetun.Port` are configured — it's the
+same check Gluetun already performs for VPN rotation and peer-port sync, now also logged and
+alerted on. Without Gluetun, set `PortCheck.Enabled: true` to opt in to the periodic check on
+its own (no rotation/sync, just the open/closed poll, logging, and alerts).
+
+### Port Notification Context
+
+The `PortClosedTitle`, `PortClosedBody`, `PortOpenedTitle`, and `PortOpenedBody` fields also
+accept `text/template` strings, with their own small context:
+
+| Field | Type | Description |
+|---|---|---|
+| `{{.Reason}}` | `string` | Why the alert fired, e.g. `"port closed"`, `"port reopened"`, or `"port not open 60s after startup"` |
 
 ## Cancel Endpoint
 


### PR DESCRIPTION
## Summary

- Adds a `PortMonitor` that checks Transmission's peer port every 5 minutes (fixed interval).
  Logs every check (`debug` when open, `warn` when closed) and sends ntfy alerts on
  open→closed **and** closed→open transitions, plus a one-time alert if the port is still
  closed 60s after `watch` starts.
- Merges with Gluetun instead of polling separately: when `Gluetun.Host`/`Port` are
  configured, the monitor delegates to `Gluetun.CheckVpnTunnel()` (rotation/peer-port sync
  unchanged); otherwise it calls `Transmission.PortTest()` directly. Either way there's a
  single RPC call and a single state tracker per tick.
- **Breaking config rename**: `Ntfy.ConfigTopic` → `Ntfy.AlertTopic`, which now gates both
  config-reload and port-state notifications together.
- New `PortCheck.Enabled` config flag opts non-Gluetun setups into the periodic check; with
  Gluetun configured the monitor runs automatically (no config change needed).
- **Behavior change**: Gluetun's port-check/rotate/sync now runs on its own fixed 5-minute
  cadence, decoupled from `--sleep` (previously tied to the feed-scrape interval).

## Test plan

- [x] `make test` — full suite passes, including new `portcheck_test.go` coverage (no-Gluetun
      and with-Gluetun paths, both transition directions, startup grace, port-test error
      handling) and updated `ntfy_test.go`/`gluetun_test.go`/`config_test.go` coverage.
- [x] `make lint` — clean (two pre-existing, unrelated `history_test.go` staticcheck findings
      from an earlier commit remain, not touched by this change).
- [x] `make` — builds cleanly.
- [x] Manual smoke test against a real Transmission/Gluetun instance (not performed in this
      session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)