### PR TITLE
Stop reprocessing feed backlog when history.json is empty; add a Forget button

### DIFF
--- a/cmd/rss4transmission/cache.go
+++ b/cmd/rss4transmission/cache.go
@@ -197,6 +197,34 @@ func (c *CacheFile) AddItem(item *FeedItem, labels map[string]string, identityKe
 	c.needSave = true
 }
 
+// RemoveEntry removes the Seen record(s) matching feedName+guid, letting the
+// item be re-evaluated on the next run (e.g. after a config change). Returns
+// true if anything was removed.
+func (c *CacheFile) RemoveEntry(feedName, guid string) bool {
+	removed := false
+	rebuildIndex := false
+	newSeen := make([]CacheRecord, 0, len(c.Seen))
+	for _, s := range c.Seen {
+		if s.Feed == feedName && s.GUID == guid {
+			removed = true
+			if len(s.Labels) > 0 {
+				rebuildIndex = true
+			}
+			continue
+		}
+		newSeen = append(newSeen, s)
+	}
+	if !removed {
+		return false
+	}
+	c.Seen = newSeen
+	if rebuildIndex {
+		c.rebuildIdentityIndex()
+	}
+	c.needSave = true
+	return true
+}
+
 // Exists checks to see if the given FeedItem already exists in the Seen cache
 // by GUID and feed name (legacy compatibility check).
 func (c *CacheFile) Exists(feedName string, item *FeedItem) bool {

--- a/cmd/rss4transmission/cache_test.go
+++ b/cmd/rss4transmission/cache_test.go
@@ -124,6 +124,72 @@ func TestAddSkippedItem_DoesNotUpdateIdentityIndex(t *testing.T) {
 	}
 }
 
+func TestRemoveEntry_RemovesExisting(t *testing.T) {
+	fi := makeFeedItem("guid-remove")
+	c := &CacheFile{
+		Version:       CACHE_VERSION,
+		Errors:        map[string]int64{},
+		Seen:          []CacheRecord{},
+		identityIndex: map[string][]map[string]string{},
+	}
+	c.AddSkippedItem(fi)
+	c.needSave = false
+
+	removed := c.RemoveEntry("testfeed", "guid-remove")
+
+	if !removed {
+		t.Error("expected RemoveEntry to report true for an existing entry")
+	}
+	if c.Exists("testfeed", fi) {
+		t.Error("expected GUID to no longer be in Seen after RemoveEntry")
+	}
+	if !c.needSave {
+		t.Error("needSave should be true after RemoveEntry")
+	}
+}
+
+func TestRemoveEntry_RebuildsIdentityIndex(t *testing.T) {
+	fi := makeFeedItem("guid-remove-identity")
+	c := &CacheFile{
+		Version:       CACHE_VERSION,
+		Errors:        map[string]int64{},
+		Seen:          []CacheRecord{},
+		identityIndex: map[string][]map[string]string{},
+	}
+	labels := map[string]string{"series": "MotoGP"}
+	c.AddItem(fi, labels, []string{"series=MotoGP"})
+
+	c.RemoveEntry("testfeed", "guid-remove-identity")
+
+	if _, ok := c.identityIndex["series=MotoGP"]; ok {
+		t.Errorf("expected identityIndex to no longer contain the removed entry's key, got %v", c.identityIndex)
+	}
+}
+
+func TestRemoveEntry_UnknownPair_NoOp(t *testing.T) {
+	fi := makeFeedItem("guid-keep")
+	c := &CacheFile{
+		Version:       CACHE_VERSION,
+		Errors:        map[string]int64{},
+		Seen:          []CacheRecord{},
+		identityIndex: map[string][]map[string]string{},
+	}
+	c.AddSkippedItem(fi)
+	c.needSave = false
+
+	removed := c.RemoveEntry("testfeed", "guid-does-not-exist")
+
+	if removed {
+		t.Error("expected RemoveEntry to report false for an unknown (feed, guid) pair")
+	}
+	if len(c.Seen) != 1 {
+		t.Errorf("expected existing entries to be untouched, got %d", len(c.Seen))
+	}
+	if c.needSave {
+		t.Error("needSave should remain false when nothing was removed")
+	}
+}
+
 func TestAddItem(t *testing.T) {
 	c := &CacheFile{
 		Version:       CACHE_VERSION,

--- a/cmd/rss4transmission/history.go
+++ b/cmd/rss4transmission/history.go
@@ -182,6 +182,24 @@ func (h *HistoryFile) FindRecord(feedName, guid string) (HistoryRecord, bool) {
 	return h.Records[idx], true
 }
 
+// RemoveRecord removes the record matching feedName+guid, if any, so it stops
+// showing in the history page and can be freshly re-evaluated on the next
+// run (paired with CacheFile.RemoveEntry via the "Forget" web action).
+// Returns true if a record was removed.
+func (h *HistoryFile) RemoveRecord(feedName, guid string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	key := historyKey(feedName, guid)
+	idx, ok := h.guidIndex[key]
+	if !ok {
+		return false
+	}
+	h.Records = append(h.Records[:idx], h.Records[idx+1:]...)
+	h.rebuildGUIDIndex()
+	return true
+}
+
 // GetRecords returns a copy of all records for safe concurrent reads.
 func (h *HistoryFile) GetRecords() []HistoryRecord {
 	h.mu.RLock()

--- a/cmd/rss4transmission/history_test.go
+++ b/cmd/rss4transmission/history_test.go
@@ -161,6 +161,58 @@ func TestFindRecord_NotFound(t *testing.T) {
 	}
 }
 
+// --- RemoveRecord ---
+
+func TestRemoveRecord_RemovesExisting(t *testing.T) {
+	h := emptyHistory()
+	h.AddOrUpdateRecord(NewHistoryRecord("feed", makeGofeedItem("Show", "guid1"), "skipped", "reason", nil))
+
+	removed := h.RemoveRecord("feed", "guid1")
+
+	if !removed {
+		t.Error("expected RemoveRecord to report true for an existing record")
+	}
+	if _, ok := h.FindRecord("feed", "guid1"); ok {
+		t.Error("expected record to no longer be found after RemoveRecord")
+	}
+	if len(h.GetRecords()) != 0 {
+		t.Errorf("expected Records to be empty after RemoveRecord, got %d", len(h.GetRecords()))
+	}
+}
+
+func TestRemoveRecord_UnknownPair_NoOp(t *testing.T) {
+	h := emptyHistory()
+	h.AddOrUpdateRecord(NewHistoryRecord("feed", makeGofeedItem("Show", "guid1"), "skipped", "reason", nil))
+
+	removed := h.RemoveRecord("feed", "guid-missing")
+
+	if removed {
+		t.Error("expected RemoveRecord to report false for an unknown (feed, guid) pair")
+	}
+	if len(h.GetRecords()) != 1 {
+		t.Errorf("expected existing records to be untouched, got %d", len(h.GetRecords()))
+	}
+}
+
+func TestRemoveRecord_IndexAllowsReAdd(t *testing.T) {
+	h := emptyHistory()
+	h.AddOrUpdateRecord(NewHistoryRecord("feed", makeGofeedItem("Show", "guid1"), "excluded", "old reason", nil))
+	h.RemoveRecord("feed", "guid1")
+
+	// After removal, re-adding the same GUID with a "worse" outcome rank
+	// (excluded) must not be blocked by AddOrUpdateRecord's stale guidIndex
+	// entry — proving rebuildGUIDIndex ran.
+	h.AddOrUpdateRecord(NewHistoryRecord("feed", makeGofeedItem("Show", "guid1"), "excluded", "new reason", nil))
+
+	rec, ok := h.FindRecord("feed", "guid1")
+	if !ok {
+		t.Fatal("expected re-added record to be found")
+	}
+	if rec.Reason != "new reason" {
+		t.Errorf("Reason = %q, want %q", rec.Reason, "new reason")
+	}
+}
+
 // --- AddOrUpdateRecord ---
 
 func TestAddOrUpdateRecord_NewGUID(t *testing.T) {

--- a/cmd/rss4transmission/once.go
+++ b/cmd/rss4transmission/once.go
@@ -186,6 +186,7 @@ func (cmd *OnceCmd) processFeed(ctx *RunContext, feedName string, feedCfg Feed, 
 		ok, reason := feedCfg.Check(item)
 		if !ok {
 			ctx.recordHistory(feedName, item, "excluded", reason, titleLabels)
+			ctx.Cache.AddSkippedItem(fi)
 			continue
 		}
 		candidates = append(candidates, &candidate{
@@ -216,7 +217,7 @@ func (cmd *OnceCmd) processFeed(ctx *RunContext, feedName string, feedCfg Feed, 
 
 	// Phase 3: Select highest-preference winner per identity key.
 	winners, skipped := selectWinners(candidates, feedCfg, ctx.Cache)
-	markCacheRejectedSeen(skipped, ctx.Cache)
+	markSkippedSeen(skipped, ctx.Cache)
 	for _, s := range skipped {
 		ctx.recordHistory(feedName, s.cand.item.Item, "skipped", s.reason, s.cand.titleLabels)
 	}
@@ -505,15 +506,16 @@ const skipReasonCacheBetter = "better version already in cache"
 // treats it as the least informative skip reason among siblings in a group.
 const skipReasonNoGroupMatched = "no group matched labels"
 
-// markCacheRejectedSeen adds the GUID of each cache-rejected candidate to the
-// seen cache. On the next run, Exists() catches these GUIDs in Phase 1, before
-// the torrent disk read, eliminating redundant I/O for items that will never
-// be dispatched again.
-func markCacheRejectedSeen(skipped []skippedCandidate, cache *CacheFile) {
+// markSkippedSeen adds the GUID of every skipped candidate to the seen cache,
+// regardless of reason (no group matched, outranked this run, covered by a
+// winner, or cache-rejected). On the next run, Exists() catches these GUIDs in
+// Phase 1, before the torrent disk read or any label/group evaluation,
+// eliminating redundant work for items that will never be dispatched again —
+// and, importantly, keeping history.json from being flooded with the same
+// non-actionable items over and over whenever it starts out empty.
+func markSkippedSeen(skipped []skippedCandidate, cache *CacheFile) {
 	for _, s := range skipped {
-		if s.reason == skipReasonCacheBetter {
-			cache.AddSkippedItem(s.cand.item)
-		}
+		cache.AddSkippedItem(s.cand.item)
 	}
 }
 

--- a/cmd/rss4transmission/once_test.go
+++ b/cmd/rss4transmission/once_test.go
@@ -283,6 +283,37 @@ func TestProcessFeed_ExcludedItemsRecordExtractedTitleLabels(t *testing.T) {
 		"excluded records should carry title-extracted labels, same as skipped/dispatched records")
 }
 
+// Regression: excluded items were never added to the seen cache, so an item
+// that stays in the RSS feed (e.g. a perpetual "Highlights" upload) got
+// re-evaluated and re-recorded to history on every single run. That's
+// invisible when history.json persists (AddOrUpdateRecord dedupes by GUID
+// against records already on disk), but floods history.json with the
+// feed's entire non-actionable backlog the moment history starts empty
+// (deleted file, or a fresh restart with no prior history).
+func TestProcessFeed_ExcludedItems_CachedSoSecondRunDoesNotReRecord(t *testing.T) {
+	extractor := &ExtractorSet{Labels: map[string]LabelDef{
+		"series": {Regexp: `(?i)(MotoGP|Moto2|Moto3)`},
+	}}
+	feedCfg := Feed{
+		Name:    "testfeed",
+		Exclude: []string{"Highlights"},
+	}
+	rss := &gofeed.Feed{Items: []*gofeed.Item{
+		{Title: "MotoGP.Round06.Highlights", GUID: "guid1"},
+	}}
+	cache := emptyCache()
+
+	run1 := &RunContext{Cache: cache, History: &HistoryFile{guidIndex: map[string]int{}}}
+	cmd := &OnceCmd{}
+	cmd.processFeed(run1, "testfeed", feedCfg, rss, extractor)
+	require.Len(t, run1.History.GetRecords(), 1, "first run should record the excluded item")
+
+	run2 := &RunContext{Cache: cache, History: &HistoryFile{guidIndex: map[string]int{}}}
+	cmd.processFeed(run2, "testfeed", feedCfg, rss, extractor)
+	assert.Empty(t, run2.History.GetRecords(),
+		"excluded items must be cached in run 1 so a fresh/empty history in run 2 doesn't re-record them")
+}
+
 // realMotoGPExtractor mirrors the production "motogp" Extractor's Regexp
 // patterns closely enough to reproduce the extraction quirks real release
 // titles hit (e.g. multiple sibling feeds extracting an identical "class"
@@ -396,7 +427,34 @@ func TestRealMotoGPFeeds_ExcludedHighlightsShowsLabelsAndMotoGPWinsPrimary(t *te
 			"over its Moto2/Moto3 siblings despite the shared Extractor giving them the same label")
 }
 
-func TestRealMotoGPFeeds_DispatchedSiblingSuppressesReprocessingAfterHistoryReset(t *testing.T) {
+// Regression: Phase-3 skipped candidates were only cached when the reason was
+// skipReasonCacheBetter, so a candidate skipped for "no group matched labels"
+// (this feed's config simply never applies to this content) got re-evaluated
+// and re-recorded to history on every run, same root cause as the Phase-1
+// excluded-item bug above.
+func TestProcessFeed_NoGroupMatched_CachedSoSecondRunDoesNotReRecord(t *testing.T) {
+	extractor := realMotoGPExtractor()
+	feeds := realMotoGPFeeds()
+	motoGP := feeds[0] // Require class=MotoGP; this item is Moto3 content, so it never matches.
+	rss := &gofeed.Feed{Items: []*gofeed.Item{
+		{Title: "Moto3.2026.Round12.Great.Britain.Race.WEB.1080p.X264.English", GUID: "guid-moto3-race"},
+	}}
+	cache := emptyCache()
+
+	run1 := &RunContext{Cache: cache, History: &HistoryFile{guidIndex: map[string]int{}}}
+	cmd := &OnceCmd{}
+	cmd.processFeed(run1, motoGP.Name, motoGP, rss, extractor)
+	run1Records := run1.History.GetRecords()
+	require.Len(t, run1Records, 1)
+	assert.Equal(t, skipReasonNoGroupMatched, run1Records[0].Reason)
+
+	run2 := &RunContext{Cache: cache, History: &HistoryFile{guidIndex: map[string]int{}}}
+	cmd.processFeed(run2, motoGP.Name, motoGP, rss, extractor)
+	assert.Empty(t, run2.History.GetRecords(),
+		"no-group-matched candidates must be cached in run 1 so a fresh/empty history in run 2 doesn't re-record them")
+}
+
+func TestRealMotoGPFeeds_AllSiblingsSuppressReprocessingAfterHistoryReset(t *testing.T) {
 	extractor := realMotoGPExtractor()
 	feeds := realMotoGPFeeds()
 	rss := &gofeed.Feed{Items: []*gofeed.Item{
@@ -406,7 +464,10 @@ func TestRealMotoGPFeeds_DispatchedSiblingSuppressesReprocessingAfterHistoryRese
 
 	// Run 1: Moto3's own Group matches this item (it's genuinely Moto3
 	// content), so it wins selection. cmd.Skip populates the cache exactly
-	// like a real dispatch would, without needing a Transmission mock.
+	// like a real dispatch would, without needing a Transmission mock. Moto2
+	// and MotoGP evaluate the same item but never match their own Group, so
+	// they're skipped for skipReasonNoGroupMatched — which is now cached too
+	// (markSkippedSeen caches every skip reason, not just cache-rejected).
 	run1 := &RunContext{Cache: cache, History: &HistoryFile{guidIndex: map[string]int{}}}
 	skipCmd := &OnceCmd{Skip: true}
 	for _, f := range feeds {
@@ -416,36 +477,20 @@ func TestRealMotoGPFeeds_DispatchedSiblingSuppressesReprocessingAfterHistoryRese
 	require.Len(t, run1Records, 3, "all three siblings should evaluate the item on a first run")
 
 	// Run 2: same cache (as if only the history file, not the seen-cache, was
-	// deleted and the process restarted), fresh empty history.
+	// deleted and the process restarted), fresh empty history. All three
+	// siblings' GUIDs are already cached from run 1 (Moto3 as dispatched,
+	// Moto2/MotoGP as no-group-matched), so Exists() short-circuits Phase 1
+	// for all of them and nothing gets re-recorded — this is the fix for the
+	// "delete history.json and restart floods the page" bug.
 	run2 := &RunContext{Cache: cache, History: &HistoryFile{guidIndex: map[string]int{}}}
 	noopCmd := &OnceCmd{}
 	for _, f := range feeds {
 		noopCmd.processFeed(run2, f.Name, f, rss, extractor)
 	}
 
-	run2Records := run2.History.GetRecords()
-	require.Len(t, run2Records, 2,
-		"Moto3 already exists in the cache from run 1 and must be silently skipped in Phase 1, "+
-			"leaving only Moto2 and MotoGP to re-record 'no group matched labels' every run")
-	for _, r := range run2Records {
-		assert.NotEqual(t, "Moto3", r.Feed)
-		assert.Equal(t, skipReasonNoGroupMatched, r.Reason)
-	}
-
-	feedGroups := func(name string) []Group {
-		for _, f := range feeds {
-			if f.Name == name {
-				return f.Groups
-			}
-		}
-		return nil
-	}
-	rows := groupHistoryRows(run2Records, feedGroups)
-	require.Len(t, rows, 2)
-	assert.True(t, rows[0].IsPrimary)
-	assert.Equal(t, "Moto2", rows[0].Feed,
-		"with Moto3's record missing, Moto2 and MotoGP both score 0 (their own Require is contradicted "+
-			"by class=Moto3, not merely silent on it), so the tie falls back to alphabetical order")
+	assert.Empty(t, run2.History.GetRecords(),
+		"every sibling's verdict from run 1 must be cached, so a fresh/empty history in run 2 "+
+			"re-records nothing for content that was already fully evaluated")
 }
 
 // --- dispatch stop-processing semantics ---
@@ -960,9 +1005,9 @@ func TestEnsureTorrentBytes_FetchesWhenEmpty(t *testing.T) {
 	}
 }
 
-// --- markCacheRejectedSeen ---
+// --- markSkippedSeen ---
 
-func TestMarkCacheRejectedSeen_AddsCacheRejected(t *testing.T) {
+func TestMarkSkippedSeen_AddsCacheRejected(t *testing.T) {
 	c := makeCandidate("guid-rej",
 		map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race"},
 		nil,
@@ -976,14 +1021,18 @@ func TestMarkCacheRejectedSeen_AddsCacheRejected(t *testing.T) {
 	skipped := []skippedCandidate{
 		{cand: c, reason: skipReasonCacheBetter},
 	}
-	markCacheRejectedSeen(skipped, cache)
+	markSkippedSeen(skipped, cache)
 
 	if !cache.Exists("testfeed", c.item) {
-		t.Error("expected GUID to be in Seen after markCacheRejectedSeen")
+		t.Error("expected GUID to be in Seen after markSkippedSeen")
 	}
 }
 
-func TestMarkCacheRejectedSeen_IgnoresOtherReasons(t *testing.T) {
+// Regression: every skip reason must be cached, not just cache-rejected —
+// otherwise items skipped for "no group matched labels" or "outranked" get
+// re-evaluated and re-recorded to history forever (see
+// TestProcessFeed_NoGroupMatched_CachedSoSecondRunDoesNotReRecord).
+func TestMarkSkippedSeen_AddsAllReasons(t *testing.T) {
 	c := makeCandidate("guid-other",
 		map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race"},
 		nil,
@@ -998,10 +1047,10 @@ func TestMarkCacheRejectedSeen_IgnoresOtherReasons(t *testing.T) {
 		{cand: c, reason: "no group matched labels"},
 		{cand: c, reason: "outranked by better candidate in this run"},
 	}
-	markCacheRejectedSeen(skipped, cache)
+	markSkippedSeen(skipped, cache)
 
-	if len(cache.Seen) != 0 {
-		t.Errorf("expected no Seen entries for non-cache-rejection reasons, got %d", len(cache.Seen))
+	if len(cache.Seen) != 2 {
+		t.Errorf("expected a Seen entry for every skipped candidate regardless of reason, got %d", len(cache.Seen))
 	}
 }
 

--- a/cmd/rss4transmission/watch.go
+++ b/cmd/rss4transmission/watch.go
@@ -199,6 +199,17 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 		return retryHistoryItem(ctx, rec)
 	}
 
+	// forgetHistory removes a (feed, guid) pair from both the seen cache and
+	// history, so it can be freshly re-evaluated (e.g. after a config change).
+	// Neither file is saved immediately; the next scheduled once.Run() tick's
+	// SaveCache/SaveHistory calls persist the removal.
+	forgetHistory := func(feed, guid string) (bool, error) {
+		reloader.mu.Lock()
+		defer reloader.mu.Unlock()
+		ctx.Cache.RemoveEntry(feed, guid)
+		return ctx.History.RemoveRecord(feed, guid), nil
+	}
+
 	// feedConfigured checks against the live (possibly reloaded) config, so
 	// the history page's Torrent button reflects the config as it stands at
 	// render time, not as it was when the server started.
@@ -247,7 +258,7 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 			if ctx.History == nil {
 				log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
 			}
-			go startWebServer("private", newWebMux(ctx.History, retryHistory, feedConfigured, feedGroups), histAddr)
+			go startWebServer("private", newWebMux(ctx.History, retryHistory, feedConfigured, feedGroups, forgetHistory), histAddr)
 		}
 	} else if cmd.PrivateListen != "" {
 		// Single-listener mode: history + cancel on the same port.
@@ -258,7 +269,7 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 		if ctx.History == nil {
 			log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
 		}
-		mux := newWebMux(ctx.History, retryHistory, feedConfigured, feedGroups)
+		mux := newWebMux(ctx.History, retryHistory, feedConfigured, feedGroups, forgetHistory)
 		if ctx.CancelStore != nil {
 			registerCancelRoutes(mux, ctx.CancelStore, ctx.Config.Cancel, removeT, getProgress, accessLog)
 			ctx.CancelRoutesEnabled = true

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -54,6 +54,11 @@ type progressFunc func(ctx context.Context, torrentID int64) (downloadedBytes in
 // Transmission. Returns the new Transmission torrent ID.
 type retryFunc func(rec HistoryRecord) (int64, error)
 
+// forgetFunc removes a (feed, guid) pair from both the seen cache and history,
+// so the item can be freshly re-evaluated on the next run. Returns whether a
+// history record was found and removed.
+type forgetFunc func(feed, guid string) (bool, error)
+
 // cancelPageData is passed to the cancel confirmation template.
 type cancelPageData struct {
 	Title         string
@@ -253,7 +258,9 @@ func groupHistoryRows(records []HistoryRecord, feedGroups func(name string) []Gr
 
 // newWebMux builds the shared HTTP mux. If history is non-nil, the history
 // page is served at "/". When history and retry are both non-nil, POST /torrent
-// is also registered to re-submit a past skipped/excluded/error item.
+// is also registered to re-submit a past skipped/excluded/error item. When
+// history and forget are both non-nil, POST /forget is also registered to
+// remove a (feed, guid) pair from the seen cache and history.
 // feedConfigured reports whether a feed name is still present in the live
 // config; the Torrent button is hidden on the history page for records whose
 // feed no longer exists, since retrying one always fails with "feed ... is no
@@ -262,7 +269,7 @@ func groupHistoryRows(records []HistoryRecord, feedGroups func(name string) []Gr
 // ties in groupHistoryRows; a nil feedGroups falls back to alphabetical
 // ordering, same as if every feed had no groups.
 // The /healthz route is always registered.
-func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name string) bool, feedGroups func(name string) []Group) *http.ServeMux {
+func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name string) bool, feedGroups func(name string) []Group, forget forgetFunc) *http.ServeMux {
 	if feedConfigured == nil {
 		feedConfigured = func(string) bool { return true }
 	}
@@ -302,6 +309,10 @@ func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name s
 		mux.HandleFunc("POST /torrent", makePostTorrentHandler(history, retry))
 	}
 
+	if history != nil && forget != nil {
+		mux.HandleFunc("POST /forget", makePostForgetHandler(history, forget))
+	}
+
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -337,6 +348,38 @@ func makePostTorrentHandler(history *HistoryFile, retry retryFunc) http.HandlerF
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, "Torrent submitted.") //nolint:errcheck
+	}
+}
+
+// makePostForgetHandler processes a "forget this" request from the history
+// page. It resolves feed+guid to a HistoryRecord (so an unknown pair 404s the
+// same way makePostTorrentHandler does) and delegates the actual removal from
+// the seen cache and history to forget.
+func makePostForgetHandler(history *HistoryFile, forget forgetFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "invalid form body", http.StatusBadRequest)
+			return
+		}
+
+		feed := r.FormValue("feed")
+		guid := r.FormValue("guid")
+		rec, ok := history.FindRecord(feed, guid)
+		if !ok {
+			http.Error(w, "history record not found", http.StatusNotFound)
+			return
+		}
+
+		if _, err := forget(feed, guid); err != nil {
+			log.WithError(err).Warnf("Failed to forget %q", rec.Title)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		log.Infof("Forgot %q from history page", rec.Title)
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "Forgotten.") //nolint:errcheck
 	}
 }
 

--- a/cmd/rss4transmission/web/history.html
+++ b/cmd/rss4transmission/web/history.html
@@ -60,11 +60,17 @@
         a { color: inherit; text-decoration: none; }
         a:hover { text-decoration: underline; }
         .labels { font-size: 0.82em; color: #666; margin-top: 3px; }
-        th:nth-child(1), td:nth-child(1) { width: 14em; white-space: nowrap; }
+        th:nth-child(1), td:nth-child(1) { width: 10em; white-space: nowrap; }
         th:nth-child(2), td:nth-child(2) { width: 9em; }
         th:nth-child(4), td:nth-child(4) { width: 8em; }
         th:nth-child(5), td:nth-child(5) { width: 18em; }
         th:nth-child(6), td:nth-child(6) { width: 7em; }
+
+        td.action {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5em;
+        }
 
         .btn-torrent, .btn-forget {
             color: #fff;
@@ -92,7 +98,6 @@
         .btn-forget {
             background: #3a3a3a;
             color: #ccc;
-            margin-left: 0.6em;
         }
         .btn-forget:hover:not(:disabled) { background: #4d4d4d; color: #fff; }
 
@@ -160,7 +165,7 @@
         <tbody id="rows">
             {{ range . }}
             <tr data-guid="{{ .GUID }}" data-feed="{{ .Feed }}" data-outcome="{{ .Outcome }}" data-labels="{{ range $k, $v := .Labels }}{{ $k }}={{ $v }} {{ end }}"{{ if not .IsPrimary }} class="group-child" style="display:none"{{ end }}>
-                <td>{{ .ProcessedAt.Format "2006-01-02 15:04:05.000" }}</td>
+                <td>{{ .ProcessedAt.Format "2006-01-02 15:04" }}</td>
                 <td>
                     {{ if and .IsPrimary (gt .GroupSize 1) }}<span class="group-toggle" data-guid="{{ .GUID }}">&#9656;</span> {{ end }}{{ .Feed }}{{ if and .IsPrimary (gt .GroupSize 1) }} <span class="group-badge">+{{ sub .GroupSize 1 }}</span>{{ end }}
                 </td>

--- a/cmd/rss4transmission/web/history.html
+++ b/cmd/rss4transmission/web/history.html
@@ -78,6 +78,19 @@
         .btn-torrent:hover { background: #08e; }
         .btn-torrent:disabled { background: #444; color: #888; cursor: default; }
 
+        .btn-forget {
+            background: #555;
+            color: #fff;
+            border: none;
+            padding: 0.3em 0.9em;
+            font-family: monospace;
+            font-size: 0.85em;
+            cursor: pointer;
+            margin-left: 0.4em;
+        }
+        .btn-forget:hover { background: #777; }
+        .btn-forget:disabled { background: #444; color: #888; cursor: default; }
+
         .group-toggle { cursor: pointer; color: #888; user-select: none; display: inline-block; width: 1em; }
         .group-badge { color: #666; font-size: 0.82em; }
         tr.group-child td { background: #232a33; }
@@ -156,6 +169,7 @@
                     {{ if and .TorrentURL (ne .Outcome "dispatched") (ne .Outcome "downloaded") (feedConfigured .Feed) }}
                     <button class="btn-torrent" data-feed="{{ .Feed }}" data-guid="{{ .GUID }}">Torrent</button>
                     {{ end }}
+                    <button class="btn-forget" data-feed="{{ .Feed }}" data-guid="{{ .GUID }}">Forget</button>
                 </td>
             </tr>
             {{ end }}
@@ -296,6 +310,34 @@
                 var guid = toggle.dataset.guid;
                 if (expandedGroups.has(guid)) expandedGroups.delete(guid); else expandedGroups.add(guid);
                 apply();
+                return;
+            }
+
+            var forgetBtn = e.target.closest('.btn-forget');
+            if (forgetBtn) {
+                var fFeed = forgetBtn.dataset.feed;
+                var fGuid = forgetBtn.dataset.guid;
+                var fRow  = forgetBtn.closest('tr');
+
+                forgetBtn.disabled = true;
+                forgetBtn.textContent = 'Forgetting…';
+
+                var fBody = new URLSearchParams();
+                fBody.set('feed', fFeed);
+                fBody.set('guid', fGuid);
+
+                fetch('/forget', { method: 'POST', body: fBody }).then(function (resp) {
+                    if (!resp.ok) {
+                        return resp.text().then(function (msg) { throw new Error(msg || resp.statusText); });
+                    }
+                    fRow.remove();
+                    rows = rows.filter(function (r) { return r !== fRow; });
+                    apply();
+                }).catch(function (err) {
+                    forgetBtn.disabled = false;
+                    forgetBtn.textContent = 'Forget';
+                    alert('Failed to forget: ' + err.message);
+                });
                 return;
             }
 

--- a/cmd/rss4transmission/web/history.html
+++ b/cmd/rss4transmission/web/history.html
@@ -66,30 +66,35 @@
         th:nth-child(5), td:nth-child(5) { width: 18em; }
         th:nth-child(6), td:nth-child(6) { width: 7em; }
 
-        .btn-torrent {
-            background: #06c;
+        .btn-torrent, .btn-forget {
             color: #fff;
             border: none;
-            padding: 0.3em 0.9em;
+            border-radius: 4px;
+            padding: 0.35em 1em;
             font-family: monospace;
             font-size: 0.85em;
+            font-weight: bold;
+            letter-spacing: 0.02em;
             cursor: pointer;
+            transition: background-color 0.15s ease, transform 0.1s ease;
         }
-        .btn-torrent:hover { background: #08e; }
-        .btn-torrent:disabled { background: #444; color: #888; cursor: default; }
+        .btn-torrent:active, .btn-forget:active { transform: translateY(1px); }
+        .btn-torrent:disabled, .btn-forget:disabled {
+            background: #3a3a3a;
+            color: #777;
+            cursor: default;
+            transform: none;
+        }
+
+        .btn-torrent { background: #0668c4; }
+        .btn-torrent:hover:not(:disabled) { background: #1a86ec; }
 
         .btn-forget {
-            background: #555;
-            color: #fff;
-            border: none;
-            padding: 0.3em 0.9em;
-            font-family: monospace;
-            font-size: 0.85em;
-            cursor: pointer;
-            margin-left: 0.4em;
+            background: #3a3a3a;
+            color: #ccc;
+            margin-left: 0.6em;
         }
-        .btn-forget:hover { background: #777; }
-        .btn-forget:disabled { background: #444; color: #888; cursor: default; }
+        .btn-forget:hover:not(:disabled) { background: #4d4d4d; color: #fff; }
 
         .group-toggle { cursor: pointer; color: #888; user-select: none; display: inline-block; width: 1em; }
         .group-badge { color: #666; font-size: 0.82em; }

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -23,7 +23,7 @@ import (
 // --- /healthz ---
 
 func TestHealthzHandler(t *testing.T) {
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	req := httptest.NewRequest("GET", "/healthz", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -78,7 +78,7 @@ func TestGetCancelHandler_RendersForm(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -103,7 +103,7 @@ func TestGetCancelHandler_RendersProgress(t *testing.T) {
 	// 2.5 GiB downloaded, 25% done
 	getProgress := makeProgressFunc(int64(2.5*float64(1<<30)), 0.25)
 
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), getProgress, nil)
 
 	req := httptest.NewRequest("GET",
@@ -128,7 +128,7 @@ func TestGetCancelHandler_ProgressUnknownOnError(t *testing.T) {
 		return 0, 0, fmt.Errorf("transmission unavailable")
 	}
 
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), errProgress, nil)
 
 	req := httptest.NewRequest("GET",
@@ -143,7 +143,7 @@ func TestGetCancelHandler_ProgressUnknownOnError(t *testing.T) {
 func TestGetCancelHandler_MissingParams(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET", "/cancel?id=test-id", nil)
@@ -159,7 +159,7 @@ func TestGetCancelHandler_BadSignature(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -176,7 +176,7 @@ func TestGetCancelHandler_Expired(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -192,7 +192,7 @@ func TestGetCancelHandler_NotFound(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -210,7 +210,7 @@ func TestGetCancelHandler_DoesNotConsumeEntry(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	removed := false
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), nil)
 
@@ -237,7 +237,7 @@ func TestPostCancelHandler_Valid(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	removed := false
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -253,7 +253,7 @@ func TestPostCancelHandler_Valid(t *testing.T) {
 func TestPostCancelHandler_MissingParams(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := strings.NewReader("id=test-id") // missing expires and sig
@@ -271,7 +271,7 @@ func TestPostCancelHandler_BadSignature(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, "badsig")
@@ -289,7 +289,7 @@ func TestPostCancelHandler_Expired(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -306,7 +306,7 @@ func TestPostCancelHandler_NotFound(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("ghost-id", expires, sig)
@@ -387,7 +387,7 @@ func TestPostCancelHandler_RemoveErrorPreservesStoreEntry(t *testing.T) {
 	failRemove := func(_ context.Context, _ []int64) error {
 		return fmt.Errorf("transmission unreachable")
 	}
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, failRemove, noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -408,7 +408,7 @@ func TestGetCancelHandler_ZeroBytesProgressBothUnknown(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	// brand-new torrent: 0 bytes downloaded, 0% done
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), makeProgressFunc(0, 0.0), nil)
 
 	req := httptest.NewRequest("GET",
@@ -458,7 +458,7 @@ func TestHistoryPage_RendersTorrentButtonForSkippedWithURL(t *testing.T) {
 		"skipped", "lost preference contest", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -470,12 +470,49 @@ func TestHistoryPage_RendersTorrentButtonForSkippedWithURL(t *testing.T) {
 	assert.Contains(t, body, `data-guid="guid-1"`)
 }
 
+func TestHistoryPage_RendersForgetButtonForSkipped(t *testing.T) {
+	h := emptyHistory()
+	rec := NewHistoryRecord("myfeed",
+		makeGofeedItemWithEnclosure("My Title", "guid-1", "https://example.com/my.torrent"),
+		"skipped", "lost preference contest", nil)
+	h.AddOrUpdateRecord(rec)
+
+	mux := newWebMux(h, nil, nil, nil, makeForgetFunc(new(bool), nil, nil, true, nil))
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	assert.Contains(t, body, `class="btn-forget"`)
+	assert.Contains(t, body, `data-feed="myfeed"`)
+	assert.Contains(t, body, `data-guid="guid-1"`)
+}
+
+func TestHistoryPage_RendersForgetButtonForDispatched(t *testing.T) {
+	h := emptyHistory()
+	rec := NewHistoryRecord("myfeed",
+		makeGofeedItemWithEnclosure("Already Dispatched", "guid-3", "https://example.com/my.torrent"),
+		"dispatched", "", nil)
+	h.AddOrUpdateRecord(rec)
+
+	// Unlike Torrent, Forget makes sense for dispatched/downloaded items too —
+	// a user may deliberately want to allow a re-download.
+	mux := newWebMux(h, nil, nil, nil, makeForgetFunc(new(bool), nil, nil, true, nil))
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `class="btn-forget"`)
+}
+
 func TestHistoryPage_NoTorrentButtonWithoutURL(t *testing.T) {
 	h := emptyHistory()
 	rec := NewHistoryRecord("myfeed", makeGofeedItem("No Enclosure", "guid-2"), "excluded", "matched exclude", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -491,7 +528,7 @@ func TestHistoryPage_NoTorrentButtonForDispatched(t *testing.T) {
 		"dispatched", "", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -509,7 +546,7 @@ func TestHistoryPage_TorrentButtonShownWhenFeedConfiguredNil(t *testing.T) {
 
 	// A nil feedConfigured means "no filter" — button shows unconditionally,
 	// matching every existing caller that doesn't care about live config.
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -526,7 +563,7 @@ func TestHistoryPage_TorrentButtonHiddenWhenFeedNotConfigured(t *testing.T) {
 	h.AddOrUpdateRecord(rec)
 
 	feedConfigured := func(name string) bool { return name == "still-here" }
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), feedConfigured, nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), feedConfigured, nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -544,7 +581,7 @@ func TestHistoryPage_TorrentButtonShownWhenFeedStillConfigured(t *testing.T) {
 	h.AddOrUpdateRecord(rec)
 
 	feedConfigured := func(name string) bool { return name == "still-here" }
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), feedConfigured, nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), feedConfigured, nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -781,7 +818,7 @@ func TestHistoryPage_GroupsRecordsSharingGUID(t *testing.T) {
 		makeGofeedItemWithEnclosure("BSB Title", "guid-1", "https://example.com/bsb.torrent"),
 		"skipped", "no group matched labels", nil))
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -822,7 +859,7 @@ func TestHistoryPage_FeedGroupsBreaksNoGroupMatchedTie(t *testing.T) {
 		return nil
 	}
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, feedGroups)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, feedGroups, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -844,7 +881,7 @@ func TestHistoryPage_UniqueGUIDRendersUngrouped(t *testing.T) {
 	h := emptyHistory()
 	h.AddOrUpdateRecord(NewHistoryRecord("myfeed", makeGofeedItem("Solo Title", "guid-solo"), "skipped", "excluded by regex", nil))
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -881,7 +918,7 @@ func TestPostTorrentHandler_Success(t *testing.T) {
 
 	called := false
 	var gotRec HistoryRecord
-	mux := newWebMux(h, makeRetryFunc(&called, &gotRec, 7, nil), nil, nil)
+	mux := newWebMux(h, makeRetryFunc(&called, &gotRec, 7, nil), nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -897,7 +934,7 @@ func TestPostTorrentHandler_Success(t *testing.T) {
 func TestPostTorrentHandler_UnknownRecord(t *testing.T) {
 	h := emptyHistory()
 	called := false
-	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, nil), nil, nil)
+	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, nil), nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("ghost-feed", "ghost-guid"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -914,7 +951,7 @@ func TestPostTorrentHandler_RetryError(t *testing.T) {
 	h.AddOrUpdateRecord(rec)
 
 	called := false
-	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, fmt.Errorf("boom: no torrent URL")), nil, nil)
+	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, fmt.Errorf("boom: no torrent URL")), nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -931,7 +968,7 @@ func TestPostTorrentHandler_NotRegisteredWhenRetryNil(t *testing.T) {
 	rec := NewHistoryRecord("myfeed", makeGofeedItem("My Title", "guid-1"), "skipped", "", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, nil, nil, nil)
+	mux := newWebMux(h, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -956,6 +993,103 @@ func TestPostTorrentHandler_NotRegisteredOnCancelMux(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rr.Code)
 }
 
+// --- POST /forget ---
+
+func makeForgetFunc(called *bool, gotFeed, gotGUID *string, ok bool, err error) forgetFunc {
+	return func(feed, guid string) (bool, error) {
+		*called = true
+		if gotFeed != nil {
+			*gotFeed = feed
+		}
+		if gotGUID != nil {
+			*gotGUID = guid
+		}
+		return ok, err
+	}
+}
+
+func TestPostForgetHandler_Success(t *testing.T) {
+	h := emptyHistory()
+	rec := NewHistoryRecord("myfeed", makeGofeedItem("My Title", "guid-1"), "skipped", "", nil)
+	h.AddOrUpdateRecord(rec)
+
+	called := false
+	var gotFeed, gotGUID string
+	mux := newWebMux(h, nil, nil, nil, makeForgetFunc(&called, &gotFeed, &gotGUID, true, nil))
+
+	req := httptest.NewRequest("POST", "/forget", makeTorrentFormBody("myfeed", "guid-1"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.True(t, called, "forget should have been invoked")
+	assert.Equal(t, "myfeed", gotFeed)
+	assert.Equal(t, "guid-1", gotGUID)
+}
+
+func TestPostForgetHandler_UnknownRecord(t *testing.T) {
+	h := emptyHistory()
+	called := false
+	mux := newWebMux(h, nil, nil, nil, makeForgetFunc(&called, nil, nil, false, nil))
+
+	req := httptest.NewRequest("POST", "/forget", makeTorrentFormBody("ghost-feed", "ghost-guid"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	assert.False(t, called, "forget must not be called for an unknown record")
+}
+
+func TestPostForgetHandler_ForgetError(t *testing.T) {
+	h := emptyHistory()
+	rec := NewHistoryRecord("myfeed", makeGofeedItem("My Title", "guid-1"), "skipped", "", nil)
+	h.AddOrUpdateRecord(rec)
+
+	called := false
+	mux := newWebMux(h, nil, nil, nil, makeForgetFunc(&called, nil, nil, false, fmt.Errorf("boom: cache write failed")))
+
+	req := httptest.NewRequest("POST", "/forget", makeTorrentFormBody("myfeed", "guid-1"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.True(t, called)
+	assert.NotEqual(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "boom: cache write failed")
+}
+
+func TestPostForgetHandler_NotRegisteredWhenForgetNil(t *testing.T) {
+	h := emptyHistory()
+	rec := NewHistoryRecord("myfeed", makeGofeedItem("My Title", "guid-1"), "skipped", "", nil)
+	h.AddOrUpdateRecord(rec)
+
+	mux := newWebMux(h, nil, nil, nil, nil)
+
+	req := httptest.NewRequest("POST", "/forget", makeTorrentFormBody("myfeed", "guid-1"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	// Go's mux returns 405 (path only registered for GET /) rather than 404 — safe, not a panic.
+	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code,
+		"POST /forget must not be registered when forget is nil")
+}
+
+func TestPostForgetHandler_NotRegisteredOnCancelMux(t *testing.T) {
+	store := NewStore(time.Hour)
+	cfg := makeCancelCfg("secret", "https://example.com")
+	mux := newCancelMux(store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
+
+	req := httptest.NewRequest("POST", "/forget", makeTorrentFormBody("myfeed", "guid-1"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
 // --- access log behavioral tests ---
 
 func TestGetCancelHandler_AccessLog_InvalidToken(t *testing.T) {
@@ -964,7 +1098,7 @@ func TestGetCancelHandler_AccessLog_InvalidToken(t *testing.T) {
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -984,7 +1118,7 @@ func TestGetCancelHandler_AccessLog_MissingParams(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET", "/cancel?id=test-id", nil)
@@ -1004,7 +1138,7 @@ func TestGetCancelHandler_AccessLog_Expired(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -1025,7 +1159,7 @@ func TestGetCancelHandler_AccessLog_NotFound(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -1047,7 +1181,7 @@ func TestGetCancelHandler_AccessLog_Success(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -1068,7 +1202,7 @@ func TestGetCancelHandler_AccessLog_NilNoOp(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -1087,7 +1221,7 @@ func TestPostCancelHandler_AccessLog_InvalidToken(t *testing.T) {
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, "badsig")
@@ -1110,7 +1244,7 @@ func TestPostCancelHandler_AccessLog_Expired(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -1132,7 +1266,7 @@ func TestPostCancelHandler_AccessLog_NotFound(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("ghost-id", expires, sig)
@@ -1156,7 +1290,7 @@ func TestPostCancelHandler_AccessLog_Success(t *testing.T) {
 
 	lg, buf := makeTestAccessLogger()
 	removed := false
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -1183,7 +1317,7 @@ func TestPostCancelHandler_AccessLog_TransmissionError(t *testing.T) {
 	failRemove2 := func(_ context.Context, _ []int64) error {
 		return fmt.Errorf("transmission unreachable")
 	}
-	mux := newWebMux(nil, nil, nil, nil)
+	mux := newWebMux(nil, nil, nil, nil, nil)
 	registerCancelRoutes(mux, store, cfg, failRemove2, noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, sig)

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -282,6 +282,15 @@ config — it's hidden or fails with an error otherwise — and disappears once 
 successfully torrented. The action lives at `POST /torrent`, served only alongside the history
 page (`--private-listen`); it is never reachable on `--public-listen`.
 
+Every row also shows a **Forget** button, which removes that item's `(feed, guid)` pair from
+both the seen cache and the history page. Use it to retest a config change — for example after
+loosening a `Group.Require` or fixing an `Exclude` regex — without hand-editing `cache.json`.
+Unlike Torrent, Forget is available for every outcome, including `dispatched`, since you may
+deliberately want to allow a re-download. On success the row disappears from the history page;
+the change is persisted to `cache.json` and `history.json` on the next scheduled run. The action
+lives at `POST /forget`, served only alongside the history page (`--private-listen`); it is never
+reachable on `--public-listen`.
+
 In Docker:
 
 ```yaml
@@ -297,6 +306,7 @@ environment:
 |---|---|---|---|
 | `/` (history page) | ✓ (requires `--history-file`) | ✓ (requires `--history-file`) | — |
 | `/torrent` | ✓ (requires `--history-file`) | ✓ (requires `--history-file`) | — |
+| `/forget` | ✓ (requires `--history-file`) | ✓ (requires `--history-file`) | — |
 | `/cancel` | ✓ | — | ✓ |
 | `/notify-complete` | ✓ | — | ✓ |
 | `/healthz` | ✓ | ✓ | ✓ |


### PR DESCRIPTION
## Summary
- Excluded (Phase 1) and all skipped (Phase 3, any reason) items are now durably recorded in the seen cache, not just dispatched/cache-rejected ones — fixes a bug where deleting/emptying `history.json` caused the entire current backlog to flood back in on the next run.
- Adds a "Forget" button and `POST /forget` endpoint to remove a `(feed, guid)` pair from both `cache.json` and `history.json`, so a config change can be retested from the UI instead of hand-editing `cache.json`.

## Test plan
- [x] `make test` (go vet + full unit test suite) passes
- [x] `make lint` passes with 0 issues
- [x] New/updated unit tests cover: excluded/skipped-item caching and no-reflood-on-empty-history behavior (`once_test.go`), `CacheFile.RemoveEntry` / `HistoryFile.RemoveRecord` (`cache_test.go`, `history_test.go`), `POST /forget` handler success/404/error/route-registration (`web_test.go`), Forget button rendering for skipped and dispatched rows (`web_test.go`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)