### PR TITLE
Collapse duplicate history rows for multi-feed-subscription items

### DIFF
--- a/cmd/rss4transmission/config.go
+++ b/cmd/rss4transmission/config.go
@@ -119,15 +119,16 @@ type GluetunConfig struct {
 }
 
 type Feed struct {
-	Name           string   `koanf:"Name"`
-	URL            string   `koanf:"URL"`
-	Exclude        []string `koanf:"Exclude"`
-	DownloadPath   string   `koanf:"DownloadPath"`
-	NoValidateCert bool     `koanf:"NoValidateCert"`
-	NoSubmit       bool     `koanf:"NoSubmit"`
-	NoNotify       bool     `koanf:"NoNotify"`
-	MaxSize        string   `koanf:"MaxSize"`
-	MinSize        string   `koanf:"MinSize"`
+	Name            string   `koanf:"Name"`
+	URL             string   `koanf:"URL"`
+	Exclude         []string `koanf:"Exclude"`
+	DownloadPath    string   `koanf:"DownloadPath"`
+	NoValidateCert  bool     `koanf:"NoValidateCert"`
+	NoSubmit        bool     `koanf:"NoSubmit"`
+	NoNotify        bool     `koanf:"NoNotify"`
+	MaxSize         string   `koanf:"MaxSize"`
+	MinSize         string   `koanf:"MinSize"`
+	HistoryPriority int      `koanf:"HistoryPriority"`
 
 	// Label-mode fields
 	Extractor string            `koanf:"Extractor"`

--- a/cmd/rss4transmission/config_test.go
+++ b/cmd/rss4transmission/config_test.go
@@ -204,6 +204,47 @@ Feeds:
 	}
 }
 
+func TestLoadConfig_FeedHistoryPriority(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	yamlContent := validExtractorYAML + `
+Feeds:
+  - Name: MotoGP
+    URL: https://example.com/motogp
+    Extractor: demo
+    Identity: [series]
+    HistoryPriority: -1
+    Groups:
+      - Require:
+          series: [X]
+  - Name: Moto2
+    URL: https://example.com/moto2
+    Extractor: demo
+    Identity: [series]
+    Groups:
+      - Require:
+          series: [X]
+`
+	if err := os.WriteFile(cfgPath, []byte(yamlContent), 0600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	rc := &RunContext{}
+	if _, err := rc.loadConfig(cfgPath); err != nil {
+		t.Fatalf("loadConfig failed: %v", err)
+	}
+
+	if len(rc.Config.Feeds) != 2 {
+		t.Fatalf("expected 2 feeds, got %d", len(rc.Config.Feeds))
+	}
+	if rc.Config.Feeds[0].HistoryPriority != -1 {
+		t.Errorf("explicit HistoryPriority = %d, want -1", rc.Config.Feeds[0].HistoryPriority)
+	}
+	if rc.Config.Feeds[1].HistoryPriority != 0 {
+		t.Errorf("unset HistoryPriority = %d, want default 0", rc.Config.Feeds[1].HistoryPriority)
+	}
+}
+
 func TestLoadConfig_PortCheckEnabledDefaultsFalse(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")

--- a/cmd/rss4transmission/once.go
+++ b/cmd/rss4transmission/once.go
@@ -493,6 +493,12 @@ func ensureTorrentBytes(item *FeedItem, cacheDir string, existing []byte) ([]byt
 // keys. Referenced in markCacheRejectedSeen to avoid string duplication.
 const skipReasonCacheBetter = "better version already in cache"
 
+// skipReasonNoGroupMatched is the reason string used when a candidate's labels
+// never matched any of the feed's Groups — i.e. this feed config never applied
+// to the item at all. Also referenced by groupHistoryRows in web.go, which
+// treats it as the least informative skip reason among siblings in a group.
+const skipReasonNoGroupMatched = "no group matched labels"
+
 // markCacheRejectedSeen adds the GUID of each cache-rejected candidate to the
 // seen cache. On the next run, Exists() catches these GUIDs in Phase 1, before
 // the torrent disk read, eliminating redundant I/O for items that will never
@@ -545,7 +551,7 @@ func selectWinners(candidates []*candidate, feedCfg Feed, cache *CacheFile) ([]*
 	skipReasons := map[*candidate]string{}
 	for _, c := range candidates {
 		if !matchedCands[c] {
-			skipReasons[c] = "no group matched labels"
+			skipReasons[c] = skipReasonNoGroupMatched
 		} else if !inBest[c] {
 			skipReasons[c] = "outranked by better candidate in this run"
 		}
@@ -582,7 +588,7 @@ func selectWinners(candidates []*candidate, feedCfg Feed, cache *CacheFile) ([]*
 		}
 	}
 	for c, reason := range skipReasons {
-		if reason != "no group matched labels" {
+		if reason != skipReasonNoGroupMatched {
 			continue
 		}
 		if key, ok := titleOnlyKey(c); ok {

--- a/cmd/rss4transmission/watch.go
+++ b/cmd/rss4transmission/watch.go
@@ -209,6 +209,18 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 		return ok
 	}
 
+	// feedPriority mirrors feedConfigured's live-config lookup, reporting a
+	// feed's HistoryPriority so groupHistoryRows can break primary-row ties.
+	feedPriority := func(name string) int {
+		reloader.mu.Lock()
+		defer reloader.mu.Unlock()
+		f, ok := findFeedByName(ctx.Config.Feeds, name)
+		if !ok {
+			return 0
+		}
+		return f.HistoryPriority
+	}
+
 	accessLog := openAccessLog(cmd.AccessLog)
 
 	if cmd.PublicListen != "" {
@@ -234,7 +246,7 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 			if ctx.History == nil {
 				log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
 			}
-			go startWebServer("private", newWebMux(ctx.History, retryHistory, feedConfigured), histAddr)
+			go startWebServer("private", newWebMux(ctx.History, retryHistory, feedConfigured, feedPriority), histAddr)
 		}
 	} else if cmd.PrivateListen != "" {
 		// Single-listener mode: history + cancel on the same port.
@@ -245,7 +257,7 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 		if ctx.History == nil {
 			log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
 		}
-		mux := newWebMux(ctx.History, retryHistory, feedConfigured)
+		mux := newWebMux(ctx.History, retryHistory, feedConfigured, feedPriority)
 		if ctx.CancelStore != nil {
 			registerCancelRoutes(mux, ctx.CancelStore, ctx.Config.Cancel, removeT, getProgress, accessLog)
 			ctx.CancelRoutesEnabled = true

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -29,6 +29,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -142,6 +143,73 @@ func parseListenAddr(s string) (string, error) {
 	return fmt.Sprintf("127.0.0.1:%d", p), nil
 }
 
+// historyRow decorates a HistoryRecord with grouping metadata for template
+// rendering: rows sharing a GUID (the same RSS item seen by multiple feed
+// configs that share an RSS URL) are grouped into one expandable entry so a
+// torrent that only matches one of several sibling feeds doesn't produce a
+// wall of "no group matched labels" rows.
+type historyRow struct {
+	HistoryRecord
+	IsPrimary bool
+	GroupSize int // total records sharing this GUID; 1 = ungrouped
+}
+
+// groupHistoryRows reorders records so rows sharing a GUID are contiguous.
+// Within a group, the record with the most interesting outcome (per
+// outcomeRank; ties broken alphabetically by Feed) is marked IsPrimary and
+// placed first; the rest follow sorted by Feed name. Group order follows
+// first appearance in the input. Records with an empty GUID are never
+// grouped with each other or anything else.
+func groupHistoryRows(records []HistoryRecord) []historyRow {
+	type group struct {
+		key     string
+		records []HistoryRecord
+	}
+
+	order := make([]string, 0, len(records))
+	groups := make(map[string]*group, len(records))
+	empties := 0
+	for _, r := range records {
+		var key string
+		if r.GUID == "" {
+			// Each empty-GUID record is its own singleton group.
+			empties++
+			key = fmt.Sprintf("\x00empty-%d", empties)
+		} else {
+			key = r.GUID
+		}
+
+		g, ok := groups[key]
+		if !ok {
+			g = &group{key: key}
+			groups[key] = g
+			order = append(order, key)
+		}
+		g.records = append(g.records, r)
+	}
+
+	rows := make([]historyRow, 0, len(records))
+	for _, key := range order {
+		g := groups[key]
+		recs := append([]HistoryRecord(nil), g.records...)
+		sort.SliceStable(recs, func(i, j int) bool {
+			ri, rj := outcomeRank(recs[i].Outcome), outcomeRank(recs[j].Outcome)
+			if ri != rj {
+				return ri < rj
+			}
+			return recs[i].Feed < recs[j].Feed
+		})
+		for i, r := range recs {
+			rows = append(rows, historyRow{
+				HistoryRecord: r,
+				IsPrimary:     i == 0,
+				GroupSize:     len(recs),
+			})
+		}
+	}
+	return rows
+}
+
 // newWebMux builds the shared HTTP mux. If history is non-nil, the history
 // page is served at "/". When history and retry are both non-nil, POST /torrent
 // is also registered to re-submit a past skipped/excluded/error item.
@@ -166,6 +234,7 @@ func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name s
 			}
 		},
 		"feedConfigured": feedConfigured,
+		"sub":            func(a, b int) int { return a - b },
 	}
 	tmpl := template.Must(template.New("history").Funcs(funcMap).Parse(historyTmpl))
 
@@ -177,8 +246,9 @@ func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name s
 			for i, j := 0, len(records)-1; i < j; i, j = i+1, j-1 {
 				records[i], records[j] = records[j], records[i]
 			}
+			rows := groupHistoryRows(records)
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			if err := tmpl.Execute(w, records); err != nil {
+			if err := tmpl.Execute(w, rows); err != nil {
 				log.WithError(err).Error("Failed to render history template")
 			}
 		})

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -166,12 +166,14 @@ func isNoGroupMatched(r HistoryRecord) bool {
 // groupHistoryRows reorders records so rows sharing a GUID are contiguous.
 // Within a group, the primary row is chosen by: "no group matched labels"
 // records always sort last (see isNoGroupMatched); among the rest, the most
-// interesting outcome wins (outcomeRank); ties break alphabetically by Feed.
-// The chosen record is marked IsPrimary and placed first; the rest follow
-// sorted the same way. Group order follows first appearance in the input.
-// Records with an empty GUID are never grouped with each other or anything
-// else.
-func groupHistoryRows(records []HistoryRecord) []historyRow {
+// interesting outcome wins (outcomeRank); ties then break by feedPriority
+// (lower wins — see Feed.HistoryPriority), letting a user explicitly declare
+// which sibling feed should win a full tie; any remaining tie breaks
+// alphabetically by Feed. The chosen record is marked IsPrimary and placed
+// first; the rest follow sorted the same way. Group order follows first
+// appearance in the input. Records with an empty GUID are never grouped with
+// each other or anything else.
+func groupHistoryRows(records []HistoryRecord, feedPriority func(name string) int) []historyRow {
 	type group struct {
 		key     string
 		records []HistoryRecord
@@ -212,6 +214,10 @@ func groupHistoryRows(records []HistoryRecord) []historyRow {
 			if ri != rj {
 				return ri < rj
 			}
+			pi, pj := feedPriority(recs[i].Feed), feedPriority(recs[j].Feed)
+			if pi != pj {
+				return pi < pj
+			}
 			return recs[i].Feed < recs[j].Feed
 		})
 		for i, r := range recs {
@@ -232,10 +238,15 @@ func groupHistoryRows(records []HistoryRecord) []historyRow {
 // config; the Torrent button is hidden on the history page for records whose
 // feed no longer exists, since retrying one always fails with "feed ... is no
 // longer configured". A nil feedConfigured shows the button unconditionally.
+// feedPriority reports a feed's Feed.HistoryPriority, used by groupHistoryRows
+// to break primary-row ties; a nil feedPriority treats every feed as priority 0.
 // The /healthz route is always registered.
-func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name string) bool) *http.ServeMux {
+func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name string) bool, feedPriority func(name string) int) *http.ServeMux {
 	if feedConfigured == nil {
 		feedConfigured = func(string) bool { return true }
+	}
+	if feedPriority == nil {
+		feedPriority = func(string) int { return 0 }
 	}
 	funcMap := template.FuncMap{
 		"outcomeClass": func(outcome string) string {
@@ -261,7 +272,7 @@ func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name s
 			for i, j := 0, len(records)-1; i < j; i, j = i+1, j-1 {
 				records[i], records[j] = records[j], records[i]
 			}
-			rows := groupHistoryRows(records)
+			rows := groupHistoryRows(records, feedPriority)
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			if err := tmpl.Execute(w, rows); err != nil {
 				log.WithError(err).Error("Failed to render history template")

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -154,24 +154,23 @@ type historyRow struct {
 	GroupSize int // total records sharing this GUID; 1 = ungrouped
 }
 
-// skipReasonRank ranks "no group matched labels" below every other reason: it
-// means this feed's Groups never applied to the item at all, whereas any other
-// skip reason (outranked, cache already has a better version, etc.) means the
-// item did match this feed's groups and is therefore more informative to show
-// as a group's primary row.
-func skipReasonRank(reason string) int {
-	if reason == skipReasonNoGroupMatched {
-		return 1
-	}
-	return 0
+// isNoGroupMatched reports whether a record's feed never applied to the item
+// at all (its Groups never matched the item's labels). This is the least
+// informative reason a record can carry — even below an excluded or errored
+// record, which at least mean the feed engaged with the item — so it's
+// checked before outcomeRank when picking a group's primary row.
+func isNoGroupMatched(r HistoryRecord) bool {
+	return r.Outcome == "skipped" && r.Reason == skipReasonNoGroupMatched
 }
 
 // groupHistoryRows reorders records so rows sharing a GUID are contiguous.
-// Within a group, the record with the most interesting outcome (per
-// outcomeRank, then skipReasonRank, ties broken alphabetically by Feed) is
-// marked IsPrimary and placed first; the rest follow sorted by Feed name.
-// Group order follows first appearance in the input. Records with an empty
-// GUID are never grouped with each other or anything else.
+// Within a group, the primary row is chosen by: "no group matched labels"
+// records always sort last (see isNoGroupMatched); among the rest, the most
+// interesting outcome wins (outcomeRank); ties break alphabetically by Feed.
+// The chosen record is marked IsPrimary and placed first; the rest follow
+// sorted the same way. Group order follows first appearance in the input.
+// Records with an empty GUID are never grouped with each other or anything
+// else.
 func groupHistoryRows(records []HistoryRecord) []historyRow {
 	type group struct {
 		key     string
@@ -205,13 +204,13 @@ func groupHistoryRows(records []HistoryRecord) []historyRow {
 		g := groups[key]
 		recs := append([]HistoryRecord(nil), g.records...)
 		sort.SliceStable(recs, func(i, j int) bool {
+			ni, nj := isNoGroupMatched(recs[i]), isNoGroupMatched(recs[j])
+			if ni != nj {
+				return nj // i sorts first when i is NOT a no-group-matched record
+			}
 			ri, rj := outcomeRank(recs[i].Outcome), outcomeRank(recs[j].Outcome)
 			if ri != rj {
 				return ri < rj
-			}
-			si, sj := skipReasonRank(recs[i].Reason), skipReasonRank(recs[j].Reason)
-			if si != sj {
-				return si < sj
 			}
 			return recs[i].Feed < recs[j].Feed
 		})

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -154,12 +154,24 @@ type historyRow struct {
 	GroupSize int // total records sharing this GUID; 1 = ungrouped
 }
 
+// skipReasonRank ranks "no group matched labels" below every other reason: it
+// means this feed's Groups never applied to the item at all, whereas any other
+// skip reason (outranked, cache already has a better version, etc.) means the
+// item did match this feed's groups and is therefore more informative to show
+// as a group's primary row.
+func skipReasonRank(reason string) int {
+	if reason == skipReasonNoGroupMatched {
+		return 1
+	}
+	return 0
+}
+
 // groupHistoryRows reorders records so rows sharing a GUID are contiguous.
 // Within a group, the record with the most interesting outcome (per
-// outcomeRank; ties broken alphabetically by Feed) is marked IsPrimary and
-// placed first; the rest follow sorted by Feed name. Group order follows
-// first appearance in the input. Records with an empty GUID are never
-// grouped with each other or anything else.
+// outcomeRank, then skipReasonRank, ties broken alphabetically by Feed) is
+// marked IsPrimary and placed first; the rest follow sorted by Feed name.
+// Group order follows first appearance in the input. Records with an empty
+// GUID are never grouped with each other or anything else.
 func groupHistoryRows(records []HistoryRecord) []historyRow {
 	type group struct {
 		key     string
@@ -196,6 +208,10 @@ func groupHistoryRows(records []HistoryRecord) []historyRow {
 			ri, rj := outcomeRank(recs[i].Outcome), outcomeRank(recs[j].Outcome)
 			if ri != rj {
 				return ri < rj
+			}
+			si, sj := skipReasonRank(recs[i].Reason), skipReasonRank(recs[j].Reason)
+			if si != sj {
+				return si < sj
 			}
 			return recs[i].Feed < recs[j].Feed
 		})

--- a/cmd/rss4transmission/web/history.html
+++ b/cmd/rss4transmission/web/history.html
@@ -237,9 +237,18 @@
             // feed's primary row, e.g. filtering Feed=WSBK when the BSB
             // feed's dispatched record is the group's primary). Auto-expand
             // its group so the matching row is still reachable instead of
-            // silently vanishing.
+            // silently vanishing — but only when the primary itself is
+            // filtered out; with the default "show everything" filter every
+            // child row trivially matches too, and that must not force every
+            // group open.
+            var primaryShow = {};
             rows.forEach(function (row, i) {
-                if (rawShow[i] && isChild(row)) expandedGroups.add(row.dataset.guid);
+                if (!isChild(row)) primaryShow[row.dataset.guid] = rawShow[i];
+            });
+            rows.forEach(function (row, i) {
+                if (rawShow[i] && isChild(row) && !primaryShow[row.dataset.guid]) {
+                    expandedGroups.add(row.dataset.guid);
+                }
             });
 
             var visible = 0;

--- a/cmd/rss4transmission/web/history.html
+++ b/cmd/rss4transmission/web/history.html
@@ -77,6 +77,11 @@
         }
         .btn-torrent:hover { background: #08e; }
         .btn-torrent:disabled { background: #444; color: #888; cursor: default; }
+
+        .group-toggle { cursor: pointer; color: #888; user-select: none; display: inline-block; width: 1em; }
+        .group-badge { color: #666; font-size: 0.82em; }
+        tr.group-child td { background: #202020; }
+        tr.group-child td:nth-child(2) { padding-left: 1.8em; }
     </style>
 </head>
 <body>
@@ -134,9 +139,11 @@
         </thead>
         <tbody id="rows">
             {{ range . }}
-            <tr data-feed="{{ .Feed }}" data-outcome="{{ .Outcome }}" data-labels="{{ range $k, $v := .Labels }}{{ $k }}={{ $v }} {{ end }}">
+            <tr data-guid="{{ .GUID }}" data-feed="{{ .Feed }}" data-outcome="{{ .Outcome }}" data-labels="{{ range $k, $v := .Labels }}{{ $k }}={{ $v }} {{ end }}"{{ if not .IsPrimary }} class="group-child" style="display:none"{{ end }}>
                 <td>{{ .ProcessedAt.Format "2006-01-02 15:04:05.000" }}</td>
-                <td>{{ .Feed }}</td>
+                <td>
+                    {{ if and .IsPrimary (gt .GroupSize 1) }}<span class="group-toggle" data-guid="{{ .GUID }}">&#9656;</span> {{ end }}{{ .Feed }}{{ if and .IsPrimary (gt .GroupSize 1) }} <span class="group-badge">+{{ sub .GroupSize 1 }}</span>{{ end }}
+                </td>
                 <td>
                     {{ if .GUID }}<a href="{{ .GUID }}" target="_blank" rel="noopener">{{ .Title }}</a>{{ else }}{{ .Title }}{{ end }}
                     {{ if .Labels }}<div class="labels">{{ range $k, $v := .Labels }}{{ $k }}={{ $v }} {{ end }}</div>{{ end }}
@@ -164,6 +171,19 @@
         var resetBtn = document.getElementById('reset');
         var rows     = Array.from(document.querySelectorAll('#rows tr'));
 
+        // GUIDs of groups the user has manually expanded (or that were
+        // auto-expanded because a filter matched one of their hidden child
+        // rows — see apply() below). Reset on page load/reload.
+        var expandedGroups = new Set();
+
+        function isChild(row) { return row.classList.contains('group-child'); }
+
+        function syncToggleGlyphs() {
+            Array.from(document.querySelectorAll('.group-toggle')).forEach(function (t) {
+                t.textContent = expandedGroups.has(t.dataset.guid) ? '▾' : '▸';
+            });
+        }
+
         // Populate feed dropdown from rendered data.
         var feeds = Array.from(new Set(rows.map(function (r) { return r.dataset.feed; }).filter(Boolean))).sort();
         feeds.forEach(function (f) {
@@ -186,6 +206,23 @@
             outcomeCheckboxes().forEach(function (cb) { cb.checked = enabled.has(cb.value); });
         }
 
+        function computeShow(row, feed, checked, labelPairs) {
+            var show = true;
+
+            if (feed && row.dataset.feed !== feed) show = false;
+
+            if (show && !checked.has(row.dataset.outcome)) show = false;
+
+            if (show && labelPairs.length > 0) {
+                var rl = row.dataset.labels || '';
+                for (var i = 0; i < labelPairs.length; i++) {
+                    if (rl.indexOf(labelPairs[i]) === -1) { show = false; break; }
+                }
+            }
+
+            return show;
+        }
+
         function apply() {
             var feed       = feedSel.value;
             var labelText  = labelIn.value.trim();
@@ -193,24 +230,26 @@
             var checked    = new Set();
             outcomeCheckboxes().forEach(function (cb) { if (cb.checked) checked.add(cb.value); });
 
+            var rawShow = rows.map(function (row) { return computeShow(row, feed, checked, labelPairs); });
+
+            // A filter can match a row that's collapsed by default (a
+            // "no group matched labels" record hiding under a different
+            // feed's primary row, e.g. filtering Feed=WSBK when the BSB
+            // feed's dispatched record is the group's primary). Auto-expand
+            // its group so the matching row is still reachable instead of
+            // silently vanishing.
+            rows.forEach(function (row, i) {
+                if (rawShow[i] && isChild(row)) expandedGroups.add(row.dataset.guid);
+            });
+
             var visible = 0;
-            rows.forEach(function (row) {
-                var show = true;
-
-                if (feed && row.dataset.feed !== feed) show = false;
-
-                if (show && !checked.has(row.dataset.outcome)) show = false;
-
-                if (show && labelPairs.length > 0) {
-                    var rl = row.dataset.labels || '';
-                    for (var i = 0; i < labelPairs.length; i++) {
-                        if (rl.indexOf(labelPairs[i]) === -1) { show = false; break; }
-                    }
-                }
-
+            rows.forEach(function (row, i) {
+                var show = rawShow[i] && (!isChild(row) || expandedGroups.has(row.dataset.guid));
                 row.style.display = show ? '' : 'none';
                 if (show) visible++;
             });
+
+            syncToggleGlyphs();
 
             // Update URL params so the 60-second meta-refresh preserves state.
             var p = new URLSearchParams();
@@ -241,6 +280,14 @@
 
         var rowsEl = document.getElementById('rows');
         rowsEl.addEventListener('click', function (e) {
+            var toggle = e.target.closest('.group-toggle');
+            if (toggle) {
+                var guid = toggle.dataset.guid;
+                if (expandedGroups.has(guid)) expandedGroups.delete(guid); else expandedGroups.add(guid);
+                apply();
+                return;
+            }
+
             var btn = e.target.closest('.btn-torrent');
             if (!btn) return;
 

--- a/cmd/rss4transmission/web/history.html
+++ b/cmd/rss4transmission/web/history.html
@@ -80,7 +80,9 @@
 
         .group-toggle { cursor: pointer; color: #888; user-select: none; display: inline-block; width: 1em; }
         .group-badge { color: #666; font-size: 0.82em; }
-        tr.group-child td { background: #202020; }
+        tr.group-child td { background: #232a33; }
+        tr.group-child:hover td { background: #2b333e; }
+        tr.group-child td:first-child { box-shadow: inset 3px 0 0 #3a6ea5; }
         tr.group-child td:nth-child(2) { padding-left: 1.8em; }
     </style>
 </head>

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -23,7 +24,7 @@ import (
 // --- /healthz ---
 
 func TestHealthzHandler(t *testing.T) {
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	req := httptest.NewRequest("GET", "/healthz", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -78,7 +79,7 @@ func TestGetCancelHandler_RendersForm(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -103,7 +104,7 @@ func TestGetCancelHandler_RendersProgress(t *testing.T) {
 	// 2.5 GiB downloaded, 25% done
 	getProgress := makeProgressFunc(int64(2.5*float64(1<<30)), 0.25)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), getProgress, nil)
 
 	req := httptest.NewRequest("GET",
@@ -128,7 +129,7 @@ func TestGetCancelHandler_ProgressUnknownOnError(t *testing.T) {
 		return 0, 0, fmt.Errorf("transmission unavailable")
 	}
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), errProgress, nil)
 
 	req := httptest.NewRequest("GET",
@@ -143,7 +144,7 @@ func TestGetCancelHandler_ProgressUnknownOnError(t *testing.T) {
 func TestGetCancelHandler_MissingParams(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET", "/cancel?id=test-id", nil)
@@ -159,7 +160,7 @@ func TestGetCancelHandler_BadSignature(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -176,7 +177,7 @@ func TestGetCancelHandler_Expired(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -192,7 +193,7 @@ func TestGetCancelHandler_NotFound(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -210,7 +211,7 @@ func TestGetCancelHandler_DoesNotConsumeEntry(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	removed := false
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), nil)
 
@@ -237,7 +238,7 @@ func TestPostCancelHandler_Valid(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	removed := false
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -253,7 +254,7 @@ func TestPostCancelHandler_Valid(t *testing.T) {
 func TestPostCancelHandler_MissingParams(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := strings.NewReader("id=test-id") // missing expires and sig
@@ -271,7 +272,7 @@ func TestPostCancelHandler_BadSignature(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, "badsig")
@@ -289,7 +290,7 @@ func TestPostCancelHandler_Expired(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -306,7 +307,7 @@ func TestPostCancelHandler_NotFound(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("ghost-id", expires, sig)
@@ -387,7 +388,7 @@ func TestPostCancelHandler_RemoveErrorPreservesStoreEntry(t *testing.T) {
 	failRemove := func(_ context.Context, _ []int64) error {
 		return fmt.Errorf("transmission unreachable")
 	}
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, failRemove, noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -408,7 +409,7 @@ func TestGetCancelHandler_ZeroBytesProgressBothUnknown(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	// brand-new torrent: 0 bytes downloaded, 0% done
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), makeProgressFunc(0, 0.0), nil)
 
 	req := httptest.NewRequest("GET",
@@ -458,7 +459,7 @@ func TestHistoryPage_RendersTorrentButtonForSkippedWithURL(t *testing.T) {
 		"skipped", "lost preference contest", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -475,7 +476,7 @@ func TestHistoryPage_NoTorrentButtonWithoutURL(t *testing.T) {
 	rec := NewHistoryRecord("myfeed", makeGofeedItem("No Enclosure", "guid-2"), "excluded", "matched exclude", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -491,7 +492,7 @@ func TestHistoryPage_NoTorrentButtonForDispatched(t *testing.T) {
 		"dispatched", "", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -509,7 +510,7 @@ func TestHistoryPage_TorrentButtonShownWhenFeedConfiguredNil(t *testing.T) {
 
 	// A nil feedConfigured means "no filter" — button shows unconditionally,
 	// matching every existing caller that doesn't care about live config.
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -526,7 +527,7 @@ func TestHistoryPage_TorrentButtonHiddenWhenFeedNotConfigured(t *testing.T) {
 	h.AddOrUpdateRecord(rec)
 
 	feedConfigured := func(name string) bool { return name == "still-here" }
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), feedConfigured)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), feedConfigured, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -544,7 +545,7 @@ func TestHistoryPage_TorrentButtonShownWhenFeedStillConfigured(t *testing.T) {
 	h.AddOrUpdateRecord(rec)
 
 	feedConfigured := func(name string) bool { return name == "still-here" }
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), feedConfigured)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), feedConfigured, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -555,6 +556,10 @@ func TestHistoryPage_TorrentButtonShownWhenFeedStillConfigured(t *testing.T) {
 
 // --- groupHistoryRows ---
 
+// zeroPriority is a no-op feedPriority func: every feed ties at priority 0,
+// leaving the alphabetical-by-Feed fallback as the deciding tier.
+func zeroPriority(string) int { return 0 }
+
 func TestGroupHistoryRows_DispatchedIsPrimaryOverSkipped(t *testing.T) {
 	records := []HistoryRecord{
 		NewHistoryRecord("WSBK", makeGofeedItem("BSB Title", "guid-1"), "skipped", "no group matched labels", nil),
@@ -563,7 +568,7 @@ func TestGroupHistoryRows_DispatchedIsPrimaryOverSkipped(t *testing.T) {
 		NewHistoryRecord("IOMTT", makeGofeedItem("BSB Title", "guid-1"), "skipped", "no group matched labels", nil),
 	}
 
-	rows := groupHistoryRows(records)
+	rows := groupHistoryRows(records, zeroPriority)
 
 	require.Len(t, rows, 4)
 	assert.True(t, rows[0].IsPrimary)
@@ -587,7 +592,7 @@ func TestGroupHistoryRows_TieBreaksAlphabeticallyByFeed(t *testing.T) {
 		NewHistoryRecord("IOMTT", makeGofeedItem("BSB Title", "guid-1"), "skipped", "no group matched labels", nil),
 	}
 
-	rows := groupHistoryRows(records)
+	rows := groupHistoryRows(records, zeroPriority)
 
 	require.Len(t, rows, 3)
 	assert.True(t, rows[0].IsPrimary)
@@ -603,7 +608,7 @@ func TestGroupHistoryRows_PrefersInformativeReasonOverNoGroupMatched(t *testing.
 		NewHistoryRecord("MotoGP", makeGofeedItem("MotoGP Title", "guid-1"), "skipped", skipReasonCacheBetter, nil),
 	}
 
-	rows := groupHistoryRows(records)
+	rows := groupHistoryRows(records, zeroPriority)
 
 	require.Len(t, rows, 3)
 	assert.True(t, rows[0].IsPrimary)
@@ -614,13 +619,38 @@ func TestGroupHistoryRows_PrefersInformativeReasonOverNoGroupMatched(t *testing.
 	assert.Equal(t, "Moto3", rows[2].Feed)
 }
 
+func TestGroupHistoryRows_HistoryPriorityBreaksNoGroupMatchedTie(t *testing.T) {
+	records := []HistoryRecord{
+		NewHistoryRecord("Moto2", makeGofeedItem("MotoGP Title", "guid-1"), "skipped", skipReasonNoGroupMatched, nil),
+		NewHistoryRecord("Moto3", makeGofeedItem("MotoGP Title", "guid-1"), "skipped", skipReasonNoGroupMatched, nil),
+		NewHistoryRecord("MotoGP", makeGofeedItem("MotoGP Title", "guid-1"), "skipped", skipReasonNoGroupMatched, nil),
+	}
+	// All three records are fully tied through isNoGroupMatched and outcomeRank,
+	// so without a priority func the alphabetical fallback would pick "Moto2".
+	preferMotoGP := func(feed string) int {
+		if feed == "MotoGP" {
+			return -1
+		}
+		return 0
+	}
+
+	rows := groupHistoryRows(records, preferMotoGP)
+
+	require.Len(t, rows, 3)
+	assert.True(t, rows[0].IsPrimary)
+	assert.Equal(t, "MotoGP", rows[0].Feed,
+		"a lower HistoryPriority must win the primary slot even when every other tier is tied")
+	assert.Equal(t, "Moto2", rows[1].Feed)
+	assert.Equal(t, "Moto3", rows[2].Feed)
+}
+
 func TestGroupHistoryRows_NoGroupMatchedIsLowestPriorityAcrossOutcomes(t *testing.T) {
 	records := []HistoryRecord{
 		NewHistoryRecord("BSB", makeGofeedItem("BSB Title", "guid-1"), "skipped", skipReasonNoGroupMatched, nil),
 		NewHistoryRecord("WSBK", makeGofeedItem("BSB Title", "guid-1"), "excluded", "matched exclude filter", nil),
 	}
 
-	rows := groupHistoryRows(records)
+	rows := groupHistoryRows(records, zeroPriority)
 
 	require.Len(t, rows, 2)
 	assert.True(t, rows[0].IsPrimary)
@@ -636,7 +666,7 @@ func TestGroupHistoryRows_EmptyGUIDNeverMerges(t *testing.T) {
 		NewHistoryRecord("feedB", makeGofeedItem("Title B", ""), "skipped", "no group matched labels", nil),
 	}
 
-	rows := groupHistoryRows(records)
+	rows := groupHistoryRows(records, zeroPriority)
 
 	require.Len(t, rows, 2)
 	for _, r := range rows {
@@ -650,7 +680,7 @@ func TestGroupHistoryRows_SingletonGroupIsPrimary(t *testing.T) {
 		NewHistoryRecord("onlyfeed", makeGofeedItem("Solo Title", "guid-solo"), "skipped", "excluded by regex", nil),
 	}
 
-	rows := groupHistoryRows(records)
+	rows := groupHistoryRows(records, zeroPriority)
 
 	require.Len(t, rows, 1)
 	assert.True(t, rows[0].IsPrimary)
@@ -664,7 +694,7 @@ func TestGroupHistoryRows_GroupsAreContiguousAtFirstAppearancePosition(t *testin
 		NewHistoryRecord("feedC", makeGofeedItem("First Title", "guid-1"), "dispatched", "", nil),
 	}
 
-	rows := groupHistoryRows(records)
+	rows := groupHistoryRows(records, zeroPriority)
 
 	require.Len(t, rows, 3)
 	// guid-1 first appears at index 0, so both its records land contiguously
@@ -698,7 +728,7 @@ func TestHistoryPage_GroupsRecordsSharingGUID(t *testing.T) {
 		makeGofeedItemWithEnclosure("BSB Title", "guid-1", "https://example.com/bsb.torrent"),
 		"skipped", "no group matched labels", nil))
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -715,11 +745,67 @@ func TestHistoryPage_GroupsRecordsSharingGUID(t *testing.T) {
 		"each skipped child keeps its own retry button; the dispatched primary has none")
 }
 
+func TestHistoryPage_FeedPriorityBreaksNoGroupMatchedTie(t *testing.T) {
+	h := emptyHistory()
+	h.AddOrUpdateRecord(NewHistoryRecord("Moto2",
+		makeGofeedItemWithEnclosure("MotoGP Title", "guid-1", "https://example.com/motogp.torrent"),
+		"skipped", "no group matched labels", nil))
+	h.AddOrUpdateRecord(NewHistoryRecord("Moto3",
+		makeGofeedItemWithEnclosure("MotoGP Title", "guid-1", "https://example.com/motogp.torrent"),
+		"skipped", "no group matched labels", nil))
+	h.AddOrUpdateRecord(NewHistoryRecord("MotoGP",
+		makeGofeedItemWithEnclosure("MotoGP Title", "guid-1", "https://example.com/motogp.torrent"),
+		"skipped", "no group matched labels", nil))
+
+	preferMotoGP := func(feed string) int {
+		if feed == "MotoGP" {
+			return -1
+		}
+		return 0
+	}
+
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, preferMotoGP)
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+
+	primaryRow := regexp.MustCompile(`<tr[^>]*data-feed="MotoGP"[^>]*>`).FindString(body)
+	require.NotEmpty(t, primaryRow, "expected a row for feed MotoGP")
+	assert.NotContains(t, primaryRow, "group-child",
+		"HistoryPriority should make MotoGP the primary row despite losing the alphabetical tie-break")
+}
+
+func TestHistoryPage_NilFeedPriorityDefaultsToAlphabetical(t *testing.T) {
+	h := emptyHistory()
+	h.AddOrUpdateRecord(NewHistoryRecord("Moto2",
+		makeGofeedItemWithEnclosure("MotoGP Title", "guid-1", "https://example.com/motogp.torrent"),
+		"skipped", "no group matched labels", nil))
+	h.AddOrUpdateRecord(NewHistoryRecord("MotoGP",
+		makeGofeedItemWithEnclosure("MotoGP Title", "guid-1", "https://example.com/motogp.torrent"),
+		"skipped", "no group matched labels", nil))
+
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil)
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+
+	primaryRow := regexp.MustCompile(`<tr[^>]*data-feed="Moto2"[^>]*>`).FindString(body)
+	require.NotEmpty(t, primaryRow, "expected a row for feed Moto2")
+	assert.NotContains(t, primaryRow, "group-child",
+		"a nil feedPriority must fall back to the alphabetical tie-break (Moto2 sorts before MotoGP)")
+}
+
 func TestHistoryPage_UniqueGUIDRendersUngrouped(t *testing.T) {
 	h := emptyHistory()
 	h.AddOrUpdateRecord(NewHistoryRecord("myfeed", makeGofeedItem("Solo Title", "guid-solo"), "skipped", "excluded by regex", nil))
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -756,7 +842,7 @@ func TestPostTorrentHandler_Success(t *testing.T) {
 
 	called := false
 	var gotRec HistoryRecord
-	mux := newWebMux(h, makeRetryFunc(&called, &gotRec, 7, nil), nil)
+	mux := newWebMux(h, makeRetryFunc(&called, &gotRec, 7, nil), nil, nil)
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -772,7 +858,7 @@ func TestPostTorrentHandler_Success(t *testing.T) {
 func TestPostTorrentHandler_UnknownRecord(t *testing.T) {
 	h := emptyHistory()
 	called := false
-	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, nil), nil)
+	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, nil), nil, nil)
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("ghost-feed", "ghost-guid"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -789,7 +875,7 @@ func TestPostTorrentHandler_RetryError(t *testing.T) {
 	h.AddOrUpdateRecord(rec)
 
 	called := false
-	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, fmt.Errorf("boom: no torrent URL")), nil)
+	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, fmt.Errorf("boom: no torrent URL")), nil, nil)
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -806,7 +892,7 @@ func TestPostTorrentHandler_NotRegisteredWhenRetryNil(t *testing.T) {
 	rec := NewHistoryRecord("myfeed", makeGofeedItem("My Title", "guid-1"), "skipped", "", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, nil, nil)
+	mux := newWebMux(h, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -839,7 +925,7 @@ func TestGetCancelHandler_AccessLog_InvalidToken(t *testing.T) {
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -859,7 +945,7 @@ func TestGetCancelHandler_AccessLog_MissingParams(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET", "/cancel?id=test-id", nil)
@@ -879,7 +965,7 @@ func TestGetCancelHandler_AccessLog_Expired(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -900,7 +986,7 @@ func TestGetCancelHandler_AccessLog_NotFound(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -922,7 +1008,7 @@ func TestGetCancelHandler_AccessLog_Success(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -943,7 +1029,7 @@ func TestGetCancelHandler_AccessLog_NilNoOp(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -962,7 +1048,7 @@ func TestPostCancelHandler_AccessLog_InvalidToken(t *testing.T) {
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, "badsig")
@@ -985,7 +1071,7 @@ func TestPostCancelHandler_AccessLog_Expired(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -1007,7 +1093,7 @@ func TestPostCancelHandler_AccessLog_NotFound(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("ghost-id", expires, sig)
@@ -1031,7 +1117,7 @@ func TestPostCancelHandler_AccessLog_Success(t *testing.T) {
 
 	lg, buf := makeTestAccessLogger()
 	removed := false
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -1058,7 +1144,7 @@ func TestPostCancelHandler_AccessLog_TransmissionError(t *testing.T) {
 	failRemove2 := func(_ context.Context, _ []int64) error {
 		return fmt.Errorf("transmission unreachable")
 	}
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, failRemove2, noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, sig)

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -553,6 +553,149 @@ func TestHistoryPage_TorrentButtonShownWhenFeedStillConfigured(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), `class="btn-torrent"`)
 }
 
+// --- groupHistoryRows ---
+
+func TestGroupHistoryRows_DispatchedIsPrimaryOverSkipped(t *testing.T) {
+	records := []HistoryRecord{
+		NewHistoryRecord("WSBK", makeGofeedItem("BSB Title", "guid-1"), "skipped", "no group matched labels", nil),
+		NewHistoryRecord("WSS", makeGofeedItem("BSB Title", "guid-1"), "skipped", "no group matched labels", nil),
+		NewHistoryRecord("BSB", makeGofeedItem("BSB Title", "guid-1"), "dispatched", "", nil),
+		NewHistoryRecord("IOMTT", makeGofeedItem("BSB Title", "guid-1"), "skipped", "no group matched labels", nil),
+	}
+
+	rows := groupHistoryRows(records)
+
+	require.Len(t, rows, 4)
+	assert.True(t, rows[0].IsPrimary)
+	assert.Equal(t, "BSB", rows[0].Feed, "the dispatched record must be the primary row")
+	assert.Equal(t, 4, rows[0].GroupSize)
+
+	for _, r := range rows[1:] {
+		assert.False(t, r.IsPrimary)
+		assert.Equal(t, 4, r.GroupSize)
+	}
+	// Non-primary rows are sorted alphabetically by feed for deterministic rendering.
+	assert.Equal(t, "IOMTT", rows[1].Feed)
+	assert.Equal(t, "WSBK", rows[2].Feed)
+	assert.Equal(t, "WSS", rows[3].Feed)
+}
+
+func TestGroupHistoryRows_TieBreaksAlphabeticallyByFeed(t *testing.T) {
+	records := []HistoryRecord{
+		NewHistoryRecord("WSBK", makeGofeedItem("BSB Title", "guid-1"), "skipped", "no group matched labels", nil),
+		NewHistoryRecord("BSB", makeGofeedItem("BSB Title", "guid-1"), "skipped", "better version already in cache", nil),
+		NewHistoryRecord("IOMTT", makeGofeedItem("BSB Title", "guid-1"), "skipped", "no group matched labels", nil),
+	}
+
+	rows := groupHistoryRows(records)
+
+	require.Len(t, rows, 3)
+	assert.True(t, rows[0].IsPrimary)
+	assert.Equal(t, "BSB", rows[0].Feed, "equal outcomeRank ties break alphabetically by feed name")
+	assert.Equal(t, "IOMTT", rows[1].Feed)
+	assert.Equal(t, "WSBK", rows[2].Feed)
+}
+
+func TestGroupHistoryRows_EmptyGUIDNeverMerges(t *testing.T) {
+	records := []HistoryRecord{
+		NewHistoryRecord("feedA", makeGofeedItem("Title A", ""), "skipped", "no group matched labels", nil),
+		NewHistoryRecord("feedB", makeGofeedItem("Title B", ""), "skipped", "no group matched labels", nil),
+	}
+
+	rows := groupHistoryRows(records)
+
+	require.Len(t, rows, 2)
+	for _, r := range rows {
+		assert.True(t, r.IsPrimary)
+		assert.Equal(t, 1, r.GroupSize, "records with an empty GUID must never be grouped together")
+	}
+}
+
+func TestGroupHistoryRows_SingletonGroupIsPrimary(t *testing.T) {
+	records := []HistoryRecord{
+		NewHistoryRecord("onlyfeed", makeGofeedItem("Solo Title", "guid-solo"), "skipped", "excluded by regex", nil),
+	}
+
+	rows := groupHistoryRows(records)
+
+	require.Len(t, rows, 1)
+	assert.True(t, rows[0].IsPrimary)
+	assert.Equal(t, 1, rows[0].GroupSize)
+}
+
+func TestGroupHistoryRows_GroupsAreContiguousAtFirstAppearancePosition(t *testing.T) {
+	records := []HistoryRecord{
+		NewHistoryRecord("feedA", makeGofeedItem("First Title", "guid-1"), "skipped", "", nil),
+		NewHistoryRecord("feedB", makeGofeedItem("Second Title", "guid-2"), "skipped", "", nil),
+		NewHistoryRecord("feedC", makeGofeedItem("First Title", "guid-1"), "dispatched", "", nil),
+	}
+
+	rows := groupHistoryRows(records)
+
+	require.Len(t, rows, 3)
+	// guid-1 first appears at index 0, so both its records land contiguously
+	// there (dispatched primary first), pushing guid-2's single record last.
+	assert.Equal(t, "guid-1", rows[0].GUID)
+	assert.Equal(t, "feedC", rows[0].Feed)
+	assert.True(t, rows[0].IsPrimary)
+	assert.Equal(t, 2, rows[0].GroupSize)
+
+	assert.Equal(t, "guid-1", rows[1].GUID)
+	assert.Equal(t, "feedA", rows[1].Feed)
+	assert.False(t, rows[1].IsPrimary)
+	assert.Equal(t, 2, rows[1].GroupSize)
+
+	assert.Equal(t, "guid-2", rows[2].GUID)
+	assert.Equal(t, 1, rows[2].GroupSize)
+}
+
+func TestHistoryPage_GroupsRecordsSharingGUID(t *testing.T) {
+	h := emptyHistory()
+	h.AddOrUpdateRecord(NewHistoryRecord("BSB",
+		makeGofeedItemWithEnclosure("BSB Title", "guid-1", "https://example.com/bsb.torrent"),
+		"dispatched", "", nil))
+	h.AddOrUpdateRecord(NewHistoryRecord("WSS",
+		makeGofeedItemWithEnclosure("BSB Title", "guid-1", "https://example.com/bsb.torrent"),
+		"skipped", "no group matched labels", nil))
+	h.AddOrUpdateRecord(NewHistoryRecord("WSBK",
+		makeGofeedItemWithEnclosure("BSB Title", "guid-1", "https://example.com/bsb.torrent"),
+		"skipped", "no group matched labels", nil))
+	h.AddOrUpdateRecord(NewHistoryRecord("IOMTT",
+		makeGofeedItemWithEnclosure("BSB Title", "guid-1", "https://example.com/bsb.torrent"),
+		"skipped", "no group matched labels", nil))
+
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+
+	assert.Equal(t, 1, strings.Count(body, `class="group-toggle"`),
+		"exactly one primary row should carry the expand toggle")
+	assert.Contains(t, body, "+3")
+	assert.Equal(t, 3, strings.Count(body, `class="group-child"`),
+		"the three skipped records must render as hidden-by-default child rows")
+	assert.Equal(t, 3, strings.Count(body, `class="btn-torrent"`),
+		"each skipped child keeps its own retry button; the dispatched primary has none")
+}
+
+func TestHistoryPage_UniqueGUIDRendersUngrouped(t *testing.T) {
+	h := emptyHistory()
+	h.AddOrUpdateRecord(NewHistoryRecord("myfeed", makeGofeedItem("Solo Title", "guid-solo"), "skipped", "excluded by regex", nil))
+
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	assert.NotContains(t, body, `class="group-toggle"`)
+	assert.NotContains(t, body, `class="group-child"`)
+}
+
 // --- POST /torrent ---
 
 func makeRetryFunc(called *bool, gotRec *HistoryRecord, id int64, err error) retryFunc {

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -614,6 +614,22 @@ func TestGroupHistoryRows_PrefersInformativeReasonOverNoGroupMatched(t *testing.
 	assert.Equal(t, "Moto3", rows[2].Feed)
 }
 
+func TestGroupHistoryRows_NoGroupMatchedIsLowestPriorityAcrossOutcomes(t *testing.T) {
+	records := []HistoryRecord{
+		NewHistoryRecord("BSB", makeGofeedItem("BSB Title", "guid-1"), "skipped", skipReasonNoGroupMatched, nil),
+		NewHistoryRecord("WSBK", makeGofeedItem("BSB Title", "guid-1"), "excluded", "matched exclude filter", nil),
+	}
+
+	rows := groupHistoryRows(records)
+
+	require.Len(t, rows, 2)
+	assert.True(t, rows[0].IsPrimary)
+	assert.Equal(t, "WSBK", rows[0].Feed,
+		"\"no group matched labels\" must be the lowest priority of all, even below an excluded outcome "+
+			"which normally ranks worse than skipped per outcomeRank")
+	assert.Equal(t, "BSB", rows[1].Feed)
+}
+
 func TestGroupHistoryRows_EmptyGUIDNeverMerges(t *testing.T) {
 	records := []HistoryRecord{
 		NewHistoryRecord("feedA", makeGofeedItem("Title A", ""), "skipped", "no group matched labels", nil),

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -596,6 +596,24 @@ func TestGroupHistoryRows_TieBreaksAlphabeticallyByFeed(t *testing.T) {
 	assert.Equal(t, "WSBK", rows[2].Feed)
 }
 
+func TestGroupHistoryRows_PrefersInformativeReasonOverNoGroupMatched(t *testing.T) {
+	records := []HistoryRecord{
+		NewHistoryRecord("Moto2", makeGofeedItem("MotoGP Title", "guid-1"), "skipped", skipReasonNoGroupMatched, nil),
+		NewHistoryRecord("Moto3", makeGofeedItem("MotoGP Title", "guid-1"), "skipped", skipReasonNoGroupMatched, nil),
+		NewHistoryRecord("MotoGP", makeGofeedItem("MotoGP Title", "guid-1"), "skipped", skipReasonCacheBetter, nil),
+	}
+
+	rows := groupHistoryRows(records)
+
+	require.Len(t, rows, 3)
+	assert.True(t, rows[0].IsPrimary)
+	assert.Equal(t, "MotoGP", rows[0].Feed,
+		"a record that actually matched this feed's groups but lost a preference contest is more "+
+			"informative than a sibling feed that never matched at all, even though it sorts later alphabetically")
+	assert.Equal(t, "Moto2", rows[1].Feed)
+	assert.Equal(t, "Moto3", rows[2].Feed)
+}
+
 func TestGroupHistoryRows_EmptyGUIDNeverMerges(t *testing.T) {
 	records := []HistoryRecord{
 		NewHistoryRecord("feedA", makeGofeedItem("Title A", ""), "skipped", "no group matched labels", nil),

--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -16,6 +16,7 @@ All feeds support these options:
 | `NoValidateCert` | Skip TLS certificate validation for this feed's URL |
 | `NoSubmit` | Dry-run: log matches but do not send to Transmission |
 | `NoNotify` | Skip ntfy notifications for this feed (see [Notifications](notifications.md)) |
+| `HistoryPriority` | History page group tie-break; lower wins (default `0`) — see [History Web UI](notifications.md#history-web-ui) |
 
 `Feeds` is a list, so feeds are always processed in the order they appear in the config file. As
 soon as one item is actually dispatched (submitted to Transmission or downloaded to disk with

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -261,6 +261,19 @@ rss4transmission watch --config config.yaml \
 The history page shows each item's feed name, title, publication date, outcome, and extracted
 labels. Records are pruned on the same schedule as the seen cache (`SeenCacheDays`).
 
+When multiple feed configs share the same RSS URL (e.g. separate `MotoGP`, `Moto2`, and `Moto3`
+feeds subscribed to one feed URL), each processes every item independently, so the same item can
+produce several history records that share a GUID. The history page collapses these into one
+expandable row: a **primary** row is shown collapsed with a `+N` badge, and the rest render as
+hidden child rows revealed by clicking the toggle. The primary row is chosen by whichever record
+is most informative — a dispatched/downloaded outcome beats skipped, which beats excluded/error;
+among records that are all "no group matched labels" (none of a feed's `Groups` matched), that's
+treated as the least informative reason and always loses. If every record on a GUID is still
+tied after that, the tie breaks by each feed's `HistoryPriority` (lower wins; default `0`), and
+finally alphabetically by feed name. Set `HistoryPriority: -1` on the `MotoGP` feed, for example,
+to make it the parent row over `Moto2`/`Moto3` whenever a bundle release matches none of the
+three feeds' groups and would otherwise fall back to whichever feed name sorts first.
+
 Rows with outcome `skipped`, `excluded`, or `error` show a **Torrent** button when a `.torrent`
 URL was captured for that item, letting you manually re-submit it to Transmission without waiting
 for the feed to re-offer it. Clicking it re-fetches the `.torrent` fresh, submits it exactly like


### PR DESCRIPTION
## Summary
- Feed configs that share an RSS URL (BSB/WSS/WSBK/IOMTT/MotoAmerica) each recorded their own history entry per item, so one torrent produced a wall of near-duplicate rows — one useful outcome plus several "no group matched labels" noise rows from sibling feeds that were never going to match.
- Groups history rows by GUID: the record with the most interesting outcome (dispatched/downloaded > skipped > excluded > error) renders as a normal primary row with a `+N` badge; a toggle expands the group to reveal each sibling feed's own row (its own reason, labels, and Torrent button) — no data is hidden, just collapsed by default.
- Filtering stays accurate per row: filtering to a feed whose record is a collapsed child auto-expands that group so you see that feed's real outcome, never the primary's.

## Test plan
- [x] `make test` (go vet + full unit suite, including new `groupHistoryRows` unit tests and HTTP-level rendering tests for grouped/ungrouped rows) — TDD throughout per CLAUDE.md
- [x] `golangci-lint run` — 0 issues
- [x] `gofmt -l` — clean
- [x] `go mod tidy` — no diff
- [x] `make build-race` — builds successfully
- [ ] Manual browser check of the toggle/expand/filter interaction was not performed (no browser tooling available in this session) — verified instead via `httptest` against the exact template-rendering code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)