### PR TITLE
Group primary-row selection for history web UI

### DIFF
--- a/cmd/rss4transmission/once.go
+++ b/cmd/rss4transmission/once.go
@@ -493,6 +493,12 @@ func ensureTorrentBytes(item *FeedItem, cacheDir string, existing []byte) ([]byt
 // keys. Referenced in markCacheRejectedSeen to avoid string duplication.
 const skipReasonCacheBetter = "better version already in cache"
 
+// skipReasonNoGroupMatched is the reason string used when a candidate's labels
+// never matched any of the feed's Groups — i.e. this feed config never applied
+// to the item at all. Also referenced by groupHistoryRows in web.go, which
+// treats it as the least informative skip reason among siblings in a group.
+const skipReasonNoGroupMatched = "no group matched labels"
+
 // markCacheRejectedSeen adds the GUID of each cache-rejected candidate to the
 // seen cache. On the next run, Exists() catches these GUIDs in Phase 1, before
 // the torrent disk read, eliminating redundant I/O for items that will never
@@ -545,7 +551,7 @@ func selectWinners(candidates []*candidate, feedCfg Feed, cache *CacheFile) ([]*
 	skipReasons := map[*candidate]string{}
 	for _, c := range candidates {
 		if !matchedCands[c] {
-			skipReasons[c] = "no group matched labels"
+			skipReasons[c] = skipReasonNoGroupMatched
 		} else if !inBest[c] {
 			skipReasons[c] = "outranked by better candidate in this run"
 		}
@@ -582,7 +588,7 @@ func selectWinners(candidates []*candidate, feedCfg Feed, cache *CacheFile) ([]*
 		}
 	}
 	for c, reason := range skipReasons {
-		if reason != "no group matched labels" {
+		if reason != skipReasonNoGroupMatched {
 			continue
 		}
 		if key, ok := titleOnlyKey(c); ok {

--- a/cmd/rss4transmission/once.go
+++ b/cmd/rss4transmission/once.go
@@ -170,21 +170,27 @@ func (cmd *OnceCmd) feedAllowed(feedName string) bool {
 // should stop processing further feeds this run — either a torrent was
 // dispatched/downloaded, or the user selected Quit interactively.
 func (cmd *OnceCmd) processFeed(ctx *RunContext, feedName string, feedCfg Feed, rss *gofeed.Feed, extractor *ExtractorSet) bool {
-	// Phase 1: Pre-filter candidates via Exclude + size, then extract title labels.
+	// Phase 1: Extract title labels for every item, then pre-filter candidates via
+	// Exclude + size. Labels are extracted before the Check() filter runs so that
+	// excluded items still carry their labels into history — matching what
+	// skipped/dispatched records show, and giving the history page's group
+	// primary-row tie-break (bestGroupScore) evidence to work with even when every
+	// sibling feed excludes the same item.
 	var candidates []*candidate
 	for _, item := range rss.Items {
 		fi := &FeedItem{Feed: feedName, Item: item}
 		if ctx.Cache.Exists(feedName, fi) {
 			continue
 		}
+		titleLabels := extractor.ExtractLabels(item.Title)
 		ok, reason := feedCfg.Check(item)
 		if !ok {
-			ctx.recordHistory(feedName, item, "excluded", reason, nil)
+			ctx.recordHistory(feedName, item, "excluded", reason, titleLabels)
 			continue
 		}
 		candidates = append(candidates, &candidate{
 			item:        fi,
-			titleLabels: extractor.ExtractLabels(item.Title),
+			titleLabels: titleLabels,
 			defaults:    extractor.Defaults(),
 		})
 	}

--- a/cmd/rss4transmission/once_test.go
+++ b/cmd/rss4transmission/once_test.go
@@ -283,6 +283,171 @@ func TestProcessFeed_ExcludedItemsRecordExtractedTitleLabels(t *testing.T) {
 		"excluded records should carry title-extracted labels, same as skipped/dispatched records")
 }
 
+// realMotoGPExtractor mirrors the production "motogp" Extractor's Regexp
+// patterns closely enough to reproduce the extraction quirks real release
+// titles hit (e.g. multiple sibling feeds extracting an identical "class"
+// value from one shared RSS item's title).
+func realMotoGPExtractor() *ExtractorSet {
+	return &ExtractorSet{Labels: map[string]LabelDef{
+		"network": {
+			Regexp: `(?i)\.(TNT\.|Pack\.TNT|Eurosport|ITV4|ZiggoSport|WEB(?:-Rip)?)`,
+		},
+		"resolution": {
+			Regexp: `(?i)(2160p|1080p|720p|540p|400p)`,
+		},
+		"year": {
+			Regexp: `\.(20\d{2})\.`,
+		},
+		"round": {
+			Regexp: `(?i)\.(?:Round|20\d\dx)(\d{1,2}|\w)\.`,
+		},
+		"language": {
+			Regexp:  `(?i)(?:H\.?264|H\.?265|X\.?264|HEVC|AVC)(?:\.[^.]+)*\.(English|German|French|Italian|Spanish|Portuguese|Dutch|Polish|Czech|Hungarian|Multi)(?:[.\-]|$)`,
+			Default: "English",
+		},
+		"class": {
+			Regexp: `(?i)(Moto[23]|MotoGP)`,
+		},
+		"session": {
+			Regexp:  `(?i)\.(Sprint(?:\.?Race)?|Qual\w*|FP[12]?|(?:Free\.?)?Practice|Race|Full\.Event|All\.Day|Warm\.Up)\.`,
+			Default: "Race",
+		},
+	}}
+}
+
+// realMotoGPFeeds mirrors the production MotoGP/Moto2/Moto3 Feed definitions
+// (Exclude + Groups.Require only — no URL/DownloadPath), which share one RSS
+// URL and one Extractor in production.
+func realMotoGPFeeds() []Feed {
+	sharedExclude := []string{
+		`(?i).*Final.5.*`,
+		`(?i).*Highlights.*`,
+		`(?i).*Samsung\.?TV.*`,
+	}
+	return []Feed{
+		{
+			Name:      "MotoGP",
+			Extractor: "motogp",
+			Identity:  []string{"network", "year", "round", "session", "language", "class"},
+			Exclude:   sharedExclude,
+			Groups: []Group{{Require: map[string][]string{
+				"class": {"MotoGP"}, "session": {"Race", "Sprint", "Qualifying", "FP1", "FP", "FP2"},
+				"language": {"English"}, "year": {"2026"}, "network": {"TNT", "WEB"}, "resolution": {"1080p"},
+			}}},
+		},
+		{
+			Name:      "Moto2",
+			Extractor: "motogp",
+			Identity:  []string{"network", "year", "round", "session", "language", "class"},
+			Exclude:   sharedExclude,
+			Groups: []Group{{Require: map[string][]string{
+				"class": {"Moto2"}, "session": {"Race", "Qualifying"},
+				"language": {"English"}, "year": {"2026"}, "network": {"TNT", "WEB"}, "resolution": {"1080p"},
+			}}},
+		},
+		{
+			Name:      "Moto3",
+			Extractor: "motogp",
+			Identity:  []string{"network", "year", "round", "session", "language", "class"},
+			Exclude:   sharedExclude,
+			Groups: []Group{{Require: map[string][]string{
+				"class": {"Moto3"}, "session": {"Race", "Qualifying"},
+				"language": {"English"}, "year": {"2026"}, "network": {"TNT", "WEB"}, "resolution": {"1080p"},
+			}}},
+		},
+	}
+}
+
+func TestRealMotoGPFeeds_ExcludedHighlightsShowsLabelsAndMotoGPWinsPrimary(t *testing.T) {
+	extractor := realMotoGPExtractor()
+	feeds := realMotoGPFeeds()
+	rss := &gofeed.Feed{Items: []*gofeed.Item{
+		{Title: "MotoGP.All.Classes.2026.Round06.Great.Britain.Race.Highlights.WEB.1080p.H264.English", GUID: "guid-highlights"},
+	}}
+
+	ctx := &RunContext{Cache: emptyCache(), History: &HistoryFile{guidIndex: map[string]int{}}}
+	cmd := &OnceCmd{}
+	for _, f := range feeds {
+		cmd.processFeed(ctx, f.Name, f, rss, extractor)
+	}
+
+	records := ctx.History.GetRecords()
+	require.Len(t, records, 3)
+	for _, r := range records {
+		assert.Equal(t, "excluded", r.Outcome)
+		assert.Equal(t, "matched exclude filter", r.Reason)
+		assert.Equal(t, "MotoGP", r.Labels["class"],
+			"excluded records must carry extracted labels for the group tie-break to use")
+	}
+
+	feedGroups := func(name string) []Group {
+		for _, f := range feeds {
+			if f.Name == name {
+				return f.Groups
+			}
+		}
+		return nil
+	}
+	rows := groupHistoryRows(records, feedGroups)
+	require.Len(t, rows, 3)
+	assert.True(t, rows[0].IsPrimary)
+	assert.Equal(t, "MotoGP", rows[0].Feed,
+		"MotoGP's own Require is the only one satisfied by class=MotoGP, so it must win primary "+
+			"over its Moto2/Moto3 siblings despite the shared Extractor giving them the same label")
+}
+
+func TestRealMotoGPFeeds_DispatchedSiblingSuppressesReprocessingAfterHistoryReset(t *testing.T) {
+	extractor := realMotoGPExtractor()
+	feeds := realMotoGPFeeds()
+	rss := &gofeed.Feed{Items: []*gofeed.Item{
+		{Title: "Moto3.2026.Round12.Great.Britain.Race.WEB.1080p.X264.English", GUID: "guid-moto3-race"},
+	}}
+	cache := emptyCache()
+
+	// Run 1: Moto3's own Group matches this item (it's genuinely Moto3
+	// content), so it wins selection. cmd.Skip populates the cache exactly
+	// like a real dispatch would, without needing a Transmission mock.
+	run1 := &RunContext{Cache: cache, History: &HistoryFile{guidIndex: map[string]int{}}}
+	skipCmd := &OnceCmd{Skip: true}
+	for _, f := range feeds {
+		skipCmd.processFeed(run1, f.Name, f, rss, extractor)
+	}
+	run1Records := run1.History.GetRecords()
+	require.Len(t, run1Records, 3, "all three siblings should evaluate the item on a first run")
+
+	// Run 2: same cache (as if only the history file, not the seen-cache, was
+	// deleted and the process restarted), fresh empty history.
+	run2 := &RunContext{Cache: cache, History: &HistoryFile{guidIndex: map[string]int{}}}
+	noopCmd := &OnceCmd{}
+	for _, f := range feeds {
+		noopCmd.processFeed(run2, f.Name, f, rss, extractor)
+	}
+
+	run2Records := run2.History.GetRecords()
+	require.Len(t, run2Records, 2,
+		"Moto3 already exists in the cache from run 1 and must be silently skipped in Phase 1, "+
+			"leaving only Moto2 and MotoGP to re-record 'no group matched labels' every run")
+	for _, r := range run2Records {
+		assert.NotEqual(t, "Moto3", r.Feed)
+		assert.Equal(t, skipReasonNoGroupMatched, r.Reason)
+	}
+
+	feedGroups := func(name string) []Group {
+		for _, f := range feeds {
+			if f.Name == name {
+				return f.Groups
+			}
+		}
+		return nil
+	}
+	rows := groupHistoryRows(run2Records, feedGroups)
+	require.Len(t, rows, 2)
+	assert.True(t, rows[0].IsPrimary)
+	assert.Equal(t, "Moto2", rows[0].Feed,
+		"with Moto3's record missing, Moto2 and MotoGP both score 0 (their own Require is contradicted "+
+			"by class=Moto3, not merely silent on it), so the tie falls back to alphabetical order")
+}
+
 // --- dispatch stop-processing semantics ---
 
 // fakeTransmissionServer emulates just enough of Transmission's RPC protocol

--- a/cmd/rss4transmission/once_test.go
+++ b/cmd/rss4transmission/once_test.go
@@ -255,6 +255,34 @@ func TestDispatch_Skip_RecordsFileDerivedLabelsInHistory(t *testing.T) {
 		"history record should include the file-derived resolution label, matching what was cached")
 }
 
+// --- processFeed excluded-item labeling ---
+
+func TestProcessFeed_ExcludedItemsRecordExtractedTitleLabels(t *testing.T) {
+	extractor := &ExtractorSet{Labels: map[string]LabelDef{
+		"series": {Regexp: `(?i)(MotoGP|Moto2|Moto3)`},
+	}}
+	feedCfg := Feed{
+		Name:    "testfeed",
+		Exclude: []string{"Highlights"},
+	}
+	rss := &gofeed.Feed{Items: []*gofeed.Item{
+		{Title: "MotoGP.Round06.Highlights", GUID: "guid1"},
+	}}
+
+	ctx := &RunContext{
+		Cache:   emptyCache(),
+		History: &HistoryFile{guidIndex: map[string]int{}},
+	}
+	cmd := &OnceCmd{}
+	cmd.processFeed(ctx, "testfeed", feedCfg, rss, extractor)
+
+	records := ctx.History.GetRecords()
+	require.Len(t, records, 1)
+	assert.Equal(t, "excluded", records[0].Outcome)
+	assert.Equal(t, "MotoGP", records[0].Labels["series"],
+		"excluded records should carry title-extracted labels, same as skipped/dispatched records")
+}
+
 // --- dispatch stop-processing semantics ---
 
 // fakeTransmissionServer emulates just enough of Transmission's RPC protocol

--- a/cmd/rss4transmission/select.go
+++ b/cmd/rss4transmission/select.go
@@ -29,6 +29,29 @@ func (g *Group) Matches(labels map[string]string) bool {
 	return true
 }
 
+// MatchScore returns how many Require keys are present in labels and satisfy
+// their allowed values, or -1 if any present key contradicts a Require
+// constraint. A contradiction on even one key is strong evidence this group
+// doesn't own the item — sibling feeds sharing an Extractor can otherwise
+// extract identity-looking labels (e.g. class=MotoGP) for an item that isn't
+// theirs, and that false positive shouldn't be diluted or offset by other,
+// incidental keys matching. A key simply absent from labels doesn't
+// contradict; it's just not counted.
+func (g *Group) MatchScore(labels map[string]string) int {
+	score := 0
+	for label, acceptable := range g.Require {
+		v, ok := labels[label]
+		if !ok {
+			continue
+		}
+		if !slices.Contains(acceptable, v) {
+			return -1
+		}
+		score++
+	}
+	return score
+}
+
 // IdentityKey computes a stable string key from the given labels using the
 // declared identity label names. Returns ("", false) if any identity label is
 // absent from labels.

--- a/cmd/rss4transmission/select_test.go
+++ b/cmd/rss4transmission/select_test.go
@@ -293,3 +293,59 @@ func TestGroupMatches_MultipleAcceptableValues(t *testing.T) {
 		t.Error("expected no match for series=MotoGP")
 	}
 }
+
+// --- Group.MatchScore ---
+
+func TestGroupMatchScore_AllRequiredMatch(t *testing.T) {
+	g := Group{Require: map[string][]string{
+		"series":  {"MotoGP"},
+		"session": {"Race", "Qualifying"},
+	}}
+	labels := map[string]string{"series": "MotoGP", "session": "Race"}
+	if got := g.MatchScore(labels); got != 2 {
+		t.Errorf("MatchScore = %d, want 2 (both Require keys present and matching)", got)
+	}
+}
+
+func TestGroupMatchScore_AbsentKeyNotCounted(t *testing.T) {
+	g := Group{Require: map[string][]string{
+		"series":  {"MotoGP"},
+		"session": {"Race"},
+	}}
+	labels := map[string]string{"series": "MotoGP"} // session absent, not a contradiction
+	if got := g.MatchScore(labels); got != 1 {
+		t.Errorf("MatchScore = %d, want 1 (absent key contributes nothing, but isn't a contradiction)", got)
+	}
+}
+
+func TestGroupMatchScore_PresentContradictionDisqualifiesWholeGroup(t *testing.T) {
+	// series is present but wrong; session also matches, but the contradiction
+	// on series must disqualify the whole group, not just fail to count series.
+	g := Group{Require: map[string][]string{
+		"series":  {"Moto2"},
+		"session": {"Race"},
+	}}
+	labels := map[string]string{"series": "MotoGP", "session": "Race"}
+	if got := g.MatchScore(labels); got != -1 {
+		t.Errorf("MatchScore = %d, want -1 (a present contradicting key disqualifies the group "+
+			"even though another key matches)", got)
+	}
+}
+
+func TestGroupMatchScore_NoOverlapAtAll(t *testing.T) {
+	g := Group{Require: map[string][]string{
+		"series": {"MotoAmerica"},
+	}}
+	labels := map[string]string{"network": "TNT"} // no overlap, no contradiction either
+	if got := g.MatchScore(labels); got != 0 {
+		t.Errorf("MatchScore = %d, want 0 (no positive evidence, but no contradiction)", got)
+	}
+}
+
+func TestGroupMatchScore_EmptyRequire(t *testing.T) {
+	g := Group{Require: map[string][]string{}}
+	labels := map[string]string{"series": "MotoGP"}
+	if got := g.MatchScore(labels); got != 0 {
+		t.Errorf("MatchScore = %d, want 0 (nothing to require, nothing to score)", got)
+	}
+}

--- a/cmd/rss4transmission/watch.go
+++ b/cmd/rss4transmission/watch.go
@@ -209,6 +209,19 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 		return ok
 	}
 
+	// feedGroups exposes a feed's own configured Groups against the live
+	// config, so the history page can break primary-row ties using the same
+	// group evaluation the feed itself uses during processing.
+	feedGroups := func(name string) []Group {
+		reloader.mu.Lock()
+		defer reloader.mu.Unlock()
+		f, ok := findFeedByName(ctx.Config.Feeds, name)
+		if !ok {
+			return nil
+		}
+		return f.Groups
+	}
+
 	accessLog := openAccessLog(cmd.AccessLog)
 
 	if cmd.PublicListen != "" {
@@ -234,7 +247,7 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 			if ctx.History == nil {
 				log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
 			}
-			go startWebServer("private", newWebMux(ctx.History, retryHistory, feedConfigured), histAddr)
+			go startWebServer("private", newWebMux(ctx.History, retryHistory, feedConfigured, feedGroups), histAddr)
 		}
 	} else if cmd.PrivateListen != "" {
 		// Single-listener mode: history + cancel on the same port.
@@ -245,7 +258,7 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 		if ctx.History == nil {
 			log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
 		}
-		mux := newWebMux(ctx.History, retryHistory, feedConfigured)
+		mux := newWebMux(ctx.History, retryHistory, feedConfigured, feedGroups)
 		if ctx.CancelStore != nil {
 			registerCancelRoutes(mux, ctx.CancelStore, ctx.Config.Cancel, removeT, getProgress, accessLog)
 			ctx.CancelRoutesEnabled = true

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -29,6 +29,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -142,6 +143,73 @@ func parseListenAddr(s string) (string, error) {
 	return fmt.Sprintf("127.0.0.1:%d", p), nil
 }
 
+// historyRow decorates a HistoryRecord with grouping metadata for template
+// rendering: rows sharing a GUID (the same RSS item seen by multiple feed
+// configs that share an RSS URL) are grouped into one expandable entry so a
+// torrent that only matches one of several sibling feeds doesn't produce a
+// wall of "no group matched labels" rows.
+type historyRow struct {
+	HistoryRecord
+	IsPrimary bool
+	GroupSize int // total records sharing this GUID; 1 = ungrouped
+}
+
+// groupHistoryRows reorders records so rows sharing a GUID are contiguous.
+// Within a group, the record with the most interesting outcome (per
+// outcomeRank; ties broken alphabetically by Feed) is marked IsPrimary and
+// placed first; the rest follow sorted by Feed name. Group order follows
+// first appearance in the input. Records with an empty GUID are never
+// grouped with each other or anything else.
+func groupHistoryRows(records []HistoryRecord) []historyRow {
+	type group struct {
+		key     string
+		records []HistoryRecord
+	}
+
+	order := make([]string, 0, len(records))
+	groups := make(map[string]*group, len(records))
+	empties := 0
+	for _, r := range records {
+		var key string
+		if r.GUID == "" {
+			// Each empty-GUID record is its own singleton group.
+			empties++
+			key = fmt.Sprintf("\x00empty-%d", empties)
+		} else {
+			key = r.GUID
+		}
+
+		g, ok := groups[key]
+		if !ok {
+			g = &group{key: key}
+			groups[key] = g
+			order = append(order, key)
+		}
+		g.records = append(g.records, r)
+	}
+
+	rows := make([]historyRow, 0, len(records))
+	for _, key := range order {
+		g := groups[key]
+		recs := append([]HistoryRecord(nil), g.records...)
+		sort.SliceStable(recs, func(i, j int) bool {
+			ri, rj := outcomeRank(recs[i].Outcome), outcomeRank(recs[j].Outcome)
+			if ri != rj {
+				return ri < rj
+			}
+			return recs[i].Feed < recs[j].Feed
+		})
+		for i, r := range recs {
+			rows = append(rows, historyRow{
+				HistoryRecord: r,
+				IsPrimary:     i == 0,
+				GroupSize:     len(recs),
+			})
+		}
+	}
+	return rows
+}
+
 // newWebMux builds the shared HTTP mux. If history is non-nil, the history
 // page is served at "/". When history and retry are both non-nil, POST /torrent
 // is also registered to re-submit a past skipped/excluded/error item.
@@ -166,6 +234,7 @@ func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name s
 			}
 		},
 		"feedConfigured": feedConfigured,
+		"sub":            func(a, b int) int { return a - b },
 	}
 	tmpl := template.Must(template.New("history").Funcs(funcMap).Parse(historyTmpl))
 
@@ -177,8 +246,9 @@ func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name s
 			for i, j := 0, len(records)-1; i < j; i, j = i+1, j-1 {
 				records[i], records[j] = records[j], records[i]
 			}
+			rows := groupHistoryRows(records)
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			if err := tmpl.Execute(w, records); err != nil {
+			if err := tmpl.Execute(w, rows); err != nil {
 				log.WithError(err).Error("Failed to render history template")
 			}
 		})

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -163,15 +163,36 @@ func isNoGroupMatched(r HistoryRecord) bool {
 	return r.Outcome == "skipped" && r.Reason == skipReasonNoGroupMatched
 }
 
+// bestGroupScore returns the highest Group.MatchScore across groups for the
+// given labels, treating a feed with no groups — or whose every group is
+// disqualified (contradicted) or simply uninformative (no positive evidence)
+// — as 0, the same as a feed with no distinguishing evidence at all.
+func bestGroupScore(groups []Group, labels map[string]string) int {
+	best := 0
+	for _, g := range groups {
+		if s := g.MatchScore(labels); s > best {
+			best = s
+		}
+	}
+	return best
+}
+
 // groupHistoryRows reorders records so rows sharing a GUID are contiguous.
 // Within a group, the primary row is chosen by: "no group matched labels"
 // records always sort last (see isNoGroupMatched); among the rest, the most
-// interesting outcome wins (outcomeRank); ties break alphabetically by Feed.
-// The chosen record is marked IsPrimary and placed first; the rest follow
-// sorted the same way. Group order follows first appearance in the input.
-// Records with an empty GUID are never grouped with each other or anything
-// else.
-func groupHistoryRows(records []HistoryRecord) []historyRow {
+// interesting outcome wins (outcomeRank); ties then prefer the record whose
+// own extracted labels give the strongest positive match against its own
+// feed's Groups (see bestGroupScore) — this matters because sibling feeds
+// sharing an Extractor can extract identical labels for an item that isn't
+// theirs, so only labels that actually satisfy a feed's own Require count as
+// evidence; any remaining tie breaks alphabetically by Feed. The chosen
+// record is marked IsPrimary and placed first; the rest follow sorted the
+// same way. Group order follows first appearance in the input. Records with
+// an empty GUID are never grouped with each other or anything else.
+func groupHistoryRows(records []HistoryRecord, feedGroups func(name string) []Group) []historyRow {
+	if feedGroups == nil {
+		feedGroups = func(string) []Group { return nil }
+	}
 	type group struct {
 		key     string
 		records []HistoryRecord
@@ -212,6 +233,11 @@ func groupHistoryRows(records []HistoryRecord) []historyRow {
 			if ri != rj {
 				return ri < rj
 			}
+			si := bestGroupScore(feedGroups(recs[i].Feed), recs[i].Labels)
+			sj := bestGroupScore(feedGroups(recs[j].Feed), recs[j].Labels)
+			if si != sj {
+				return si > sj // higher score sorts first
+			}
 			return recs[i].Feed < recs[j].Feed
 		})
 		for i, r := range recs {
@@ -232,8 +258,11 @@ func groupHistoryRows(records []HistoryRecord) []historyRow {
 // config; the Torrent button is hidden on the history page for records whose
 // feed no longer exists, since retrying one always fails with "feed ... is no
 // longer configured". A nil feedConfigured shows the button unconditionally.
+// feedGroups reports a feed's own configured Groups, used to break primary-row
+// ties in groupHistoryRows; a nil feedGroups falls back to alphabetical
+// ordering, same as if every feed had no groups.
 // The /healthz route is always registered.
-func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name string) bool) *http.ServeMux {
+func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name string) bool, feedGroups func(name string) []Group) *http.ServeMux {
 	if feedConfigured == nil {
 		feedConfigured = func(string) bool { return true }
 	}
@@ -261,7 +290,7 @@ func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name s
 			for i, j := 0, len(records)-1; i < j; i, j = i+1, j-1 {
 				records[i], records[j] = records[j], records[i]
 			}
-			rows := groupHistoryRows(records)
+			rows := groupHistoryRows(records, feedGroups)
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			if err := tmpl.Execute(w, rows); err != nil {
 				log.WithError(err).Error("Failed to render history template")

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -154,24 +154,23 @@ type historyRow struct {
 	GroupSize int // total records sharing this GUID; 1 = ungrouped
 }
 
-// skipReasonRank ranks "no group matched labels" below every other reason: it
-// means this feed's Groups never applied to the item at all, whereas any other
-// skip reason (outranked, cache already has a better version, etc.) means the
-// item did match this feed's groups and is therefore more informative to show
-// as a group's primary row.
-func skipReasonRank(reason string) int {
-	if reason == skipReasonNoGroupMatched {
-		return 1
-	}
-	return 0
+// isNoGroupMatched reports whether a record's feed never applied to the item
+// at all (its Groups never matched the item's labels). This is the least
+// informative reason a record can carry — even below an excluded or errored
+// record, which at least mean the feed engaged with the item — so it's
+// checked before outcomeRank when picking a group's primary row.
+func isNoGroupMatched(r HistoryRecord) bool {
+	return r.Outcome == "skipped" && r.Reason == skipReasonNoGroupMatched
 }
 
 // groupHistoryRows reorders records so rows sharing a GUID are contiguous.
-// Within a group, the record with the most interesting outcome (per
-// outcomeRank, then skipReasonRank, ties broken alphabetically by Feed) is
-// marked IsPrimary and placed first; the rest follow sorted by Feed name.
-// Group order follows first appearance in the input. Records with an empty
-// GUID are never grouped with each other or anything else.
+// Within a group, the primary row is chosen by: "no group matched labels"
+// records always sort last (see isNoGroupMatched); among the rest, the most
+// interesting outcome wins (outcomeRank); ties break alphabetically by Feed.
+// The chosen record is marked IsPrimary and placed first; the rest follow
+// sorted the same way. Group order follows first appearance in the input.
+// Records with an empty GUID are never grouped with each other or anything
+// else.
 func groupHistoryRows(records []HistoryRecord) []historyRow {
 	type group struct {
 		key     string
@@ -205,13 +204,13 @@ func groupHistoryRows(records []HistoryRecord) []historyRow {
 		g := groups[key]
 		recs := append([]HistoryRecord(nil), g.records...)
 		sort.SliceStable(recs, func(i, j int) bool {
+			ni, nj := isNoGroupMatched(recs[i]), isNoGroupMatched(recs[j])
+			if ni != nj {
+				return nj // i sorts first when i is NOT a no-group-matched record
+			}
 			ri, rj := outcomeRank(recs[i].Outcome), outcomeRank(recs[j].Outcome)
 			if ri != rj {
 				return ri < rj
-			}
-			si, sj := skipReasonRank(recs[i].Reason), skipReasonRank(recs[j].Reason)
-			if si != sj {
-				return si < sj
 			}
 			return recs[i].Feed < recs[j].Feed
 		})

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -154,12 +154,24 @@ type historyRow struct {
 	GroupSize int // total records sharing this GUID; 1 = ungrouped
 }
 
+// skipReasonRank ranks "no group matched labels" below every other reason: it
+// means this feed's Groups never applied to the item at all, whereas any other
+// skip reason (outranked, cache already has a better version, etc.) means the
+// item did match this feed's groups and is therefore more informative to show
+// as a group's primary row.
+func skipReasonRank(reason string) int {
+	if reason == skipReasonNoGroupMatched {
+		return 1
+	}
+	return 0
+}
+
 // groupHistoryRows reorders records so rows sharing a GUID are contiguous.
 // Within a group, the record with the most interesting outcome (per
-// outcomeRank; ties broken alphabetically by Feed) is marked IsPrimary and
-// placed first; the rest follow sorted by Feed name. Group order follows
-// first appearance in the input. Records with an empty GUID are never
-// grouped with each other or anything else.
+// outcomeRank, then skipReasonRank, ties broken alphabetically by Feed) is
+// marked IsPrimary and placed first; the rest follow sorted by Feed name.
+// Group order follows first appearance in the input. Records with an empty
+// GUID are never grouped with each other or anything else.
 func groupHistoryRows(records []HistoryRecord) []historyRow {
 	type group struct {
 		key     string
@@ -196,6 +208,10 @@ func groupHistoryRows(records []HistoryRecord) []historyRow {
 			ri, rj := outcomeRank(recs[i].Outcome), outcomeRank(recs[j].Outcome)
 			if ri != rj {
 				return ri < rj
+			}
+			si, sj := skipReasonRank(recs[i].Reason), skipReasonRank(recs[j].Reason)
+			if si != sj {
+				return si < sj
 			}
 			return recs[i].Feed < recs[j].Feed
 		})

--- a/cmd/rss4transmission/web/history.html
+++ b/cmd/rss4transmission/web/history.html
@@ -237,9 +237,18 @@
             // feed's primary row, e.g. filtering Feed=WSBK when the BSB
             // feed's dispatched record is the group's primary). Auto-expand
             // its group so the matching row is still reachable instead of
-            // silently vanishing.
+            // silently vanishing — but only when the primary itself is
+            // filtered out; with the default "show everything" filter every
+            // child row trivially matches too, and that must not force every
+            // group open.
+            var primaryShow = {};
             rows.forEach(function (row, i) {
-                if (rawShow[i] && isChild(row)) expandedGroups.add(row.dataset.guid);
+                if (!isChild(row)) primaryShow[row.dataset.guid] = rawShow[i];
+            });
+            rows.forEach(function (row, i) {
+                if (rawShow[i] && isChild(row) && !primaryShow[row.dataset.guid]) {
+                    expandedGroups.add(row.dataset.guid);
+                }
             });
 
             var visible = 0;

--- a/cmd/rss4transmission/web/history.html
+++ b/cmd/rss4transmission/web/history.html
@@ -77,6 +77,11 @@
         }
         .btn-torrent:hover { background: #08e; }
         .btn-torrent:disabled { background: #444; color: #888; cursor: default; }
+
+        .group-toggle { cursor: pointer; color: #888; user-select: none; display: inline-block; width: 1em; }
+        .group-badge { color: #666; font-size: 0.82em; }
+        tr.group-child td { background: #202020; }
+        tr.group-child td:nth-child(2) { padding-left: 1.8em; }
     </style>
 </head>
 <body>
@@ -134,9 +139,11 @@
         </thead>
         <tbody id="rows">
             {{ range . }}
-            <tr data-feed="{{ .Feed }}" data-outcome="{{ .Outcome }}" data-labels="{{ range $k, $v := .Labels }}{{ $k }}={{ $v }} {{ end }}">
+            <tr data-guid="{{ .GUID }}" data-feed="{{ .Feed }}" data-outcome="{{ .Outcome }}" data-labels="{{ range $k, $v := .Labels }}{{ $k }}={{ $v }} {{ end }}"{{ if not .IsPrimary }} class="group-child" style="display:none"{{ end }}>
                 <td>{{ .ProcessedAt.Format "2006-01-02 15:04:05.000" }}</td>
-                <td>{{ .Feed }}</td>
+                <td>
+                    {{ if and .IsPrimary (gt .GroupSize 1) }}<span class="group-toggle" data-guid="{{ .GUID }}">&#9656;</span> {{ end }}{{ .Feed }}{{ if and .IsPrimary (gt .GroupSize 1) }} <span class="group-badge">+{{ sub .GroupSize 1 }}</span>{{ end }}
+                </td>
                 <td>
                     {{ if .GUID }}<a href="{{ .GUID }}" target="_blank" rel="noopener">{{ .Title }}</a>{{ else }}{{ .Title }}{{ end }}
                     {{ if .Labels }}<div class="labels">{{ range $k, $v := .Labels }}{{ $k }}={{ $v }} {{ end }}</div>{{ end }}
@@ -164,6 +171,19 @@
         var resetBtn = document.getElementById('reset');
         var rows     = Array.from(document.querySelectorAll('#rows tr'));
 
+        // GUIDs of groups the user has manually expanded (or that were
+        // auto-expanded because a filter matched one of their hidden child
+        // rows — see apply() below). Reset on page load/reload.
+        var expandedGroups = new Set();
+
+        function isChild(row) { return row.classList.contains('group-child'); }
+
+        function syncToggleGlyphs() {
+            Array.from(document.querySelectorAll('.group-toggle')).forEach(function (t) {
+                t.textContent = expandedGroups.has(t.dataset.guid) ? '▾' : '▸';
+            });
+        }
+
         // Populate feed dropdown from rendered data.
         var feeds = Array.from(new Set(rows.map(function (r) { return r.dataset.feed; }).filter(Boolean))).sort();
         feeds.forEach(function (f) {
@@ -186,6 +206,23 @@
             outcomeCheckboxes().forEach(function (cb) { cb.checked = enabled.has(cb.value); });
         }
 
+        function computeShow(row, feed, checked, labelPairs) {
+            var show = true;
+
+            if (feed && row.dataset.feed !== feed) show = false;
+
+            if (show && !checked.has(row.dataset.outcome)) show = false;
+
+            if (show && labelPairs.length > 0) {
+                var rl = row.dataset.labels || '';
+                for (var i = 0; i < labelPairs.length; i++) {
+                    if (rl.indexOf(labelPairs[i]) === -1) { show = false; break; }
+                }
+            }
+
+            return show;
+        }
+
         function apply() {
             var feed       = feedSel.value;
             var labelText  = labelIn.value.trim();
@@ -193,24 +230,26 @@
             var checked    = new Set();
             outcomeCheckboxes().forEach(function (cb) { if (cb.checked) checked.add(cb.value); });
 
+            var rawShow = rows.map(function (row) { return computeShow(row, feed, checked, labelPairs); });
+
+            // A filter can match a row that's collapsed by default (a
+            // "no group matched labels" record hiding under a different
+            // feed's primary row, e.g. filtering Feed=WSBK when the BSB
+            // feed's dispatched record is the group's primary). Auto-expand
+            // its group so the matching row is still reachable instead of
+            // silently vanishing.
+            rows.forEach(function (row, i) {
+                if (rawShow[i] && isChild(row)) expandedGroups.add(row.dataset.guid);
+            });
+
             var visible = 0;
-            rows.forEach(function (row) {
-                var show = true;
-
-                if (feed && row.dataset.feed !== feed) show = false;
-
-                if (show && !checked.has(row.dataset.outcome)) show = false;
-
-                if (show && labelPairs.length > 0) {
-                    var rl = row.dataset.labels || '';
-                    for (var i = 0; i < labelPairs.length; i++) {
-                        if (rl.indexOf(labelPairs[i]) === -1) { show = false; break; }
-                    }
-                }
-
+            rows.forEach(function (row, i) {
+                var show = rawShow[i] && (!isChild(row) || expandedGroups.has(row.dataset.guid));
                 row.style.display = show ? '' : 'none';
                 if (show) visible++;
             });
+
+            syncToggleGlyphs();
 
             // Update URL params so the 60-second meta-refresh preserves state.
             var p = new URLSearchParams();
@@ -241,6 +280,14 @@
 
         var rowsEl = document.getElementById('rows');
         rowsEl.addEventListener('click', function (e) {
+            var toggle = e.target.closest('.group-toggle');
+            if (toggle) {
+                var guid = toggle.dataset.guid;
+                if (expandedGroups.has(guid)) expandedGroups.delete(guid); else expandedGroups.add(guid);
+                apply();
+                return;
+            }
+
             var btn = e.target.closest('.btn-torrent');
             if (!btn) return;
 

--- a/cmd/rss4transmission/web/history.html
+++ b/cmd/rss4transmission/web/history.html
@@ -80,7 +80,9 @@
 
         .group-toggle { cursor: pointer; color: #888; user-select: none; display: inline-block; width: 1em; }
         .group-badge { color: #666; font-size: 0.82em; }
-        tr.group-child td { background: #202020; }
+        tr.group-child td { background: #232a33; }
+        tr.group-child:hover td { background: #2b333e; }
+        tr.group-child td:first-child { box-shadow: inset 3px 0 0 #3a6ea5; }
         tr.group-child td:nth-child(2) { padding-left: 1.8em; }
     </style>
 </head>

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -553,6 +553,149 @@ func TestHistoryPage_TorrentButtonShownWhenFeedStillConfigured(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), `class="btn-torrent"`)
 }
 
+// --- groupHistoryRows ---
+
+func TestGroupHistoryRows_DispatchedIsPrimaryOverSkipped(t *testing.T) {
+	records := []HistoryRecord{
+		NewHistoryRecord("WSBK", makeGofeedItem("BSB Title", "guid-1"), "skipped", "no group matched labels", nil),
+		NewHistoryRecord("WSS", makeGofeedItem("BSB Title", "guid-1"), "skipped", "no group matched labels", nil),
+		NewHistoryRecord("BSB", makeGofeedItem("BSB Title", "guid-1"), "dispatched", "", nil),
+		NewHistoryRecord("IOMTT", makeGofeedItem("BSB Title", "guid-1"), "skipped", "no group matched labels", nil),
+	}
+
+	rows := groupHistoryRows(records)
+
+	require.Len(t, rows, 4)
+	assert.True(t, rows[0].IsPrimary)
+	assert.Equal(t, "BSB", rows[0].Feed, "the dispatched record must be the primary row")
+	assert.Equal(t, 4, rows[0].GroupSize)
+
+	for _, r := range rows[1:] {
+		assert.False(t, r.IsPrimary)
+		assert.Equal(t, 4, r.GroupSize)
+	}
+	// Non-primary rows are sorted alphabetically by feed for deterministic rendering.
+	assert.Equal(t, "IOMTT", rows[1].Feed)
+	assert.Equal(t, "WSBK", rows[2].Feed)
+	assert.Equal(t, "WSS", rows[3].Feed)
+}
+
+func TestGroupHistoryRows_TieBreaksAlphabeticallyByFeed(t *testing.T) {
+	records := []HistoryRecord{
+		NewHistoryRecord("WSBK", makeGofeedItem("BSB Title", "guid-1"), "skipped", "no group matched labels", nil),
+		NewHistoryRecord("BSB", makeGofeedItem("BSB Title", "guid-1"), "skipped", "better version already in cache", nil),
+		NewHistoryRecord("IOMTT", makeGofeedItem("BSB Title", "guid-1"), "skipped", "no group matched labels", nil),
+	}
+
+	rows := groupHistoryRows(records)
+
+	require.Len(t, rows, 3)
+	assert.True(t, rows[0].IsPrimary)
+	assert.Equal(t, "BSB", rows[0].Feed, "equal outcomeRank ties break alphabetically by feed name")
+	assert.Equal(t, "IOMTT", rows[1].Feed)
+	assert.Equal(t, "WSBK", rows[2].Feed)
+}
+
+func TestGroupHistoryRows_EmptyGUIDNeverMerges(t *testing.T) {
+	records := []HistoryRecord{
+		NewHistoryRecord("feedA", makeGofeedItem("Title A", ""), "skipped", "no group matched labels", nil),
+		NewHistoryRecord("feedB", makeGofeedItem("Title B", ""), "skipped", "no group matched labels", nil),
+	}
+
+	rows := groupHistoryRows(records)
+
+	require.Len(t, rows, 2)
+	for _, r := range rows {
+		assert.True(t, r.IsPrimary)
+		assert.Equal(t, 1, r.GroupSize, "records with an empty GUID must never be grouped together")
+	}
+}
+
+func TestGroupHistoryRows_SingletonGroupIsPrimary(t *testing.T) {
+	records := []HistoryRecord{
+		NewHistoryRecord("onlyfeed", makeGofeedItem("Solo Title", "guid-solo"), "skipped", "excluded by regex", nil),
+	}
+
+	rows := groupHistoryRows(records)
+
+	require.Len(t, rows, 1)
+	assert.True(t, rows[0].IsPrimary)
+	assert.Equal(t, 1, rows[0].GroupSize)
+}
+
+func TestGroupHistoryRows_GroupsAreContiguousAtFirstAppearancePosition(t *testing.T) {
+	records := []HistoryRecord{
+		NewHistoryRecord("feedA", makeGofeedItem("First Title", "guid-1"), "skipped", "", nil),
+		NewHistoryRecord("feedB", makeGofeedItem("Second Title", "guid-2"), "skipped", "", nil),
+		NewHistoryRecord("feedC", makeGofeedItem("First Title", "guid-1"), "dispatched", "", nil),
+	}
+
+	rows := groupHistoryRows(records)
+
+	require.Len(t, rows, 3)
+	// guid-1 first appears at index 0, so both its records land contiguously
+	// there (dispatched primary first), pushing guid-2's single record last.
+	assert.Equal(t, "guid-1", rows[0].GUID)
+	assert.Equal(t, "feedC", rows[0].Feed)
+	assert.True(t, rows[0].IsPrimary)
+	assert.Equal(t, 2, rows[0].GroupSize)
+
+	assert.Equal(t, "guid-1", rows[1].GUID)
+	assert.Equal(t, "feedA", rows[1].Feed)
+	assert.False(t, rows[1].IsPrimary)
+	assert.Equal(t, 2, rows[1].GroupSize)
+
+	assert.Equal(t, "guid-2", rows[2].GUID)
+	assert.Equal(t, 1, rows[2].GroupSize)
+}
+
+func TestHistoryPage_GroupsRecordsSharingGUID(t *testing.T) {
+	h := emptyHistory()
+	h.AddOrUpdateRecord(NewHistoryRecord("BSB",
+		makeGofeedItemWithEnclosure("BSB Title", "guid-1", "https://example.com/bsb.torrent"),
+		"dispatched", "", nil))
+	h.AddOrUpdateRecord(NewHistoryRecord("WSS",
+		makeGofeedItemWithEnclosure("BSB Title", "guid-1", "https://example.com/bsb.torrent"),
+		"skipped", "no group matched labels", nil))
+	h.AddOrUpdateRecord(NewHistoryRecord("WSBK",
+		makeGofeedItemWithEnclosure("BSB Title", "guid-1", "https://example.com/bsb.torrent"),
+		"skipped", "no group matched labels", nil))
+	h.AddOrUpdateRecord(NewHistoryRecord("IOMTT",
+		makeGofeedItemWithEnclosure("BSB Title", "guid-1", "https://example.com/bsb.torrent"),
+		"skipped", "no group matched labels", nil))
+
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+
+	assert.Equal(t, 1, strings.Count(body, `class="group-toggle"`),
+		"exactly one primary row should carry the expand toggle")
+	assert.Contains(t, body, "+3")
+	assert.Equal(t, 3, strings.Count(body, `class="group-child"`),
+		"the three skipped records must render as hidden-by-default child rows")
+	assert.Equal(t, 3, strings.Count(body, `class="btn-torrent"`),
+		"each skipped child keeps its own retry button; the dispatched primary has none")
+}
+
+func TestHistoryPage_UniqueGUIDRendersUngrouped(t *testing.T) {
+	h := emptyHistory()
+	h.AddOrUpdateRecord(NewHistoryRecord("myfeed", makeGofeedItem("Solo Title", "guid-solo"), "skipped", "excluded by regex", nil))
+
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	assert.NotContains(t, body, `class="group-toggle"`)
+	assert.NotContains(t, body, `class="group-child"`)
+}
+
 // --- POST /torrent ---
 
 func makeRetryFunc(called *bool, gotRec *HistoryRecord, id int64, err error) retryFunc {

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -614,6 +614,22 @@ func TestGroupHistoryRows_PrefersInformativeReasonOverNoGroupMatched(t *testing.
 	assert.Equal(t, "Moto3", rows[2].Feed)
 }
 
+func TestGroupHistoryRows_NoGroupMatchedIsLowestPriorityAcrossOutcomes(t *testing.T) {
+	records := []HistoryRecord{
+		NewHistoryRecord("BSB", makeGofeedItem("BSB Title", "guid-1"), "skipped", skipReasonNoGroupMatched, nil),
+		NewHistoryRecord("WSBK", makeGofeedItem("BSB Title", "guid-1"), "excluded", "matched exclude filter", nil),
+	}
+
+	rows := groupHistoryRows(records)
+
+	require.Len(t, rows, 2)
+	assert.True(t, rows[0].IsPrimary)
+	assert.Equal(t, "WSBK", rows[0].Feed,
+		"\"no group matched labels\" must be the lowest priority of all, even below an excluded outcome "+
+			"which normally ranks worse than skipped per outcomeRank")
+	assert.Equal(t, "BSB", rows[1].Feed)
+}
+
 func TestGroupHistoryRows_EmptyGUIDNeverMerges(t *testing.T) {
 	records := []HistoryRecord{
 		NewHistoryRecord("feedA", makeGofeedItem("Title A", ""), "skipped", "no group matched labels", nil),

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -23,7 +23,7 @@ import (
 // --- /healthz ---
 
 func TestHealthzHandler(t *testing.T) {
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	req := httptest.NewRequest("GET", "/healthz", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -78,7 +78,7 @@ func TestGetCancelHandler_RendersForm(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -103,7 +103,7 @@ func TestGetCancelHandler_RendersProgress(t *testing.T) {
 	// 2.5 GiB downloaded, 25% done
 	getProgress := makeProgressFunc(int64(2.5*float64(1<<30)), 0.25)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), getProgress, nil)
 
 	req := httptest.NewRequest("GET",
@@ -128,7 +128,7 @@ func TestGetCancelHandler_ProgressUnknownOnError(t *testing.T) {
 		return 0, 0, fmt.Errorf("transmission unavailable")
 	}
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), errProgress, nil)
 
 	req := httptest.NewRequest("GET",
@@ -143,7 +143,7 @@ func TestGetCancelHandler_ProgressUnknownOnError(t *testing.T) {
 func TestGetCancelHandler_MissingParams(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET", "/cancel?id=test-id", nil)
@@ -159,7 +159,7 @@ func TestGetCancelHandler_BadSignature(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -176,7 +176,7 @@ func TestGetCancelHandler_Expired(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -192,7 +192,7 @@ func TestGetCancelHandler_NotFound(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -210,7 +210,7 @@ func TestGetCancelHandler_DoesNotConsumeEntry(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	removed := false
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), nil)
 
@@ -237,7 +237,7 @@ func TestPostCancelHandler_Valid(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	removed := false
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -253,7 +253,7 @@ func TestPostCancelHandler_Valid(t *testing.T) {
 func TestPostCancelHandler_MissingParams(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := strings.NewReader("id=test-id") // missing expires and sig
@@ -271,7 +271,7 @@ func TestPostCancelHandler_BadSignature(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, "badsig")
@@ -289,7 +289,7 @@ func TestPostCancelHandler_Expired(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -306,7 +306,7 @@ func TestPostCancelHandler_NotFound(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("ghost-id", expires, sig)
@@ -387,7 +387,7 @@ func TestPostCancelHandler_RemoveErrorPreservesStoreEntry(t *testing.T) {
 	failRemove := func(_ context.Context, _ []int64) error {
 		return fmt.Errorf("transmission unreachable")
 	}
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, failRemove, noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -408,7 +408,7 @@ func TestGetCancelHandler_ZeroBytesProgressBothUnknown(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	// brand-new torrent: 0 bytes downloaded, 0% done
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), makeProgressFunc(0, 0.0), nil)
 
 	req := httptest.NewRequest("GET",
@@ -458,7 +458,7 @@ func TestHistoryPage_RendersTorrentButtonForSkippedWithURL(t *testing.T) {
 		"skipped", "lost preference contest", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -475,7 +475,7 @@ func TestHistoryPage_NoTorrentButtonWithoutURL(t *testing.T) {
 	rec := NewHistoryRecord("myfeed", makeGofeedItem("No Enclosure", "guid-2"), "excluded", "matched exclude", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -491,7 +491,7 @@ func TestHistoryPage_NoTorrentButtonForDispatched(t *testing.T) {
 		"dispatched", "", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -509,7 +509,7 @@ func TestHistoryPage_TorrentButtonShownWhenFeedConfiguredNil(t *testing.T) {
 
 	// A nil feedConfigured means "no filter" — button shows unconditionally,
 	// matching every existing caller that doesn't care about live config.
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -526,7 +526,7 @@ func TestHistoryPage_TorrentButtonHiddenWhenFeedNotConfigured(t *testing.T) {
 	h.AddOrUpdateRecord(rec)
 
 	feedConfigured := func(name string) bool { return name == "still-here" }
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), feedConfigured)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), feedConfigured, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -544,7 +544,7 @@ func TestHistoryPage_TorrentButtonShownWhenFeedStillConfigured(t *testing.T) {
 	h.AddOrUpdateRecord(rec)
 
 	feedConfigured := func(name string) bool { return name == "still-here" }
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), feedConfigured)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), feedConfigured, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -563,7 +563,7 @@ func TestGroupHistoryRows_DispatchedIsPrimaryOverSkipped(t *testing.T) {
 		NewHistoryRecord("IOMTT", makeGofeedItem("BSB Title", "guid-1"), "skipped", "no group matched labels", nil),
 	}
 
-	rows := groupHistoryRows(records)
+	rows := groupHistoryRows(records, nil)
 
 	require.Len(t, rows, 4)
 	assert.True(t, rows[0].IsPrimary)
@@ -587,7 +587,7 @@ func TestGroupHistoryRows_TieBreaksAlphabeticallyByFeed(t *testing.T) {
 		NewHistoryRecord("IOMTT", makeGofeedItem("BSB Title", "guid-1"), "skipped", "no group matched labels", nil),
 	}
 
-	rows := groupHistoryRows(records)
+	rows := groupHistoryRows(records, nil)
 
 	require.Len(t, rows, 3)
 	assert.True(t, rows[0].IsPrimary)
@@ -603,7 +603,7 @@ func TestGroupHistoryRows_PrefersInformativeReasonOverNoGroupMatched(t *testing.
 		NewHistoryRecord("MotoGP", makeGofeedItem("MotoGP Title", "guid-1"), "skipped", skipReasonCacheBetter, nil),
 	}
 
-	rows := groupHistoryRows(records)
+	rows := groupHistoryRows(records, nil)
 
 	require.Len(t, rows, 3)
 	assert.True(t, rows[0].IsPrimary)
@@ -620,7 +620,7 @@ func TestGroupHistoryRows_NoGroupMatchedIsLowestPriorityAcrossOutcomes(t *testin
 		NewHistoryRecord("WSBK", makeGofeedItem("BSB Title", "guid-1"), "excluded", "matched exclude filter", nil),
 	}
 
-	rows := groupHistoryRows(records)
+	rows := groupHistoryRows(records, nil)
 
 	require.Len(t, rows, 2)
 	assert.True(t, rows[0].IsPrimary)
@@ -636,7 +636,7 @@ func TestGroupHistoryRows_EmptyGUIDNeverMerges(t *testing.T) {
 		NewHistoryRecord("feedB", makeGofeedItem("Title B", ""), "skipped", "no group matched labels", nil),
 	}
 
-	rows := groupHistoryRows(records)
+	rows := groupHistoryRows(records, nil)
 
 	require.Len(t, rows, 2)
 	for _, r := range rows {
@@ -650,7 +650,7 @@ func TestGroupHistoryRows_SingletonGroupIsPrimary(t *testing.T) {
 		NewHistoryRecord("onlyfeed", makeGofeedItem("Solo Title", "guid-solo"), "skipped", "excluded by regex", nil),
 	}
 
-	rows := groupHistoryRows(records)
+	rows := groupHistoryRows(records, nil)
 
 	require.Len(t, rows, 1)
 	assert.True(t, rows[0].IsPrimary)
@@ -664,7 +664,7 @@ func TestGroupHistoryRows_GroupsAreContiguousAtFirstAppearancePosition(t *testin
 		NewHistoryRecord("feedC", makeGofeedItem("First Title", "guid-1"), "dispatched", "", nil),
 	}
 
-	rows := groupHistoryRows(records)
+	rows := groupHistoryRows(records, nil)
 
 	require.Len(t, rows, 3)
 	// guid-1 first appears at index 0, so both its records land contiguously
@@ -683,6 +683,89 @@ func TestGroupHistoryRows_GroupsAreContiguousAtFirstAppearancePosition(t *testin
 	assert.Equal(t, 1, rows[2].GroupSize)
 }
 
+func TestGroupHistoryRows_MatchScoreBreaksNoGroupMatchedTie(t *testing.T) {
+	// All three records are fully tied through isNoGroupMatched and outcomeRank.
+	// MotoGP/Moto2/Moto3 share one Extractor, so every sibling extracted the
+	// same class=MotoGP label from this genuinely-MotoGP-titled item. Only
+	// MotoGP's own Require is actually satisfied by that value; Moto2 and
+	// Moto3's own Require values are contradicted by it, so they must score
+	// no better than a plain alphabetical tie.
+	records := []HistoryRecord{
+		NewHistoryRecord("Moto2", makeGofeedItem("MotoGP Title", "guid-1"), "skipped", skipReasonNoGroupMatched,
+			map[string]string{"class": "MotoGP"}),
+		NewHistoryRecord("Moto3", makeGofeedItem("MotoGP Title", "guid-1"), "skipped", skipReasonNoGroupMatched,
+			map[string]string{"class": "MotoGP"}),
+		NewHistoryRecord("MotoGP", makeGofeedItem("MotoGP Title", "guid-1"), "skipped", skipReasonNoGroupMatched,
+			map[string]string{"class": "MotoGP"}),
+	}
+	feedGroups := func(name string) []Group {
+		switch name {
+		case "MotoGP":
+			return []Group{{Require: map[string][]string{"class": {"MotoGP"}}}}
+		case "Moto2":
+			return []Group{{Require: map[string][]string{"class": {"Moto2"}}}}
+		case "Moto3":
+			return []Group{{Require: map[string][]string{"class": {"Moto3"}}}}
+		}
+		return nil
+	}
+
+	rows := groupHistoryRows(records, feedGroups)
+
+	require.Len(t, rows, 3)
+	assert.True(t, rows[0].IsPrimary)
+	assert.Equal(t, "MotoGP", rows[0].Feed,
+		"the record whose own group Require is actually satisfied by its labels must win, even though "+
+			"its siblings extracted the identical labels via a shared Extractor")
+	assert.Equal(t, "Moto2", rows[1].Feed)
+	assert.Equal(t, "Moto3", rows[2].Feed)
+}
+
+func TestGroupHistoryRows_MatchScoreIgnoresGroupsWithNoOverlap(t *testing.T) {
+	// BSB/WSBK/WSS/MotoAmerica/IOMTT share one URL as an optimization, not
+	// because they're related — a genuinely BSB item may leave the other
+	// feeds with zero overlapping labels at all (not a contradiction, just
+	// absence). Absence must not count as evidence either way; BSB's own
+	// positive match must still win over a plain alphabetical fallback.
+	records := []HistoryRecord{
+		NewHistoryRecord("WSBK", makeGofeedItem("BSB Title", "guid-1"), "skipped", skipReasonNoGroupMatched,
+			map[string]string{"series": "BSB"}),
+		NewHistoryRecord("BSB", makeGofeedItem("BSB Title", "guid-1"), "skipped", skipReasonNoGroupMatched,
+			map[string]string{"series": "BSB"}),
+	}
+	feedGroups := func(name string) []Group {
+		switch name {
+		case "BSB":
+			return []Group{{Require: map[string][]string{"series": {"BSB"}}}}
+		case "WSBK":
+			// WSBK's own Require key ("class") never even appears in these
+			// labels — zero overlap, not a contradiction.
+			return []Group{{Require: map[string][]string{"class": {"Superbike"}}}}
+		}
+		return nil
+	}
+
+	rows := groupHistoryRows(records, feedGroups)
+
+	require.Len(t, rows, 2)
+	assert.True(t, rows[0].IsPrimary)
+	assert.Equal(t, "BSB", rows[0].Feed,
+		"BSB's positive match must win even though WSBK sorts first alphabetically")
+}
+
+func TestGroupHistoryRows_NilFeedGroupsFallsBackToAlphabetical(t *testing.T) {
+	records := []HistoryRecord{
+		NewHistoryRecord("WSBK", makeGofeedItem("BSB Title", "guid-1"), "skipped", skipReasonNoGroupMatched, nil),
+		NewHistoryRecord("BSB", makeGofeedItem("BSB Title", "guid-1"), "skipped", skipReasonNoGroupMatched, nil),
+	}
+
+	rows := groupHistoryRows(records, nil)
+
+	require.Len(t, rows, 2)
+	assert.True(t, rows[0].IsPrimary)
+	assert.Equal(t, "BSB", rows[0].Feed, "a nil feedGroups must behave like every feed scoring 0")
+}
+
 func TestHistoryPage_GroupsRecordsSharingGUID(t *testing.T) {
 	h := emptyHistory()
 	h.AddOrUpdateRecord(NewHistoryRecord("BSB",
@@ -698,7 +781,7 @@ func TestHistoryPage_GroupsRecordsSharingGUID(t *testing.T) {
 		makeGofeedItemWithEnclosure("BSB Title", "guid-1", "https://example.com/bsb.torrent"),
 		"skipped", "no group matched labels", nil))
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -715,11 +798,53 @@ func TestHistoryPage_GroupsRecordsSharingGUID(t *testing.T) {
 		"each skipped child keeps its own retry button; the dispatched primary has none")
 }
 
+func TestHistoryPage_FeedGroupsBreaksNoGroupMatchedTie(t *testing.T) {
+	h := emptyHistory()
+	h.AddOrUpdateRecord(NewHistoryRecord("Moto2",
+		makeGofeedItemWithEnclosure("MotoGP Title", "guid-1", "https://example.com/motogp.torrent"),
+		"skipped", "no group matched labels", map[string]string{"class": "MotoGP"}))
+	h.AddOrUpdateRecord(NewHistoryRecord("Moto3",
+		makeGofeedItemWithEnclosure("MotoGP Title", "guid-1", "https://example.com/motogp.torrent"),
+		"skipped", "no group matched labels", map[string]string{"class": "MotoGP"}))
+	h.AddOrUpdateRecord(NewHistoryRecord("MotoGP",
+		makeGofeedItemWithEnclosure("MotoGP Title", "guid-1", "https://example.com/motogp.torrent"),
+		"skipped", "no group matched labels", map[string]string{"class": "MotoGP"}))
+
+	feedGroups := func(name string) []Group {
+		switch name {
+		case "MotoGP":
+			return []Group{{Require: map[string][]string{"class": {"MotoGP"}}}}
+		case "Moto2":
+			return []Group{{Require: map[string][]string{"class": {"Moto2"}}}}
+		case "Moto3":
+			return []Group{{Require: map[string][]string{"class": {"Moto3"}}}}
+		}
+		return nil
+	}
+
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, feedGroups)
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+
+	primaryIdx := strings.Index(body, `class="group-toggle"`)
+	require.NotEqual(t, -1, primaryIdx, "expected a primary row with the expand toggle")
+	rowStart := strings.LastIndex(body[:primaryIdx], "<tr")
+	rowEnd := strings.Index(body[primaryIdx:], "</tr>") + primaryIdx
+	primaryRow := body[rowStart:rowEnd]
+	assert.Contains(t, primaryRow, `data-feed="MotoGP"`,
+		"the record whose own group Require is actually satisfied by its labels must be the primary row, "+
+			"even though its siblings extracted the identical labels via a shared Extractor")
+}
+
 func TestHistoryPage_UniqueGUIDRendersUngrouped(t *testing.T) {
 	h := emptyHistory()
 	h.AddOrUpdateRecord(NewHistoryRecord("myfeed", makeGofeedItem("Solo Title", "guid-solo"), "skipped", "excluded by regex", nil))
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -756,7 +881,7 @@ func TestPostTorrentHandler_Success(t *testing.T) {
 
 	called := false
 	var gotRec HistoryRecord
-	mux := newWebMux(h, makeRetryFunc(&called, &gotRec, 7, nil), nil)
+	mux := newWebMux(h, makeRetryFunc(&called, &gotRec, 7, nil), nil, nil)
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -772,7 +897,7 @@ func TestPostTorrentHandler_Success(t *testing.T) {
 func TestPostTorrentHandler_UnknownRecord(t *testing.T) {
 	h := emptyHistory()
 	called := false
-	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, nil), nil)
+	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, nil), nil, nil)
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("ghost-feed", "ghost-guid"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -789,7 +914,7 @@ func TestPostTorrentHandler_RetryError(t *testing.T) {
 	h.AddOrUpdateRecord(rec)
 
 	called := false
-	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, fmt.Errorf("boom: no torrent URL")), nil)
+	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, fmt.Errorf("boom: no torrent URL")), nil, nil)
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -806,7 +931,7 @@ func TestPostTorrentHandler_NotRegisteredWhenRetryNil(t *testing.T) {
 	rec := NewHistoryRecord("myfeed", makeGofeedItem("My Title", "guid-1"), "skipped", "", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, nil, nil)
+	mux := newWebMux(h, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -839,7 +964,7 @@ func TestGetCancelHandler_AccessLog_InvalidToken(t *testing.T) {
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -859,7 +984,7 @@ func TestGetCancelHandler_AccessLog_MissingParams(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET", "/cancel?id=test-id", nil)
@@ -879,7 +1004,7 @@ func TestGetCancelHandler_AccessLog_Expired(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -900,7 +1025,7 @@ func TestGetCancelHandler_AccessLog_NotFound(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -922,7 +1047,7 @@ func TestGetCancelHandler_AccessLog_Success(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -943,7 +1068,7 @@ func TestGetCancelHandler_AccessLog_NilNoOp(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -962,7 +1087,7 @@ func TestPostCancelHandler_AccessLog_InvalidToken(t *testing.T) {
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, "badsig")
@@ -985,7 +1110,7 @@ func TestPostCancelHandler_AccessLog_Expired(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -1007,7 +1132,7 @@ func TestPostCancelHandler_AccessLog_NotFound(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("ghost-id", expires, sig)
@@ -1031,7 +1156,7 @@ func TestPostCancelHandler_AccessLog_Success(t *testing.T) {
 
 	lg, buf := makeTestAccessLogger()
 	removed := false
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -1058,7 +1183,7 @@ func TestPostCancelHandler_AccessLog_TransmissionError(t *testing.T) {
 	failRemove2 := func(_ context.Context, _ []int64) error {
 		return fmt.Errorf("transmission unreachable")
 	}
-	mux := newWebMux(nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, failRemove2, noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, sig)

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -596,6 +596,24 @@ func TestGroupHistoryRows_TieBreaksAlphabeticallyByFeed(t *testing.T) {
 	assert.Equal(t, "WSBK", rows[2].Feed)
 }
 
+func TestGroupHistoryRows_PrefersInformativeReasonOverNoGroupMatched(t *testing.T) {
+	records := []HistoryRecord{
+		NewHistoryRecord("Moto2", makeGofeedItem("MotoGP Title", "guid-1"), "skipped", skipReasonNoGroupMatched, nil),
+		NewHistoryRecord("Moto3", makeGofeedItem("MotoGP Title", "guid-1"), "skipped", skipReasonNoGroupMatched, nil),
+		NewHistoryRecord("MotoGP", makeGofeedItem("MotoGP Title", "guid-1"), "skipped", skipReasonCacheBetter, nil),
+	}
+
+	rows := groupHistoryRows(records)
+
+	require.Len(t, rows, 3)
+	assert.True(t, rows[0].IsPrimary)
+	assert.Equal(t, "MotoGP", rows[0].Feed,
+		"a record that actually matched this feed's groups but lost a preference contest is more "+
+			"informative than a sibling feed that never matched at all, even though it sorts later alphabetically")
+	assert.Equal(t, "Moto2", rows[1].Feed)
+	assert.Equal(t, "Moto3", rows[2].Feed)
+}
+
 func TestGroupHistoryRows_EmptyGUIDNeverMerges(t *testing.T) {
 	records := []HistoryRecord{
 		NewHistoryRecord("feedA", makeGofeedItem("Title A", ""), "skipped", "no group matched labels", nil),

--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -34,24 +34,24 @@ a single-capture regex and an optional normalize map:
 
 ```yaml
 Extractors:
-  motogp:
+  talkshow:
     Labels:
-      series:
-        Regexp: '(?i)(MotoGP|Moto2|Moto3)'
+      edition:
+        Regexp: '(?i)(US|UK|AU)\.Edition'
         Normalize:
-          '(?i)motogp': 'MotoGP'
-          '(?i)moto2': 'Moto2'
-          '(?i)moto3': 'Moto3'
-      round:
-        Regexp: 'RD(\d+)'
-      session:
-        Regexp: '(?i)(Race|Qualifying|Sprint|Practice\d*)'
+          '(?i)us': 'US'
+          '(?i)uk': 'UK'
+          '(?i)au': 'AU'
+      episode:
+        Regexp: 'E(\d+)'
+      segment:
+        Regexp: '(?i)(FullEpisode|Recap|Preview)'
         Normalize:
-          'Qual[^.]*': 'Qualifying'
+          'Rec[^.]*': 'Recap'
       resolution:
         Regexp: '(\d{3,4}p)'
       network:
-        Regexp: '(?i)\.(TNT|NBC|Sky|BT)\.'
+        Regexp: '(?i)\.(NBC|Sky|BT|AMZN)\.'
 ```
 
 - **Regexp**: must contain exactly one capture group — the value of that group becomes the label
@@ -68,23 +68,23 @@ A feed enters label mode when `Extractor` is set:
 
 ```yaml
 Feeds:
-  - Name: MotoGP2024
+  - Name: TalkShowUS
     URL: https://rss.example.com/feed
-    DownloadPath: /torrents/motogp
+    DownloadPath: /torrents/talkshow
     Exclude:
-      - '.*Highlights.*'
-    Extractor: motogp          # references an Extractor defined above
-    Identity: [series, round, session]   # uniquely identifies one event
+      - '.*Bloopers.*'
+    Extractor: talkshow          # references an Extractor defined above
+    Identity: [edition, episode, segment]   # uniquely identifies one broadcast
     Prefer:
       - label: resolution
         order: [1080p, 720p]   # 1080p wins over 720p; unlisted values rank lowest
       - label: network
-        order: [TNT, NBC]      # tiebreaker if resolution is equal
+        order: [NBC, Sky]      # tiebreaker if resolution is equal
     Groups:
       - Require:
-          series: [MotoGP]
+          edition: [US]
       - Require:
-          series: [Moto2, Moto3]
+          edition: [UK, AU]
 ```
 
 **How it works:**
@@ -95,11 +95,11 @@ Feeds:
    values).
 3. Each passing candidate's `.torrent` file is fetched and its file names are extracted. Title
    labels and file labels are unioned.
-4. Candidates sharing the same `Identity` key (e.g. `series=MotoGP|round=1|session=Race`) compete.
-   The winner is the highest-ranked candidate by the `Prefer` ordering not already bettered in the
-   seen cache.
-5. A multi-class bundle (one torrent covering MotoGP + Moto2 + Moto3 files) is submitted once but
-   recorded against all covered identity keys.
+4. Candidates sharing the same `Identity` key (e.g. `edition=US|episode=1|segment=FullEpisode`)
+   compete. The winner is the highest-ranked candidate by the `Prefer` ordering not already
+   bettered in the seen cache.
+5. A multi-edition bundle (one torrent covering the US + UK + AU files together) is submitted once
+   but recorded against all covered identity keys.
 
 ## Full Configuration Example
 
@@ -118,33 +118,33 @@ SeenFile:      /config/seen.json
 SeenCacheDays: 30  # prune records older than this many days
 
 Extractors:
-  motogp:
+  talkshow:
     Labels:
-      series:
-        Regexp: '(?i)(MotoGP|Moto2|Moto3)'
+      edition:
+        Regexp: '(?i)(US|UK|AU)\.Edition'
         Normalize:
-          '(?i)motogp': 'MotoGP'
-          '(?i)moto2': 'Moto2'
-          '(?i)moto3': 'Moto3'
-      round:
-        Regexp: 'RD(\d+)'
-      session:
-        Regexp: '(?i)(Race|Qualifying|Sprint)'
+          '(?i)us': 'US'
+          '(?i)uk': 'UK'
+          '(?i)au': 'AU'
+      episode:
+        Regexp: 'E(\d+)'
+      segment:
+        Regexp: '(?i)(FullEpisode|Recap)'
         Normalize:
-          'Qual[^.]*': 'Qualifying'
+          'Rec[^.]*': 'Recap'
       resolution:
         Regexp: '(\d{3,4}p)'
 
 Feeds:
-  - Name: MotoGP2024
+  - Name: TalkShow2024
     URL: https://rss.example.com/feed
-    DownloadPath: /torrents/motogp
-    Extractor: motogp
-    Identity: [series, round, session]
+    DownloadPath: /torrents/talkshow
+    Extractor: talkshow
+    Identity: [edition, episode, segment]
     Prefer:
       - label: resolution
         order: [1080p, 720p]
     Groups:
       - Require:
-          series: [MotoGP, Moto2, Moto3]
+          edition: [US, UK, AU]
 ```

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -261,6 +261,18 @@ rss4transmission watch --config config.yaml \
 The history page shows each item's feed name, title, publication date, outcome, and extracted
 labels. Records are pruned on the same schedule as the seen cache (`SeenCacheDays`).
 
+When multiple sibling feeds share one RSS URL — for example, separate feeds for different
+categories of content that all happen to be published through the same feed URL — the same item
+produces one history record per sibling. These are collapsed into a single expandable group
+instead of a wall of near-duplicate rows. The visible parent row is chosen by, in order: a record
+that actually engaged with the item beats one whose `Groups` never matched at all; among those,
+the more informative outcome wins; remaining ties prefer whichever sibling's own extracted labels
+actually satisfy its own `Groups.Require` constraints (see
+[Feeds & Labels](feeds.md#label-based-feed-configuration)) — this matters because siblings that
+share an `Extractor` can extract identical-looking labels for an item that isn't actually theirs,
+so only a label value that satisfies a feed's own `Require` counts as evidence. Any remaining tie
+breaks alphabetically by feed name.
+
 Rows with outcome `skipped`, `excluded`, or `error` show a **Torrent** button when a `.torrent`
 URL was captured for that item, letting you manually re-submit it to Transmission without waiting
 for the feed to re-offer it. Clicking it re-fetches the `.torrent` fresh, submits it exactly like


### PR DESCRIPTION
## Summary
- Collapse history rows sharing a GUID (the same RSS item seen by multiple sibling feeds that share one RSS URL) into a single expandable group, choosing a sensible primary/parent row instead of a wall of near-duplicate rows.
- Primary-row tie-break order: an engaged record beats one whose `Groups` never matched at all → more informative outcome wins → strongest positive `Group.MatchScore` evidence wins → alphabetical by feed name.
- `Group.MatchScore` scores a feed's own `Groups.Require` against a record's own extracted labels: present+matching keys count, absent keys are ignored, but any present *contradicting* key disqualifies the whole group. This specifically prevents sibling feeds that share an `Extractor` from false-crediting a tie via incidental label overlap on an item that isn't actually theirs.
- Threaded a new `feedGroups func(name string) []Group` closure through `newWebMux`/`watch.go`, mirroring the existing `feedConfigured` pattern, so the tie-break reflects the live (possibly reloaded) config.
- Updated `docs/feeds.md` and `docs/notifications.md` to document the grouping/tie-break behavior, using a generic example domain instead of a niche one.

## Test plan
- [x] `make test` (go vet + full unit suite)
- [x] `gofmt -l` clean
- [x] `golangci-lint run` clean (`make lint`)
- [x] New unit tests cover: shared-Extractor false-positive avoidance, zero-label-overlap siblings, nil `feedGroups` fallback to alphabetical, and end-to-end handler-level rendering of the correct primary row

🤖 Generated with [Claude Code](https://claude.com/claude-code)