### PR TITLE
Add Feed.Action: notify for manual-confirmation torrents

### DIFF
--- a/bin/torrent-complete.sh
+++ b/bin/torrent-complete.sh
@@ -6,13 +6,13 @@
 # server (same host:port as --cancel-listen, e.g. http://localhost:8080).
 # The server renders the notification using your configured templates and priority.
 #
-# If Cancel.HMACSecret is configured in rss4transmission, set CANCEL_HMAC_SECRET
+# If Notifications.HMACSecret is configured in rss4transmission, set HMAC_SECRET
 # to the same value so the endpoint can authenticate the request.
 #
 # Example (Docker Compose):
 #   environment:
 #     - RSS4TRANSMISSION_URL=http://rss4transmission:8080
-#     - CANCEL_HMAC_SECRET=<same value as Cancel.HMACSecret in config.yaml>
+#     - HMAC_SECRET=<same value as Notifications.HMACSecret in config.yaml>
 #
 # Transmission passes torrent details via environment variables:
 #   TR_TORRENT_NAME  - torrent name
@@ -20,8 +20,8 @@
 #   TR_TORRENT_ID    - Transmission torrent ID (integer)
 
 CURL_ARGS=()
-if [ -n "${CANCEL_HMAC_SECRET}" ]; then
-    CURL_ARGS+=("-H" "Authorization: Bearer ${CANCEL_HMAC_SECRET}")
+if [ -n "${HMAC_SECRET}" ]; then
+    CURL_ARGS+=("-H" "Authorization: Bearer ${HMAC_SECRET}")
 fi
 
 /usr/bin/curl -s -X POST \

--- a/cmd/rss4transmission/config.go
+++ b/cmd/rss4transmission/config.go
@@ -27,14 +27,14 @@ import (
 )
 
 var ConfigDefaults = map[string]interface{}{
-	"Transmission.Host":     "localhost",
-	"Transmission.Port":     9091,
-	"Transmission.HTTPS":    false,
-	"Transmission.Path":     "/transmission/rpc",
-	"Transmission.Username": "admin",
-	"Transmission.Password": "admin",
-	"SeenCacheDays":         30,
-	"Cancel.TokenTTLH":      24,
+	"Transmission.Host":       "localhost",
+	"Transmission.Port":       9091,
+	"Transmission.HTTPS":      false,
+	"Transmission.Path":       "/transmission/rpc",
+	"Transmission.Username":   "admin",
+	"Transmission.Password":   "admin",
+	"SeenCacheDays":           30,
+	"Notifications.TokenTTLH": 24,
 }
 
 type Config struct {
@@ -43,7 +43,7 @@ type Config struct {
 	Transmission  Transmission             `koanf:"Transmission"`
 	Gluetun       GluetunConfig            `koanf:"Gluetun"`
 	Ntfy          NtfyConfig               `koanf:"Ntfy"`
-	Cancel        CancelConfig             `koanf:"Cancel"`
+	Notifications NotificationsConfig      `koanf:"Notifications"`
 	PortCheck     PortCheckConfig          `koanf:"PortCheck"`
 	SeenFile      string                   `koanf:"SeenFile"`
 	SeenCacheDays int                      `koanf:"SeenCacheDays"`
@@ -59,6 +59,9 @@ type NtfyConfig struct {
 	CompletedTitle    string `koanf:"CompletedTitle"`
 	CompletedBody     string `koanf:"CompletedBody"`
 	CompletedPriority string `koanf:"CompletedPriority"`
+	SeenTitle         string `koanf:"SeenTitle"`
+	SeenBody          string `koanf:"SeenBody"`
+	SeenPriority      string `koanf:"SeenPriority"`
 
 	AlertTopic             string `koanf:"AlertTopic"`
 	ConfigReloadedTitle    string `koanf:"ConfigReloadedTitle"`
@@ -78,6 +81,8 @@ type NtfyConfig struct {
 	startedBodyTmpl         *template.Template
 	completedTitleTmpl      *template.Template
 	completedBodyTmpl       *template.Template
+	seenTitleTmpl           *template.Template
+	seenBodyTmpl            *template.Template
 	configReloadedTitleTmpl *template.Template
 	configReloadedBodyTmpl  *template.Template
 	configFailedTitleTmpl   *template.Template
@@ -92,7 +97,7 @@ type PortCheckConfig struct {
 	Enabled bool `koanf:"Enabled"`
 }
 
-type CancelConfig struct {
+type NotificationsConfig struct {
 	HMACSecret string `koanf:"HMACSecret"` //nolint:gosec
 	BaseURL    string `koanf:"BaseURL"`
 	TokenTTLH  int    `koanf:"TokenTTLH"`
@@ -126,6 +131,7 @@ type Feed struct {
 	NoValidateCert bool     `koanf:"NoValidateCert"`
 	NoSubmit       bool     `koanf:"NoSubmit"`
 	NoNotify       bool     `koanf:"NoNotify"`
+	Action         string   `koanf:"Action"`
 	MaxSize        string   `koanf:"MaxSize"`
 	MinSize        string   `koanf:"MinSize"`
 
@@ -172,6 +178,12 @@ func (f *Feed) Validate(name string, extractors map[string]*ExtractorSet) error 
 	}
 	if len(f.Groups) == 0 {
 		return fmt.Errorf("feed %q: Groups must contain at least one entry", name)
+	}
+	if f.Action != "" && f.Action != "download" && f.Action != "notify" {
+		return fmt.Errorf("feed %q: Action must be %q or %q, got %q", name, "download", "notify", f.Action)
+	}
+	if f.Action == "notify" && f.NoNotify {
+		return fmt.Errorf("feed %q: NoNotify cannot be combined with Action: notify", name)
 	}
 	return nil
 }

--- a/cmd/rss4transmission/config_test.go
+++ b/cmd/rss4transmission/config_test.go
@@ -128,6 +128,58 @@ func TestFeedValidate_Valid(t *testing.T) {
 	}
 }
 
+func TestFeedValidate_InvalidAction(t *testing.T) {
+	es := &ExtractorSet{Labels: map[string]LabelDef{}}
+	f := &Feed{
+		Extractor: "racing",
+		Identity:  []string{"series"},
+		Groups:    []Group{{Require: map[string][]string{"series": {"MotoGP"}}}},
+		Action:    "bogus",
+	}
+	if err := f.Validate("myfeed", map[string]*ExtractorSet{"racing": es}); err == nil {
+		t.Error("expected error for invalid Action value")
+	}
+}
+
+func TestFeedValidate_ActionNotifyConflictsWithNoNotify(t *testing.T) {
+	es := &ExtractorSet{Labels: map[string]LabelDef{}}
+	f := &Feed{
+		Extractor: "racing",
+		Identity:  []string{"series"},
+		Groups:    []Group{{Require: map[string][]string{"series": {"MotoGP"}}}},
+		Action:    "notify",
+		NoNotify:  true,
+	}
+	if err := f.Validate("myfeed", map[string]*ExtractorSet{"racing": es}); err == nil {
+		t.Error("expected error when Action: notify is combined with NoNotify")
+	}
+}
+
+func TestFeedValidate_ActionNotifyValid(t *testing.T) {
+	es := &ExtractorSet{Labels: map[string]LabelDef{}}
+	f := &Feed{
+		Extractor: "racing",
+		Identity:  []string{"series"},
+		Groups:    []Group{{Require: map[string][]string{"series": {"MotoGP"}}}},
+		Action:    "notify",
+	}
+	if err := f.Validate("myfeed", map[string]*ExtractorSet{"racing": es}); err != nil {
+		t.Errorf("expected Action: notify to be valid on its own: %v", err)
+	}
+}
+
+func TestFeedValidate_ActionDefaultEmpty(t *testing.T) {
+	es := &ExtractorSet{Labels: map[string]LabelDef{}}
+	f := &Feed{
+		Extractor: "racing",
+		Identity:  []string{"series"},
+		Groups:    []Group{{Require: map[string][]string{"series": {"MotoGP"}}}},
+	}
+	if err := f.Validate("myfeed", map[string]*ExtractorSet{"racing": es}); err != nil {
+		t.Errorf("expected empty Action (default download) to be valid: %v", err)
+	}
+}
+
 func TestValidateFeedNames_Unique(t *testing.T) {
 	feeds := []Feed{{Name: "A", URL: "https://a"}, {Name: "B", URL: "https://b"}}
 	if err := validateFeedNames(feeds); err != nil {

--- a/cmd/rss4transmission/history.go
+++ b/cmd/rss4transmission/history.go
@@ -52,17 +52,19 @@ type HistoryRecord struct {
 }
 
 // outcomeRank returns a rank for dedup: lower is more interesting.
-// "dispatched"/"downloaded" beat "skipped" beat "excluded" beat "error".
+// "dispatched"/"downloaded" beat "notified" beat "skipped" beat "excluded" beat "error".
 func outcomeRank(outcome string) int {
 	switch outcome {
 	case "dispatched", "downloaded":
 		return 0
-	case "skipped":
+	case "notified":
 		return 1
-	case "excluded":
+	case "skipped":
 		return 2
-	default:
+	case "excluded":
 		return 3
+	default:
+		return 4
 	}
 }
 

--- a/cmd/rss4transmission/history_test.go
+++ b/cmd/rss4transmission/history_test.go
@@ -32,11 +32,12 @@ func TestOutcomeRank(t *testing.T) {
 	}{
 		{"dispatched", 0},
 		{"downloaded", 0},
-		{"skipped", 1},
-		{"excluded", 2},
-		{"error", 3},
-		{"unknown", 3},
-		{"", 3},
+		{"notified", 1},
+		{"skipped", 2},
+		{"excluded", 3},
+		{"error", 4},
+		{"unknown", 4},
+		{"", 4},
 	}
 	for _, tc := range cases {
 		if got := outcomeRank(tc.outcome); got != tc.want {
@@ -276,6 +277,36 @@ func TestAddOrUpdateRecord_SkippedToDispatched(t *testing.T) {
 
 	if h.Records[0].Outcome != "dispatched" {
 		t.Errorf("Outcome = %q, want dispatched (skipped should upgrade to dispatched)", h.Records[0].Outcome)
+	}
+}
+
+func TestAddOrUpdateRecord_NotifiedToDispatched(t *testing.T) {
+	h := emptyHistory()
+	h.AddOrUpdateRecord(NewHistoryRecord("feed", makeGofeedItem("Show", "guid1"), "notified", "", nil))
+	h.AddOrUpdateRecord(NewHistoryRecord("feed", makeGofeedItem("Show", "guid1"), "dispatched", "", nil))
+
+	if h.Records[0].Outcome != "dispatched" {
+		t.Errorf("Outcome = %q, want dispatched (notified should upgrade to dispatched)", h.Records[0].Outcome)
+	}
+}
+
+func TestAddOrUpdateRecord_DispatchedToNotified_NoDowngrade(t *testing.T) {
+	h := emptyHistory()
+	h.AddOrUpdateRecord(NewHistoryRecord("feed", makeGofeedItem("Show", "guid1"), "dispatched", "", nil))
+	h.AddOrUpdateRecord(NewHistoryRecord("feed", makeGofeedItem("Show", "guid1"), "notified", "", nil))
+
+	if h.Records[0].Outcome != "dispatched" {
+		t.Errorf("Outcome = %q, want dispatched (should not downgrade to notified)", h.Records[0].Outcome)
+	}
+}
+
+func TestAddOrUpdateRecord_SkippedToNotified_Updates(t *testing.T) {
+	h := emptyHistory()
+	h.AddOrUpdateRecord(NewHistoryRecord("feed", makeGofeedItem("Show", "guid1"), "skipped", "", nil))
+	h.AddOrUpdateRecord(NewHistoryRecord("feed", makeGofeedItem("Show", "guid1"), "notified", "", nil))
+
+	if h.Records[0].Outcome != "notified" {
+		t.Errorf("Outcome = %q, want notified (should upgrade from skipped)", h.Records[0].Outcome)
 	}
 }
 

--- a/cmd/rss4transmission/main.go
+++ b/cmd/rss4transmission/main.go
@@ -61,6 +61,8 @@ type RunContext struct {
 	History             *HistoryFile
 	CancelStore         *Store
 	CancelRoutesEnabled bool
+	StartStore          *StartStore
+	StartRoutesEnabled  bool
 	Transmission        *transmissionrpc.Client
 	Provider            *file.File
 }

--- a/cmd/rss4transmission/ntfy.go
+++ b/cmd/rss4transmission/ntfy.go
@@ -36,6 +36,7 @@ type NtfyTemplateContext struct {
 	Published *time.Time // may be nil; guard with {{if .Published}}
 	TorrentID int64
 	CancelURL string
+	StartURL  string
 }
 
 var validNtfyPriorities = map[string]struct{}{
@@ -97,6 +98,13 @@ func (c *NtfyConfig) Validate() error {
 			&c.CompletedTitle, &c.CompletedBody, &c.CompletedPriority,
 			"Torrent Complete", "{{.Title}}\n{{.Dir}}", "default",
 			"CompletedTitle", "CompletedBody", "CompletedPriority")
+		if err != nil {
+			return err
+		}
+		c.seenTitleTmpl, c.seenBodyTmpl, err = compileNotificationTemplates(
+			&c.SeenTitle, &c.SeenBody, &c.SeenPriority,
+			"Torrent Found", "{{.Title}}\n{{.Size}}", "default",
+			"SeenTitle", "SeenBody", "SeenPriority")
 		if err != nil {
 			return err
 		}
@@ -195,6 +203,22 @@ func (c *NtfyClient) SendTorrentStarted(ctx *NtfyTemplateContext) error {
 		actions = fmt.Sprintf("view, More Info, %s", ctx.CancelURL)
 	}
 	return c.post(c.cfg.Topic, title, body, actions, c.cfg.StartedPriority)
+}
+
+func (c *NtfyClient) SendTorrentSeen(ctx *NtfyTemplateContext) error {
+	title, err := renderTemplate(c.cfg.seenTitleTmpl, ctx)
+	if err != nil {
+		return err
+	}
+	body, err := renderTemplate(c.cfg.seenBodyTmpl, ctx)
+	if err != nil {
+		return err
+	}
+	var actions string
+	if ctx.StartURL != "" {
+		actions = fmt.Sprintf("view, Start Download, %s", ctx.StartURL)
+	}
+	return c.post(c.cfg.Topic, title, body, actions, c.cfg.SeenPriority)
 }
 
 func (c *NtfyClient) SendTorrentCompleted(ctx *NtfyTemplateContext) error {

--- a/cmd/rss4transmission/ntfy_test.go
+++ b/cmd/rss4transmission/ntfy_test.go
@@ -35,7 +35,10 @@ func captureNtfyRequest(t *testing.T, alertTopic string, send func(*NtfyClient) 
 	return captured
 }
 
-func TestSendTorrentStarted_Headers(t *testing.T) {
+// captureNtfyTopicRequest is captureNtfyRequest's Topic-based counterpart, used
+// by the torrent started/found notification tests (BaseURL is filled in here).
+func captureNtfyTopicRequest(t *testing.T, cfg NtfyConfig, send func(*NtfyClient) error) *http.Request {
+	t.Helper()
 	var captured *http.Request
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		captured = r
@@ -43,19 +46,21 @@ func TestSendTorrentStarted_Headers(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cfg := mustValidateNtfyConfig(t, NtfyConfig{
-		BaseURL: srv.URL,
-		Topic:   "mytopic",
-		Token:   "tk_testtoken",
-	})
-	c := NewNtfyClient(cfg)
-	err := c.SendTorrentStarted(&NtfyTemplateContext{
-		Title:     "My.Show.S01E01",
-		Size:      "4.32 GB",
-		CancelURL: "https://example.com/cancel?id=x",
-	})
-	require.NoError(t, err)
+	cfg.BaseURL = srv.URL
+	require.NoError(t, send(NewNtfyClient(mustValidateNtfyConfig(t, cfg))))
 	require.NotNil(t, captured)
+	return captured
+}
+
+func TestSendTorrentStarted_Headers(t *testing.T) {
+	captured := captureNtfyTopicRequest(t, NtfyConfig{Topic: "mytopic", Token: "tk_testtoken"},
+		func(c *NtfyClient) error {
+			return c.SendTorrentStarted(&NtfyTemplateContext{
+				Title:     "My.Show.S01E01",
+				Size:      "4.32 GB",
+				CancelURL: "https://example.com/cancel?id=x",
+			})
+		})
 
 	assert.Equal(t, "POST", captured.Method)
 	assert.Equal(t, "/mytopic", captured.URL.Path)
@@ -106,6 +111,102 @@ func TestSendTorrentStarted_NoSize(t *testing.T) {
 	c := NewNtfyClient(cfg)
 	require.NoError(t, c.SendTorrentStarted(&NtfyTemplateContext{Title: "My.Show.S01E01"}))
 	assert.Equal(t, "My.Show.S01E01\n", string(body))
+}
+
+func TestSendTorrentSeen_Headers(t *testing.T) {
+	captured := captureNtfyTopicRequest(t, NtfyConfig{Topic: "mytopic", Token: "tk_testtoken"},
+		func(c *NtfyClient) error {
+			return c.SendTorrentSeen(&NtfyTemplateContext{
+				Title:    "My.Show.S01E01",
+				Size:     "4.32 GB",
+				StartURL: "https://example.com/start?id=x",
+			})
+		})
+
+	assert.Equal(t, "POST", captured.Method)
+	assert.Equal(t, "/mytopic", captured.URL.Path)
+	assert.Equal(t, "Torrent Found", captured.Header.Get("Title"))
+	assert.Equal(t, "default", captured.Header.Get("Priority"))
+
+	wantAction := "view, Start Download, https://example.com/start?id=x"
+	assert.Equal(t, wantAction, captured.Header.Get("Actions"))
+
+	assert.Equal(t, "Bearer tk_testtoken", captured.Header.Get("Authorization"))
+}
+
+func TestSendTorrentSeen_Body(t *testing.T) {
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		body, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, Topic: "t"})
+	c := NewNtfyClient(cfg)
+	require.NoError(t, c.SendTorrentSeen(&NtfyTemplateContext{
+		Title:    "My.Show.S01E01",
+		Size:     "4.32 GB",
+		StartURL: "https://example.com/start",
+	}))
+	assert.Equal(t, "My.Show.S01E01\n4.32 GB", string(body))
+}
+
+func TestSendTorrentSeen_NoStartURL(t *testing.T) {
+	var captured *http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{BaseURL: srv.URL, Topic: "mytopic", Token: "tk_testtoken"})
+	c := NewNtfyClient(cfg)
+	err := c.SendTorrentSeen(&NtfyTemplateContext{Title: "My.Show.S01E01"})
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	assert.Empty(t, captured.Header.Get("Actions"), "empty startURL must produce no Actions header")
+}
+
+func TestSendTorrentSeen_CustomTitleTemplate(t *testing.T) {
+	var captured *http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{
+		BaseURL:   srv.URL,
+		Topic:     "t",
+		SeenTitle: "{{.FeedName}}: {{.Title}}",
+	})
+	c := NewNtfyClient(cfg)
+	require.NoError(t, c.SendTorrentSeen(&NtfyTemplateContext{
+		Title:    "My.Show.S01E01",
+		FeedName: "shows",
+	}))
+	assert.Equal(t, "shows: My.Show.S01E01", captured.Header.Get("Title"))
+}
+
+func TestSendTorrentSeen_CustomPriority(t *testing.T) {
+	var captured *http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := mustValidateNtfyConfig(t, NtfyConfig{
+		BaseURL:      srv.URL,
+		Topic:        "t",
+		SeenPriority: "high",
+	})
+	c := NewNtfyClient(cfg)
+	require.NoError(t, c.SendTorrentSeen(&NtfyTemplateContext{Title: "My.Show"}))
+	assert.Equal(t, "high", captured.Header.Get("Priority"))
 }
 
 func TestSendTorrentCompleted_Headers(t *testing.T) {
@@ -324,8 +425,10 @@ func TestNtfyConfig_Validate_Defaults(t *testing.T) {
 
 	assert.Equal(t, "Torrent Started", cfg.StartedTitle)
 	assert.Equal(t, "Torrent Complete", cfg.CompletedTitle)
+	assert.Equal(t, "Torrent Found", cfg.SeenTitle)
 	assert.Equal(t, "default", cfg.StartedPriority)
 	assert.Equal(t, "default", cfg.CompletedPriority)
+	assert.Equal(t, "default", cfg.SeenPriority)
 
 	ctx := &NtfyTemplateContext{Title: "T", Size: "4.32 GB"}
 	out, err := renderTemplate(cfg.startedTitleTmpl, ctx)
@@ -356,6 +459,13 @@ func TestNtfyConfig_Validate_InvalidTemplate(t *testing.T) {
 	err := cfg.Validate()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "StartedTitle")
+}
+
+func TestNtfyConfig_Validate_InvalidSeenTemplate(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", Topic: "test", SeenTitle: "{{.Unclosed"}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SeenTitle")
 }
 
 func TestNtfyConfig_Validate_InvalidPriority(t *testing.T) {

--- a/cmd/rss4transmission/once.go
+++ b/cmd/rss4transmission/once.go
@@ -41,15 +41,15 @@ func sendNtfyStarted(ctx *RunContext, feedCfg Feed, torrentID int64, meta Cancel
 
 	var cancelURL, cancelID string
 	if ctx.CancelRoutesEnabled &&
-		ctx.Config.Cancel.HMACSecret != "" &&
-		ctx.Config.Cancel.BaseURL != "" &&
+		ctx.Config.Notifications.HMACSecret != "" &&
+		ctx.Config.Notifications.BaseURL != "" &&
 		ctx.CancelStore != nil &&
 		torrentID != 0 {
 		cancelID = newUUID()
-		ttl := time.Duration(ctx.Config.Cancel.TokenTTLH) * time.Hour
-		expires, sig := GenerateToken([]byte(ctx.Config.Cancel.HMACSecret), cancelID, ttl)
+		ttl := time.Duration(ctx.Config.Notifications.TokenTTLH) * time.Hour
+		expires, sig := GenerateToken([]byte(ctx.Config.Notifications.HMACSecret), cancelID, ttl)
 		cancelURL = fmt.Sprintf("%s/cancel?id=%s&expires=%d&sig=%s",
-			strings.TrimRight(ctx.Config.Cancel.BaseURL, "/"), cancelID, expires, sig)
+			strings.TrimRight(ctx.Config.Notifications.BaseURL, "/"), cancelID, expires, sig)
 	}
 
 	var guid, link string
@@ -82,6 +82,61 @@ func sendNtfyStarted(ctx *RunContext, feedCfg Feed, torrentID int64, meta Cancel
 	// never saw the cancel link and the store entry would be unreachable.
 	if cancelID != "" {
 		ctx.CancelStore.Register(cancelID, torrentID, meta)
+	}
+}
+
+// sendNtfySeen sends a "torrent found" notification to ntfy for a feed whose
+// Action is "notify". The start action button is only included when start
+// routes are registered (--private-listen or --public-listen) and all
+// Notifications config fields are set; otherwise a plain notification is
+// sent. No NoNotify guard is needed here: Feed.Validate() already forbids
+// combining Action: notify with NoNotify.
+func sendNtfySeen(ctx *RunContext, feedCfg Feed, feedName, guid string, meta CancelMetadata, item *gofeed.Item) {
+	if ctx.Config.Ntfy.BaseURL == "" || ctx.Config.Ntfy.Topic == "" {
+		return
+	}
+
+	var startURL, startID string
+	if ctx.StartRoutesEnabled &&
+		ctx.Config.Notifications.HMACSecret != "" &&
+		ctx.Config.Notifications.BaseURL != "" &&
+		ctx.StartStore != nil {
+		startID = newUUID()
+		ttl := time.Duration(ctx.Config.Notifications.TokenTTLH) * time.Hour
+		expires, sig := GenerateToken([]byte(ctx.Config.Notifications.HMACSecret), startID, ttl)
+		startURL = fmt.Sprintf("%s/start?id=%s&expires=%d&sig=%s",
+			strings.TrimRight(ctx.Config.Notifications.BaseURL, "/"), startID, expires, sig)
+	}
+
+	var itemGUID, link string
+	var published *time.Time
+	if item != nil {
+		itemGUID = item.GUID
+		link = item.Link
+		published = item.PublishedParsed
+	}
+	ntfyCtx := &NtfyTemplateContext{
+		Title:     meta.Title,
+		FeedName:  meta.FeedName,
+		Files:     meta.Files,
+		Labels:    meta.Labels,
+		SizeBytes: meta.SizeBytes,
+		Size:      formatGB(meta.SizeBytes),
+		GUID:      itemGUID,
+		Link:      link,
+		Published: published,
+		StartURL:  startURL,
+	}
+
+	client := NewNtfyClient(ctx.Config.Ntfy)
+	if err := client.SendTorrentSeen(ntfyCtx); err != nil {
+		log.WithError(err).Warn("Failed to send ntfy notification")
+		return
+	}
+	// Register only after the notification was delivered; if Send failed the user
+	// never saw the start link and the store entry would be unreachable.
+	if startID != "" {
+		ctx.StartStore.Register(startID, StartMetadata{FeedName: feedName, GUID: guid})
 	}
 }
 
@@ -351,6 +406,16 @@ func (cmd *OnceCmd) dispatch(ctx *RunContext, feedCfg Feed, feedName string, w *
 			return false
 		}
 		ctx.recordHistory(feedName, w.item.Item, "downloaded", "", labels)
+	} else if feedCfg.Action == "notify" {
+		meta := CancelMetadata{
+			Title:     w.item.Item.Title,
+			FeedName:  feedName,
+			Labels:    labels,
+			Files:     w.fileNames,
+			SizeBytes: extractSize(w.item.Item),
+		}
+		sendNtfySeen(ctx, feedCfg, feedName, w.item.Item.GUID, meta, w.item.Item)
+		ctx.recordHistory(feedName, w.item.Item, "notified", "", labels)
 	} else {
 		torrentBytes, err := ensureTorrentBytes(w.item, cmd.TorrentCacheDir, w.torrentBytes)
 		if err != nil {

--- a/cmd/rss4transmission/once.go
+++ b/cmd/rss4transmission/once.go
@@ -91,7 +91,7 @@ func sendNtfyStarted(ctx *RunContext, feedCfg Feed, torrentID int64, meta Cancel
 // Notifications config fields are set; otherwise a plain notification is
 // sent. No NoNotify guard is needed here: Feed.Validate() already forbids
 // combining Action: notify with NoNotify.
-func sendNtfySeen(ctx *RunContext, feedCfg Feed, feedName, guid string, meta CancelMetadata, item *gofeed.Item) {
+func sendNtfySeen(ctx *RunContext, feedName, guid string, meta CancelMetadata, item *gofeed.Item) {
 	if ctx.Config.Ntfy.BaseURL == "" || ctx.Config.Ntfy.Topic == "" {
 		return
 	}
@@ -414,7 +414,7 @@ func (cmd *OnceCmd) dispatch(ctx *RunContext, feedCfg Feed, feedName string, w *
 			Files:     w.fileNames,
 			SizeBytes: extractSize(w.item.Item),
 		}
-		sendNtfySeen(ctx, feedCfg, feedName, w.item.Item.GUID, meta, w.item.Item)
+		sendNtfySeen(ctx, feedName, w.item.Item.GUID, meta, w.item.Item)
 		ctx.recordHistory(feedName, w.item.Item, "notified", "", labels)
 	} else {
 		torrentBytes, err := ensureTorrentBytes(w.item, cmd.TorrentCacheDir, w.torrentBytes)

--- a/cmd/rss4transmission/once_test.go
+++ b/cmd/rss4transmission/once_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -606,6 +607,93 @@ func TestDispatch_RealSubmit_StopsProcessing(t *testing.T) {
 	records := ctx.History.GetRecords()
 	require.Len(t, records, 1)
 	assert.Equal(t, "dispatched", records[0].Outcome)
+}
+
+func TestDispatch_Notify_DoesNotSubmitToTransmission(t *testing.T) {
+	requests := 0
+	transmissionSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer transmissionSrv.Close()
+	endpoint, err := url.Parse(transmissionSrv.URL)
+	require.NoError(t, err)
+	client, err := transmissionrpc.New(endpoint, nil)
+	require.NoError(t, err)
+
+	c := makeCandidate("guid1", map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race"}, nil)
+	feedCfg := makeFeed([]string{"series", "round", "session"}, nil, nil)
+	feedCfg.Action = "notify"
+	keys := []string{"series=MotoGP|round=RD01|session=Race"}
+
+	ctx := &RunContext{
+		Cache:        emptyCache(),
+		History:      &HistoryFile{guidIndex: map[string]int{}},
+		Transmission: client,
+	}
+	cmd := &OnceCmd{}
+	stop := cmd.dispatch(ctx, feedCfg, "testfeed", c, keys)
+
+	assert.True(t, stop, "a notify dispatch must stop processing like a real submit")
+	assert.Equal(t, 0, requests, "Action: notify must not submit to Transmission")
+
+	records := ctx.History.GetRecords()
+	require.Len(t, records, 1)
+	assert.Equal(t, "notified", records[0].Outcome)
+
+	assert.True(t, ctx.Cache.Exists("testfeed", c.item), "cache should still record the notified GUID")
+}
+
+func TestDispatch_Notify_SendsNtfyAndRegistersStartStore(t *testing.T) {
+	var captured *http.Request
+	ntfySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ntfySrv.Close()
+
+	ntfyCfg := NtfyConfig{BaseURL: ntfySrv.URL, Topic: "t"}
+	require.NoError(t, ntfyCfg.Validate())
+
+	c := makeCandidate("guid1", map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race"}, nil)
+	feedCfg := makeFeed([]string{"series", "round", "session"}, nil, nil)
+	feedCfg.Action = "notify"
+	keys := []string{"series=MotoGP|round=RD01|session=Race"}
+
+	ctx := &RunContext{
+		Cache:   emptyCache(),
+		History: &HistoryFile{guidIndex: map[string]int{}},
+		Config: Config{
+			Ntfy: ntfyCfg,
+			Notifications: NotificationsConfig{
+				HMACSecret: "secret",
+				BaseURL:    "https://example.com",
+				TokenTTLH:  24,
+			},
+		},
+		StartStore:         NewStartStore(time.Hour),
+		StartRoutesEnabled: true,
+	}
+	cmd := &OnceCmd{}
+	stop := cmd.dispatch(ctx, feedCfg, "testfeed", c, keys)
+	assert.True(t, stop)
+
+	require.NotNil(t, captured, "ntfy should have been called")
+	assert.Equal(t, "Torrent Found", captured.Header.Get("Title"))
+	actions := captured.Header.Get("Actions")
+	require.NotEmpty(t, actions, "notify action must include a start link")
+	assert.Contains(t, actions, "https://example.com/start?id=")
+
+	idx := strings.Index(actions, "id=")
+	require.True(t, idx >= 0)
+	idPart := actions[idx+len("id="):]
+	if amp := strings.Index(idPart, "&"); amp >= 0 {
+		idPart = idPart[:amp]
+	}
+	meta, ok := ctx.StartStore.Peek(idPart)
+	require.True(t, ok, "start link id should be registered in StartStore")
+	assert.Equal(t, "testfeed", meta.FeedName)
+	assert.Equal(t, "guid1", meta.GUID)
 }
 
 // --- retryHistoryItem ---

--- a/cmd/rss4transmission/start.go
+++ b/cmd/rss4transmission/start.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// StartMetadata identifies the history record a /start link should resubmit.
+type StartMetadata struct {
+	FeedName string
+	GUID     string
+}
+
+type startEntry struct {
+	expiresAt time.Time
+	meta      StartMetadata
+}
+
+// StartStore maps per-notification UUIDs to the feed/GUID pair a /start link
+// should resubmit via retryHistoryItem.
+type StartStore struct {
+	ttl time.Duration
+	m   sync.Map
+}
+
+func NewStartStore(ttl time.Duration) *StartStore {
+	return &StartStore{ttl: ttl}
+}
+
+func (s *StartStore) Register(id string, meta StartMetadata) {
+	s.m.Store(id, &startEntry{
+		expiresAt: time.Now().Add(s.ttl),
+		meta:      meta,
+	})
+}
+
+// Peek returns the metadata for the given id without consuming the entry.
+// Returns false if the id is not found.
+func (s *StartStore) Peek(id string) (StartMetadata, bool) {
+	val, ok := s.m.Load(id)
+	if !ok {
+		return StartMetadata{}, false
+	}
+	return val.(*startEntry).meta, true
+}
+
+// StartReaper launches a goroutine that removes entries whose token TTL has
+// elapsed. It stops when ctx is cancelled. It is a no-op if the TTL is non-positive.
+func (s *StartStore) StartReaper(ctx context.Context) {
+	if s.ttl <= 0 {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(s.ttl)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				now := time.Now()
+				s.m.Range(func(key, val interface{}) bool {
+					if val.(*startEntry).expiresAt.Before(now) {
+						s.m.Delete(key)
+					}
+					return true
+				})
+			}
+		}
+	}()
+}

--- a/cmd/rss4transmission/start_test.go
+++ b/cmd/rss4transmission/start_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- StartStore ---
+
+func TestStartStore_RegisterAndPeek(t *testing.T) {
+	s := NewStartStore(time.Hour)
+	s.Register("id-1", StartMetadata{FeedName: "shows", GUID: "guid-1"})
+
+	meta, ok := s.Peek("id-1")
+	require.True(t, ok)
+	assert.Equal(t, "shows", meta.FeedName)
+	assert.Equal(t, "guid-1", meta.GUID)
+}
+
+func TestStartStore_Peek_Missing(t *testing.T) {
+	s := NewStartStore(time.Hour)
+	_, ok := s.Peek("does-not-exist")
+	assert.False(t, ok)
+}
+
+func TestStartStore_Peek_DoesNotConsumeEntry(t *testing.T) {
+	s := NewStartStore(time.Hour)
+	s.Register("id-2", StartMetadata{FeedName: "shows", GUID: "guid-2"})
+
+	_, ok := s.Peek("id-2")
+	require.True(t, ok, "first Peek should find the entry")
+
+	_, ok = s.Peek("id-2")
+	assert.True(t, ok, "second Peek should still find entry")
+}
+
+func TestStartStore_Reaper_RemovesExpired(t *testing.T) {
+	s := NewStartStore(50 * time.Millisecond)
+	s.Register("id-expire", StartMetadata{FeedName: "shows", GUID: "guid-expire"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s.StartReaper(ctx)
+
+	time.Sleep(200 * time.Millisecond)
+
+	_, ok := s.Peek("id-expire")
+	assert.False(t, ok, "expired entry should have been reaped")
+}
+
+func TestStartStore_Reaper_KeepsFreshEntries(t *testing.T) {
+	s := NewStartStore(time.Hour)
+	s.Register("id-fresh", StartMetadata{FeedName: "shows", GUID: "guid-fresh"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s.StartReaper(ctx)
+
+	time.Sleep(50 * time.Millisecond)
+
+	_, ok := s.Peek("id-fresh")
+	assert.True(t, ok, "fresh entry should not be reaped")
+}

--- a/cmd/rss4transmission/watch.go
+++ b/cmd/rss4transmission/watch.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -37,6 +39,31 @@ func warnNotifyFeedsWithoutHistory(feeds []Feed, history *HistoryFile) {
 				"it will never be downloadable via /start", f.Name)
 		}
 	}
+}
+
+// logNtfyStatus reports at startup whether ntfy push notifications are
+// enabled and, if so, which topics are active: Topic gates torrent
+// started/found/completed notifications, AlertTopic gates config-reload and
+// port-state notifications, and either can be configured without the other.
+func logNtfyStatus(cfg NtfyConfig) {
+	if cfg.BaseURL == "" {
+		log.Infof("ntfy notifications disabled (Ntfy.BaseURL not configured)")
+		return
+	}
+
+	var active []string
+	if cfg.Topic != "" {
+		active = append(active, fmt.Sprintf("torrent (topic: %s)", cfg.Topic))
+	}
+	if cfg.AlertTopic != "" {
+		active = append(active, fmt.Sprintf("alert (topic: %s)", cfg.AlertTopic))
+	}
+
+	if len(active) == 0 {
+		log.Infof("ntfy notifications configured but no topics set; no notifications will be sent")
+		return
+	}
+	log.Infof("ntfy notifications enabled: %s", strings.Join(active, ", "))
 }
 
 // retryLoadConfig calls tryLoad repeatedly, sleeping interval between attempts.
@@ -244,6 +271,7 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 	}
 
 	warnNotifyFeedsWithoutHistory(ctx.Config.Feeds, ctx.History)
+	logNtfyStatus(ctx.Config.Ntfy)
 
 	var removeT removeFunc
 	var getProgress progressFunc

--- a/cmd/rss4transmission/watch.go
+++ b/cmd/rss4transmission/watch.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/hekmon/transmissionrpc/v3"
+	"github.com/sirupsen/logrus"
 )
 
 const defaultRetryInterval = 60 * time.Second
@@ -17,9 +18,25 @@ type WatchCmd struct {
 	Sleep           int      `kong:"short='s',default='300',help='Seconds to sleep between scraping'"`
 	HistoryFile     string   `kong:"help='Path to history JSON file'"`
 	PrivateListen   string   `kong:"help='Address to serve torrent history on (internal only), as host:port or bare port (disabled if empty)'"`
-	PublicListen    string   `kong:"help='Address to serve /cancel, /notify-complete, and /healthz on (host:port or bare port); splits listeners so history stays on the private listener'"`
+	PublicListen    string   `kong:"help='Address to serve /cancel, /start, /notify-complete, and /healthz on (host:port or bare port); splits listeners so history stays on the private listener'"`
 	TorrentCacheDir string   `kong:"help='Directory to cache fetched .torrent files across runs'"`
 	AccessLog       string   `kong:"help='Path to append-mode HTTP access log for fail2ban integration (disabled if empty)'"`
+}
+
+// warnNotifyFeedsWithoutHistory logs a startup warning for each feed configured
+// with Action: notify when no history file is available: the /start token to
+// history-record mapping requires ctx.History to resolve, so a notify feed
+// with no history file can never be manually started.
+func warnNotifyFeedsWithoutHistory(feeds []Feed, history *HistoryFile) {
+	if history != nil {
+		return
+	}
+	for _, f := range feeds {
+		if f.Action == "notify" {
+			log.Warnf("feed %q has Action: notify but no --history-file was provided; "+
+				"it will never be downloadable via /start", f.Name)
+		}
+	}
 }
 
 // retryLoadConfig calls tryLoad repeatedly, sleeping interval between attempts.
@@ -116,6 +133,68 @@ func (r *configReloader) recover() {
 	}
 }
 
+// setupWebServers wires and starts the HTTP listener(s) for /cancel, /start,
+// /notify-complete, /healthz, and (on the private listener) the history UI,
+// based on which of --public-listen / --private-listen were configured. It
+// sets ctx.CancelRoutesEnabled / ctx.StartRoutesEnabled to reflect what was
+// actually registered. Factored out of WatchCmd.Run to keep its cyclomatic
+// complexity down.
+func setupWebServers(cmd *WatchCmd, ctx *RunContext, removeT removeFunc, getProgress progressFunc,
+	retryHistory retryFunc, feedConfigured func(string) bool, feedGroups func(string) []Group,
+	forgetHistory forgetFunc, accessLog *logrus.Logger,
+) {
+	if cmd.PublicListen != "" {
+		// Split-listener mode: /cancel, /start, /notify-complete, and /healthz on the
+		// public port, history on a separate private port. Cancel/start routes are NOT
+		// registered on the private mux.
+		if ctx.CancelStore != nil {
+			ctx.CancelRoutesEnabled = true
+		}
+		if ctx.StartStore != nil && ctx.History != nil {
+			ctx.StartRoutesEnabled = true
+		}
+		addr, err := parseListenAddr(cmd.PublicListen)
+		if err != nil {
+			log.Fatalf("--public-listen: %s", err)
+		}
+		cancelMux := newCancelMux(ctx.CancelStore, ctx.Config.Notifications, removeT, getProgress,
+			ctx.StartStore, retryHistory, ctx.History, accessLog)
+		registerNotifyCompleteRoute(cancelMux, ctx.Config.Ntfy, ctx.Config.Notifications, accessLog)
+		go startWebServer("public", cancelMux, addr)
+
+		if cmd.PrivateListen != "" {
+			histAddr, err := parseListenAddr(cmd.PrivateListen)
+			if err != nil {
+				log.Fatalf("--private-listen: %s", err)
+			}
+			if ctx.History == nil {
+				log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
+			}
+			go startWebServer("private", newWebMux(ctx.History, retryHistory, feedConfigured, feedGroups, forgetHistory), histAddr)
+		}
+	} else if cmd.PrivateListen != "" {
+		// Single-listener mode: history + cancel on the same port.
+		addr, err := parseListenAddr(cmd.PrivateListen)
+		if err != nil {
+			log.Fatalf("--private-listen: %s", err)
+		}
+		if ctx.History == nil {
+			log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
+		}
+		mux := newWebMux(ctx.History, retryHistory, feedConfigured, feedGroups, forgetHistory)
+		if ctx.CancelStore != nil {
+			registerCancelRoutes(mux, ctx.CancelStore, ctx.Config.Notifications, removeT, getProgress, accessLog)
+			ctx.CancelRoutesEnabled = true
+		}
+		if ctx.StartStore != nil && ctx.History != nil {
+			registerStartRoutes(mux, ctx.StartStore, ctx.Config.Notifications, retryHistory, ctx.History, accessLog)
+			ctx.StartRoutesEnabled = true
+		}
+		registerNotifyCompleteRoute(mux, ctx.Config.Ntfy, ctx.Config.Notifications, accessLog)
+		go startWebServer("private", mux, addr)
+	}
+}
+
 func (cmd *WatchCmd) Run(ctx *RunContext) error {
 	reloader := &configReloader{
 		reload: func() error {
@@ -152,15 +231,19 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 		}
 	}
 
-	// Initialize the cancel store if the HMAC secret is configured.
+	// Initialize the cancel and start stores if the HMAC secret is configured.
 	// The reaper context is cancelled when Run returns, preventing a goroutine leak.
 	reaperCtx, reaperCancel := context.WithCancel(context.Background())
 	defer reaperCancel()
-	if ctx.Config.Cancel.HMACSecret != "" {
-		ttl := time.Duration(ctx.Config.Cancel.TokenTTLH) * time.Hour
+	if ctx.Config.Notifications.HMACSecret != "" {
+		ttl := time.Duration(ctx.Config.Notifications.TokenTTLH) * time.Hour
 		ctx.CancelStore = NewStore(ttl)
 		ctx.CancelStore.StartReaper(reaperCtx)
+		ctx.StartStore = NewStartStore(ttl)
+		ctx.StartStore.StartReaper(reaperCtx)
 	}
+
+	warnNotifyFeedsWithoutHistory(ctx.Config.Feeds, ctx.History)
 
 	var removeT removeFunc
 	var getProgress progressFunc
@@ -235,48 +318,7 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 
 	accessLog := openAccessLog(cmd.AccessLog)
 
-	if cmd.PublicListen != "" {
-		// Split-listener mode: /cancel, /notify-complete, and /healthz on the public
-		// port, history on a separate private port. Cancel routes are NOT registered on
-		// the private mux.
-		if ctx.CancelStore != nil {
-			ctx.CancelRoutesEnabled = true
-		}
-		addr, err := parseListenAddr(cmd.PublicListen)
-		if err != nil {
-			log.Fatalf("--public-listen: %s", err)
-		}
-		cancelMux := newCancelMux(ctx.CancelStore, ctx.Config.Cancel, removeT, getProgress, accessLog)
-		registerNotifyCompleteRoute(cancelMux, ctx.Config.Ntfy, ctx.Config.Cancel, accessLog)
-		go startWebServer("public", cancelMux, addr)
-
-		if cmd.PrivateListen != "" {
-			histAddr, err := parseListenAddr(cmd.PrivateListen)
-			if err != nil {
-				log.Fatalf("--private-listen: %s", err)
-			}
-			if ctx.History == nil {
-				log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
-			}
-			go startWebServer("private", newWebMux(ctx.History, retryHistory, feedConfigured, feedGroups, forgetHistory), histAddr)
-		}
-	} else if cmd.PrivateListen != "" {
-		// Single-listener mode: history + cancel on the same port.
-		addr, err := parseListenAddr(cmd.PrivateListen)
-		if err != nil {
-			log.Fatalf("--private-listen: %s", err)
-		}
-		if ctx.History == nil {
-			log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
-		}
-		mux := newWebMux(ctx.History, retryHistory, feedConfigured, feedGroups, forgetHistory)
-		if ctx.CancelStore != nil {
-			registerCancelRoutes(mux, ctx.CancelStore, ctx.Config.Cancel, removeT, getProgress, accessLog)
-			ctx.CancelRoutesEnabled = true
-		}
-		registerNotifyCompleteRoute(mux, ctx.Config.Ntfy, ctx.Config.Cancel, accessLog)
-		go startWebServer("private", mux, addr)
-	}
+	setupWebServers(cmd, ctx, removeT, getProgress, retryHistory, feedConfigured, feedGroups, forgetHistory, accessLog)
 
 	var g *Gluetun
 	if ctx.Config.Gluetun.Host != "" && ctx.Config.Gluetun.Port != 0 {

--- a/cmd/rss4transmission/watch_test.go
+++ b/cmd/rss4transmission/watch_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestWatchCmd_HasHistoryFileField(t *testing.T) {
@@ -62,6 +64,62 @@ func TestRunContext_NoPublicListenEnabledField(t *testing.T) {
 	if ok {
 		t.Error("RunContext must not have a PublicListenEnabled field; use CancelRoutesEnabled instead")
 	}
+}
+
+func TestRunContext_HasStartRoutesEnabledField(t *testing.T) {
+	_, ok := reflect.TypeOf(RunContext{}).FieldByName("StartRoutesEnabled")
+	if !ok {
+		t.Error("RunContext must have a StartRoutesEnabled field")
+	}
+}
+
+func TestRunContext_HasStartStoreField(t *testing.T) {
+	_, ok := reflect.TypeOf(RunContext{}).FieldByName("StartStore")
+	if !ok {
+		t.Error("RunContext must have a StartStore field")
+	}
+}
+
+// --- warnNotifyFeedsWithoutHistory ---
+
+func TestWarnNotifyFeedsWithoutHistory_WarnsWhenHistoryNil(t *testing.T) {
+	origLog := log
+	defer func() { log = origLog }()
+	lg, buf := makeTestAccessLogger()
+	log = lg
+
+	feeds := []Feed{
+		{Name: "shows", Action: "notify"},
+		{Name: "movies", Action: "download"},
+	}
+	warnNotifyFeedsWithoutHistory(feeds, nil)
+
+	assert.Contains(t, buf.String(), "shows")
+	assert.NotContains(t, buf.String(), "movies")
+}
+
+func TestWarnNotifyFeedsWithoutHistory_NoWarningWhenHistoryConfigured(t *testing.T) {
+	origLog := log
+	defer func() { log = origLog }()
+	lg, buf := makeTestAccessLogger()
+	log = lg
+
+	feeds := []Feed{{Name: "shows", Action: "notify"}}
+	warnNotifyFeedsWithoutHistory(feeds, emptyHistory())
+
+	assert.Empty(t, buf.String())
+}
+
+func TestWarnNotifyFeedsWithoutHistory_NoWarningWhenNoNotifyFeeds(t *testing.T) {
+	origLog := log
+	defer func() { log = origLog }()
+	lg, buf := makeTestAccessLogger()
+	log = lg
+
+	feeds := []Feed{{Name: "movies", Action: "download"}}
+	warnNotifyFeedsWithoutHistory(feeds, nil)
+
+	assert.Empty(t, buf.String())
 }
 
 func TestConfig_NoHistoryFileField(t *testing.T) {

--- a/cmd/rss4transmission/watch_test.go
+++ b/cmd/rss4transmission/watch_test.go
@@ -122,6 +122,68 @@ func TestWarnNotifyFeedsWithoutHistory_NoWarningWhenNoNotifyFeeds(t *testing.T) 
 	assert.Empty(t, buf.String())
 }
 
+// --- logNtfyStatus ---
+
+func TestLogNtfyStatus_DisabledWhenNoBaseURL(t *testing.T) {
+	origLog := log
+	defer func() { log = origLog }()
+	lg, buf := makeTestAccessLogger()
+	log = lg
+
+	logNtfyStatus(NtfyConfig{Topic: "torrents", AlertTopic: "alerts"})
+
+	assert.Contains(t, buf.String(), "disabled")
+	assert.NotContains(t, buf.String(), "torrents")
+	assert.NotContains(t, buf.String(), "alerts")
+}
+
+func TestLogNtfyStatus_TopicOnly(t *testing.T) {
+	origLog := log
+	defer func() { log = origLog }()
+	lg, buf := makeTestAccessLogger()
+	log = lg
+
+	logNtfyStatus(NtfyConfig{BaseURL: "https://ntfy.sh", Topic: "torrents"})
+
+	assert.Contains(t, buf.String(), "torrents")
+	assert.NotContains(t, buf.String(), "alerts")
+}
+
+func TestLogNtfyStatus_AlertTopicOnly(t *testing.T) {
+	origLog := log
+	defer func() { log = origLog }()
+	lg, buf := makeTestAccessLogger()
+	log = lg
+
+	logNtfyStatus(NtfyConfig{BaseURL: "https://ntfy.sh", AlertTopic: "alerts"})
+
+	assert.Contains(t, buf.String(), "alerts")
+	assert.NotContains(t, buf.String(), "torrents")
+}
+
+func TestLogNtfyStatus_BothTopics(t *testing.T) {
+	origLog := log
+	defer func() { log = origLog }()
+	lg, buf := makeTestAccessLogger()
+	log = lg
+
+	logNtfyStatus(NtfyConfig{BaseURL: "https://ntfy.sh", Topic: "torrents", AlertTopic: "alerts"})
+
+	assert.Contains(t, buf.String(), "torrents")
+	assert.Contains(t, buf.String(), "alerts")
+}
+
+func TestLogNtfyStatus_BaseURLSetButNoTopics(t *testing.T) {
+	origLog := log
+	defer func() { log = origLog }()
+	lg, buf := makeTestAccessLogger()
+	log = lg
+
+	logNtfyStatus(NtfyConfig{BaseURL: "https://ntfy.sh"})
+
+	assert.Contains(t, buf.String(), "no topics")
+}
+
 func TestConfig_NoHistoryFileField(t *testing.T) {
 	_, ok := reflect.TypeOf(Config{}).FieldByName("HistoryFile")
 	if ok {

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -32,6 +32,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -41,6 +42,9 @@ var historyTmpl string
 
 //go:embed web/cancel.html
 var cancelTmpl string
+
+//go:embed web/start.html
+var startTmpl string
 
 // removeFunc is the signature for removing torrents from Transmission.
 type removeFunc func(ctx context.Context, ids []int64) error
@@ -68,6 +72,20 @@ type cancelPageData struct {
 	SizeFormatted string
 	Downloaded    string // bytes downloaded so far, formatted (e.g. "234.5 MB"), or "Unknown"
 	Percent       string // percent done (e.g. "12.3%"), or "Unknown"
+	ID            string
+	Expires       int64
+	Sig           string
+}
+
+// startPageData is passed to the /start confirmation template. Unlike
+// cancelPageData it carries no Files list: HistoryRecord does not persist
+// file names, only the torrent-level TorrentURL/SizeBytes used to resubmit.
+type startPageData struct {
+	Title         string
+	FeedName      string
+	Labels        map[string]string
+	SizeFormatted string
+	Published     string
 	ID            string
 	Expires       int64
 	Sig           string
@@ -383,17 +401,28 @@ func makePostForgetHandler(history *HistoryFile, forget forgetFunc) http.Handler
 	}
 }
 
-// newCancelMux builds a public-facing mux serving only GET /cancel, POST /cancel,
-// and GET /healthz. Use this when --public-listen is set to expose the cancel
-// endpoint on its own port, keeping the history page on a separate private listener.
+// newCancelMux builds a public-facing mux serving GET/POST /cancel, GET/POST
+// /start, and GET /healthz. Use this when --public-listen is set to expose
+// these token-gated endpoints on their own port, keeping the history page on
+// a separate private listener.
 // POST /cancel is only registered when both store and remove are non-nil.
+// GET /start is only registered when both startStore and history are
+// non-nil; POST /start additionally requires retry to be non-nil.
 // accessLog is optional; when non-nil each request outcome is written to it.
-func newCancelMux(store *Store, cfg CancelConfig, remove removeFunc, getProgress progressFunc, accessLog *logrus.Logger) *http.ServeMux {
+func newCancelMux(store *Store, cfg NotificationsConfig, remove removeFunc, getProgress progressFunc,
+	startStore *StartStore, retry retryFunc, history *HistoryFile, accessLog *logrus.Logger,
+) *http.ServeMux {
 	mux := http.NewServeMux()
 	if store != nil {
 		mux.HandleFunc("GET /cancel", makeGetCancelHandler(store, cfg, getProgress, accessLog))
 		if remove != nil {
 			mux.HandleFunc("POST /cancel", makePostCancelHandler(store, cfg, remove, accessLog))
+		}
+	}
+	if startStore != nil && history != nil {
+		mux.HandleFunc("GET /start", makeGetStartHandler(startStore, cfg, history, accessLog))
+		if retry != nil {
+			mux.HandleFunc("POST /start", makePostStartHandler(startStore, cfg, history, retry, accessLog))
 		}
 	}
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -404,15 +433,22 @@ func newCancelMux(store *Store, cfg CancelConfig, remove removeFunc, getProgress
 
 // registerCancelRoutes adds GET /cancel and POST /cancel handlers to mux.
 // accessLog is optional; when non-nil each request outcome is written to it.
-func registerCancelRoutes(mux *http.ServeMux, store *Store, cfg CancelConfig, remove removeFunc, getProgress progressFunc, accessLog *logrus.Logger) {
+func registerCancelRoutes(mux *http.ServeMux, store *Store, cfg NotificationsConfig, remove removeFunc, getProgress progressFunc, accessLog *logrus.Logger) {
 	mux.HandleFunc("GET /cancel", makeGetCancelHandler(store, cfg, getProgress, accessLog))
 	mux.HandleFunc("POST /cancel", makePostCancelHandler(store, cfg, remove, accessLog))
+}
+
+// registerStartRoutes adds GET /start and POST /start handlers to mux.
+// accessLog is optional; when non-nil each request outcome is written to it.
+func registerStartRoutes(mux *http.ServeMux, startStore *StartStore, cfg NotificationsConfig, retry retryFunc, history *HistoryFile, accessLog *logrus.Logger) {
+	mux.HandleFunc("GET /start", makeGetStartHandler(startStore, cfg, history, accessLog))
+	mux.HandleFunc("POST /start", makePostStartHandler(startStore, cfg, history, retry, accessLog))
 }
 
 // registerNotifyCompleteRoute adds POST /notify-complete to mux when ntfy is configured.
 // When cancelCfg.HMACSecret is non-empty the endpoint requires
 // Authorization: Bearer <HMACSecret>. accessLog is optional.
-func registerNotifyCompleteRoute(mux *http.ServeMux, ntfyCfg NtfyConfig, cancelCfg CancelConfig, accessLog *logrus.Logger) {
+func registerNotifyCompleteRoute(mux *http.ServeMux, ntfyCfg NtfyConfig, cancelCfg NotificationsConfig, accessLog *logrus.Logger) {
 	if ntfyCfg.BaseURL == "" || ntfyCfg.Topic == "" {
 		return
 	}
@@ -426,7 +462,7 @@ type notifyCompleteRequest struct {
 	ID   int64  `json:"id"`
 }
 
-func makeNotifyCompleteHandler(ntfyCfg NtfyConfig, cancelCfg CancelConfig, accessLog *logrus.Logger) http.HandlerFunc {
+func makeNotifyCompleteHandler(ntfyCfg NtfyConfig, cancelCfg NotificationsConfig, accessLog *logrus.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if cancelCfg.HMACSecret != "" {
 			got := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
@@ -507,7 +543,7 @@ func tokenErrorResponse(w http.ResponseWriter, err error) {
 // makeGetCancelHandler serves the confirmation form. It validates the token,
 // peeks the store for metadata without consuming the entry, and queries
 // Transmission for live download progress via getProgress.
-func makeGetCancelHandler(store *Store, cfg CancelConfig, getProgress progressFunc, accessLog *logrus.Logger) http.HandlerFunc {
+func makeGetCancelHandler(store *Store, cfg NotificationsConfig, getProgress progressFunc, accessLog *logrus.Logger) http.HandlerFunc {
 	secret := []byte(cfg.HMACSecret)
 	tmpl := template.Must(template.New("cancel").Parse(cancelTmpl))
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -586,7 +622,7 @@ func makeGetCancelHandler(store *Store, cfg CancelConfig, getProgress progressFu
 // makePostCancelHandler processes the confirmation form submission. It re-validates
 // the token, removes the torrent from Transmission, and only then consumes the
 // store entry so users can retry if the Transmission call fails.
-func makePostCancelHandler(store *Store, cfg CancelConfig, remove removeFunc, accessLog *logrus.Logger) http.HandlerFunc {
+func makePostCancelHandler(store *Store, cfg NotificationsConfig, remove removeFunc, accessLog *logrus.Logger) http.HandlerFunc {
 	secret := []byte(cfg.HMACSecret)
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
@@ -657,6 +693,182 @@ func makePostCancelHandler(store *Store, cfg CancelConfig, remove removeFunc, ac
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, "Download cancelled.") //nolint:errcheck
+	}
+}
+
+// makeGetStartHandler serves the /start confirmation form. It validates the
+// token, peeks the StartStore for the feed/GUID pair without consuming the
+// entry, then resolves the HistoryRecord to render.
+func makeGetStartHandler(store *StartStore, cfg NotificationsConfig, history *HistoryFile, accessLog *logrus.Logger) http.HandlerFunc {
+	secret := []byte(cfg.HMACSecret)
+	tmpl := template.Must(template.New("start").Parse(startTmpl))
+	return func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		id := q.Get("id")
+		expires, err := parseCancelToken(secret, id, q.Get("expires"), q.Get("sig"))
+		if err != nil {
+			if accessLog != nil {
+				result := "invalid_token"
+				if errors.Is(err, ErrTokenExpired) {
+					result = "expired"
+				}
+				accessLog.WithFields(logrus.Fields{
+					"client_ip": clientIP(r),
+					"endpoint":  "/start",
+					"method":    r.Method,
+					"result":    result,
+				}).Warn("start access")
+			}
+			tokenErrorResponse(w, err)
+			return
+		}
+		sig := q.Get("sig")
+
+		meta, ok := store.Peek(id)
+		if !ok {
+			if accessLog != nil {
+				accessLog.WithFields(logrus.Fields{
+					"client_ip": clientIP(r),
+					"endpoint":  "/start",
+					"method":    r.Method,
+					"result":    "not_found",
+				}).Warn("start access")
+			}
+			http.Error(w, "torrent not found or already started", http.StatusNotFound)
+			return
+		}
+
+		rec, ok := history.FindRecord(meta.FeedName, meta.GUID)
+		if !ok {
+			if accessLog != nil {
+				accessLog.WithFields(logrus.Fields{
+					"client_ip": clientIP(r),
+					"endpoint":  "/start",
+					"method":    r.Method,
+					"result":    "not_found",
+				}).Warn("start access")
+			}
+			http.Error(w, "torrent not found or already started", http.StatusNotFound)
+			return
+		}
+
+		if accessLog != nil {
+			accessLog.WithFields(logrus.Fields{
+				"client_ip": clientIP(r),
+				"endpoint":  "/start",
+				"method":    r.Method,
+				"result":    "ok",
+			}).Info("start access")
+		}
+
+		published := ""
+		if !rec.Published.IsZero() {
+			published = rec.Published.Format(time.RFC1123)
+		}
+
+		data := startPageData{
+			Title:         rec.Title,
+			FeedName:      rec.Feed,
+			Labels:        rec.Labels,
+			SizeFormatted: formatGB(rec.SizeBytes),
+			Published:     published,
+			ID:            id,
+			Expires:       expires,
+			Sig:           sig,
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.Execute(w, data); err != nil {
+			log.WithError(err).Error("Failed to render start template")
+		}
+	}
+}
+
+// makePostStartHandler processes the /start confirmation form submission. It
+// re-validates the token, resolves the HistoryRecord, and submits it via
+// retry (retryHistoryItem). Unlike /cancel, the StartStore entry is never
+// consumed: retryHistoryItem's own outcome guard (dispatched/downloaded ->
+// error) already makes a replayed /start link idempotent.
+func makePostStartHandler(store *StartStore, cfg NotificationsConfig, history *HistoryFile, retry retryFunc, accessLog *logrus.Logger) http.HandlerFunc {
+	secret := []byte(cfg.HMACSecret)
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "invalid form body", http.StatusBadRequest)
+			return
+		}
+
+		id := r.FormValue("id")
+		_, err := parseCancelToken(secret, id, r.FormValue("expires"), r.FormValue("sig"))
+		if err != nil {
+			if accessLog != nil {
+				result := "invalid_token"
+				if errors.Is(err, ErrTokenExpired) {
+					result = "expired"
+				}
+				accessLog.WithFields(logrus.Fields{
+					"client_ip": clientIP(r),
+					"endpoint":  "/start",
+					"method":    r.Method,
+					"result":    result,
+				}).Warn("start access")
+			}
+			tokenErrorResponse(w, err)
+			return
+		}
+
+		meta, ok := store.Peek(id)
+		if !ok {
+			if accessLog != nil {
+				accessLog.WithFields(logrus.Fields{
+					"client_ip": clientIP(r),
+					"endpoint":  "/start",
+					"method":    r.Method,
+					"result":    "not_found",
+				}).Warn("start access")
+			}
+			http.Error(w, "torrent not found or already started", http.StatusNotFound)
+			return
+		}
+
+		rec, ok := history.FindRecord(meta.FeedName, meta.GUID)
+		if !ok {
+			if accessLog != nil {
+				accessLog.WithFields(logrus.Fields{
+					"client_ip": clientIP(r),
+					"endpoint":  "/start",
+					"method":    r.Method,
+					"result":    "not_found",
+				}).Warn("start access")
+			}
+			http.Error(w, "torrent not found or already started", http.StatusNotFound)
+			return
+		}
+
+		if _, err := retry(rec); err != nil {
+			log.WithError(err).Warnf("Failed to start torrent for %q", rec.Title)
+			if accessLog != nil {
+				accessLog.WithFields(logrus.Fields{
+					"client_ip": clientIP(r),
+					"endpoint":  "/start",
+					"method":    r.Method,
+					"result":    "error",
+				}).Warn("start access")
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		if accessLog != nil {
+			accessLog.WithFields(logrus.Fields{
+				"client_ip": clientIP(r),
+				"endpoint":  "/start",
+				"method":    r.Method,
+				"result":    "started",
+			}).Info("start access")
+		}
+		log.Infof("Manually started download via web confirmation: %q (start-id %s)", rec.Title, id)
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "Torrent submitted.") //nolint:errcheck
 	}
 }
 

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -296,6 +296,8 @@ func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name s
 			switch outcome {
 			case "dispatched", "downloaded":
 				return "dispatched"
+			case "notified":
+				return "notified"
 			case "error":
 				return "error"
 			default:

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -529,12 +529,13 @@ func makeNotifyCompleteHandler(ntfyCfg NtfyConfig, cancelCfg NotificationsConfig
 	}
 }
 
-// tokenErrorResponse translates a parseCancelToken error into the appropriate HTTP response.
+// tokenErrorResponse translates a parseCancelToken error into the appropriate
+// HTTP response. Shared by /cancel and /start, so the wording stays generic.
 func tokenErrorResponse(w http.ResponseWriter, err error) {
 	if errors.Is(err, ErrMissingCancelParams) {
 		http.Error(w, "missing required parameters", http.StatusBadRequest)
 	} else if errors.Is(err, ErrTokenExpired) {
-		http.Error(w, "cancel link has expired", http.StatusGone)
+		http.Error(w, "link has expired", http.StatusGone)
 	} else {
 		http.Error(w, "invalid token", http.StatusBadRequest)
 	}

--- a/cmd/rss4transmission/web/history.html
+++ b/cmd/rss4transmission/web/history.html
@@ -43,6 +43,7 @@
         }
         .outcome-pill input:checked + label { color: #e0e0e0; }
         .outcome-pill input:checked + label.dispatched { color: #6f6; border-color: #6f6; }
+        .outcome-pill input:checked + label.notified   { color: #6cf; border-color: #6cf; }
         .outcome-pill input:checked + label.skipped    { color: #fa0; border-color: #fa0; }
         .outcome-pill input:checked + label.excluded   { color: #fa0; border-color: #fa0; }
         .outcome-pill input:checked + label.error      { color: #f66; border-color: #f66; }
@@ -55,6 +56,7 @@
         td { padding: 6px 12px; border-bottom: 1px solid #2a2a2a; vertical-align: top; word-break: break-word; }
         tr:hover td { background: #222; }
         .dispatched { color: #6f6; }
+        .notified { color: #6cf; }
         .error { color: #f66; }
         .skipped { color: #fa0; }
         a { color: inherit; text-decoration: none; }
@@ -129,6 +131,10 @@
                     <label class="dispatched" for="o-dispatched">dispatched</label>
                 </span>
                 <span class="outcome-pill">
+                    <input type="checkbox" id="o-notified" value="notified" checked>
+                    <label class="notified" for="o-notified">notified</label>
+                </span>
+                <span class="outcome-pill">
                     <input type="checkbox" id="o-skipped" value="skipped" checked>
                     <label class="skipped" for="o-skipped">skipped</label>
                 </span>
@@ -189,7 +195,7 @@
     <script>
     (function () {
         var TOTAL = {{ len . }};
-        var ALL_OUTCOMES = ['dispatched', 'skipped', 'excluded', 'error'];
+        var ALL_OUTCOMES = ['dispatched', 'notified', 'skipped', 'excluded', 'error'];
 
         var countEl  = document.getElementById('count');
         var feedSel  = document.getElementById('f-feed');
@@ -384,6 +390,7 @@
 
         function outcomeClass(outcome) {
             if (outcome === 'dispatched' || outcome === 'downloaded') return 'dispatched';
+            if (outcome === 'notified') return 'notified';
             if (outcome === 'error') return 'error';
             return 'skipped';
         }

--- a/cmd/rss4transmission/web/start.html
+++ b/cmd/rss4transmission/web/start.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Start Download — RSS4Transmission</title>
+    <style>
+        body { font-family: monospace; margin: 2em; background: #1a1a1a; color: #e0e0e0; }
+        h1 { color: #6c6; margin-bottom: 0.25em; }
+        p.subtitle { color: #888; margin-top: 0; margin-bottom: 1.5em; }
+
+        table { border-collapse: collapse; margin-bottom: 1.5em; }
+        th {
+            background: #2a2a2a;
+            padding: 6px 14px 6px 0;
+            text-align: left;
+            color: #aaa;
+            font-weight: normal;
+            white-space: nowrap;
+            vertical-align: top;
+        }
+        td { padding: 6px 12px; vertical-align: top; word-break: break-word; }
+        tr:hover td { background: #222; }
+
+        .actions { display: flex; align-items: center; gap: 1.5em; margin-top: 0.5em; }
+        .btn-start {
+            background: #063;
+            color: #fff;
+            border: none;
+            padding: 0.5em 1.6em;
+            font-family: monospace;
+            font-size: 1em;
+            cursor: pointer;
+        }
+        .btn-start:hover { background: #084; }
+        .keep-link { color: #888; font-size: 0.9em; cursor: pointer; text-decoration: underline; }
+        .keep-link:hover { color: #aaa; }
+    </style>
+</head>
+<body>
+    <h1>Start Download?</h1>
+    <p class="subtitle">This torrent was seen but not downloaded automatically. Review the details below and confirm if you want to start it.</p>
+
+    <table>
+        <tr>
+            <th>Feed</th>
+            <td>{{ .FeedName }}</td>
+        </tr>
+        <tr>
+            <th>Title</th>
+            <td>{{ .Title }}</td>
+        </tr>
+        <tr>
+            <th>Size</th>
+            <td>{{ .SizeFormatted }}</td>
+        </tr>
+        {{ if .Published }}
+        <tr>
+            <th>Published</th>
+            <td>{{ .Published }}</td>
+        </tr>
+        {{ end }}
+        {{ range $k, $v := .Labels }}
+        <tr>
+            <th>{{ $k }}</th>
+            <td>{{ $v }}</td>
+        </tr>
+        {{ end }}
+    </table>
+
+    <form method="POST" action="/start">
+        <input type="hidden" name="id"      value="{{ .ID }}">
+        <input type="hidden" name="expires" value="{{ .Expires }}">
+        <input type="hidden" name="sig"     value="{{ .Sig }}">
+        <div class="actions">
+            <button class="btn-start" type="submit">Start Download</button>
+            <a class="keep-link" href="#" onclick="window.close(); return false;">Not Now</a>
+        </div>
+    </form>
+</body>
+</html>

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -470,6 +470,37 @@ func TestHistoryPage_RendersTorrentButtonForSkippedWithURL(t *testing.T) {
 	assert.Contains(t, body, `data-guid="guid-1"`)
 }
 
+func TestHistoryPage_NotifiedOutcomeRendersWithOwnClass(t *testing.T) {
+	h := emptyHistory()
+	rec := NewHistoryRecord("myfeed",
+		makeGofeedItemWithEnclosure("Needs Review", "guid-1", "https://example.com/my.torrent"),
+		"notified", "", nil)
+	h.AddOrUpdateRecord(rec)
+
+	mux := newWebMux(h, nil, nil, nil, nil)
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	assert.Contains(t, body, `data-outcome="notified"`)
+	assert.Contains(t, body, `class="outcome notified"`)
+}
+
+func TestHistoryPage_NotifiedOutcomeFilterPillPresentAndChecked(t *testing.T) {
+	h := emptyHistory()
+	mux := newWebMux(h, nil, nil, nil, nil)
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	assert.Contains(t, body, `id="o-notified" value="notified" checked`,
+		"the notified outcome must have its own filter checkbox, checked by default, or notified records are hidden on load")
+}
+
 func TestHistoryPage_RendersForgetButtonForSkipped(t *testing.T) {
 	h := emptyHistory()
 	rec := NewHistoryRecord("myfeed",

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -32,8 +32,8 @@ func TestHealthzHandler(t *testing.T) {
 
 // --- /cancel helpers ---
 
-func makeCancelCfg(secret, baseURL string) CancelConfig {
-	return CancelConfig{HMACSecret: secret, BaseURL: baseURL, TokenTTLH: 24}
+func makeCancelCfg(secret, baseURL string) NotificationsConfig {
+	return NotificationsConfig{HMACSecret: secret, BaseURL: baseURL, TokenTTLH: 24}
 }
 
 func makeRemoveFunc(called *bool) removeFunc {
@@ -323,7 +323,7 @@ func TestPostCancelHandler_NotFound(t *testing.T) {
 func TestNewCancelMux_HealthzReachable(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newCancelMux(store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
+	mux := newCancelMux(store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil, nil, nil, nil)
 
 	req := httptest.NewRequest("GET", "/healthz", nil)
 	rr := httptest.NewRecorder()
@@ -334,7 +334,7 @@ func TestNewCancelMux_HealthzReachable(t *testing.T) {
 func TestNewCancelMux_CancelReachable(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newCancelMux(store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
+	mux := newCancelMux(store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil, nil, nil, nil)
 
 	// A POST with missing params should return 400, not 404 — proving the route exists.
 	body := strings.NewReader("id=x")
@@ -348,7 +348,7 @@ func TestNewCancelMux_CancelReachable(t *testing.T) {
 func TestNewCancelMux_HistoryNotReachable(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newCancelMux(store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
+	mux := newCancelMux(store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil, nil, nil, nil)
 
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
@@ -358,7 +358,7 @@ func TestNewCancelMux_HistoryNotReachable(t *testing.T) {
 
 func TestNewCancelMux_NilStoreHealthzStillWorks(t *testing.T) {
 	cfg := makeCancelCfg("", "")
-	mux := newCancelMux(nil, cfg, nil, nil, nil)
+	mux := newCancelMux(nil, cfg, nil, nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("GET", "/healthz", nil)
 	rr := httptest.NewRecorder()
@@ -368,7 +368,7 @@ func TestNewCancelMux_NilStoreHealthzStillWorks(t *testing.T) {
 
 func TestNewCancelMux_NilStoreCancelReturns404(t *testing.T) {
 	cfg := makeCancelCfg("", "")
-	mux := newCancelMux(nil, cfg, nil, nil, nil)
+	mux := newCancelMux(nil, cfg, nil, nil, nil, nil, nil, nil)
 
 	body := strings.NewReader("id=x&expires=1&sig=y")
 	req := httptest.NewRequest("POST", "/cancel", body)
@@ -426,7 +426,7 @@ func TestNewCancelMux_NilRemovePostReturns404(t *testing.T) {
 	store.Register("test-id", 42, CancelMetadata{})
 	cfg := makeCancelCfg("secret", "https://example.com")
 	// non-nil store, nil remove → POST /cancel must not be registered (no panic)
-	mux := newCancelMux(store, cfg, nil, nil, nil)
+	mux := newCancelMux(store, cfg, nil, nil, nil, nil, nil, nil)
 
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -983,7 +983,7 @@ func TestPostTorrentHandler_NotRegisteredWhenRetryNil(t *testing.T) {
 func TestPostTorrentHandler_NotRegisteredOnCancelMux(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newCancelMux(store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
+	mux := newCancelMux(store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -1080,7 +1080,7 @@ func TestPostForgetHandler_NotRegisteredWhenForgetNil(t *testing.T) {
 func TestPostForgetHandler_NotRegisteredOnCancelMux(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newCancelMux(store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
+	mux := newCancelMux(store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/forget", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -1486,7 +1486,7 @@ func TestParseListenAddr(t *testing.T) {
 
 // --- POST /notify-complete ---
 
-func makeNotifyCompleteMux(t *testing.T, ntfyCfg NtfyConfig, cancelCfg CancelConfig) *http.ServeMux {
+func makeNotifyCompleteMux(t *testing.T, ntfyCfg NtfyConfig, cancelCfg NotificationsConfig) *http.ServeMux {
 	t.Helper()
 	require.NoError(t, ntfyCfg.Validate())
 	mux := http.NewServeMux()
@@ -1502,7 +1502,7 @@ func TestNotifyComplete_Success(t *testing.T) {
 	}))
 	defer ntfySrv.Close()
 
-	mux := makeNotifyCompleteMux(t, NtfyConfig{BaseURL: ntfySrv.URL, Topic: "t"}, CancelConfig{})
+	mux := makeNotifyCompleteMux(t, NtfyConfig{BaseURL: ntfySrv.URL, Topic: "t"}, NotificationsConfig{})
 	body := bytes.NewBufferString(`{"name":"My.Show.S01E01","dir":"/downloads","id":42}`)
 	req := httptest.NewRequest("POST", "/notify-complete", body)
 	req.Header.Set("Content-Type", "application/json")
@@ -1521,7 +1521,7 @@ func TestNotifyComplete_BadJSON(t *testing.T) {
 	}))
 	defer ntfySrv.Close()
 
-	mux := makeNotifyCompleteMux(t, NtfyConfig{BaseURL: ntfySrv.URL, Topic: "t"}, CancelConfig{})
+	mux := makeNotifyCompleteMux(t, NtfyConfig{BaseURL: ntfySrv.URL, Topic: "t"}, NotificationsConfig{})
 	req := httptest.NewRequest("POST", "/notify-complete", bytes.NewBufferString(`not-json`))
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -1535,7 +1535,7 @@ func TestNotifyComplete_NtfyError(t *testing.T) {
 	}))
 	defer ntfySrv.Close()
 
-	mux := makeNotifyCompleteMux(t, NtfyConfig{BaseURL: ntfySrv.URL, Topic: "t"}, CancelConfig{})
+	mux := makeNotifyCompleteMux(t, NtfyConfig{BaseURL: ntfySrv.URL, Topic: "t"}, NotificationsConfig{})
 	body := bytes.NewBufferString(`{"name":"My.Show","dir":"/dl","id":1}`)
 	req := httptest.NewRequest("POST", "/notify-complete", body)
 	rr := httptest.NewRecorder()
@@ -1556,7 +1556,7 @@ func TestNotifyComplete_CustomTemplate(t *testing.T) {
 		BaseURL:        ntfySrv.URL,
 		Topic:          "t",
 		CompletedTitle: "Done: {{.Title}}",
-	}, CancelConfig{})
+	}, NotificationsConfig{})
 	body := bytes.NewBufferString(`{"name":"My.Show.S01E01","dir":"/dl","id":7}`)
 	req := httptest.NewRequest("POST", "/notify-complete", body)
 	rr := httptest.NewRecorder()
@@ -1578,7 +1578,7 @@ func TestNotifyComplete_CustomPriority(t *testing.T) {
 		BaseURL:           ntfySrv.URL,
 		Topic:             "t",
 		CompletedPriority: "high",
-	}, CancelConfig{})
+	}, NotificationsConfig{})
 	body := bytes.NewBufferString(`{"name":"My.Show","dir":"/dl","id":3}`)
 	req := httptest.NewRequest("POST", "/notify-complete", body)
 	rr := httptest.NewRecorder()
@@ -1592,7 +1592,7 @@ func TestNotifyComplete_NotRegisteredWhenNtfyUnconfigured(t *testing.T) {
 	mux := http.NewServeMux()
 	ntfyCfg := NtfyConfig{} // no BaseURL/Topic
 	require.NoError(t, ntfyCfg.Validate())
-	registerNotifyCompleteRoute(mux, ntfyCfg, CancelConfig{}, nil)
+	registerNotifyCompleteRoute(mux, ntfyCfg, NotificationsConfig{}, nil)
 
 	req := httptest.NewRequest("POST", "/notify-complete", nil)
 	rr := httptest.NewRecorder()
@@ -1608,7 +1608,7 @@ func TestNotifyComplete_Auth_NoSecretConfigured(t *testing.T) {
 	defer ntfySrv.Close()
 
 	// HMACSecret empty → no auth required
-	mux := makeNotifyCompleteMux(t, NtfyConfig{BaseURL: ntfySrv.URL, Topic: "t"}, CancelConfig{})
+	mux := makeNotifyCompleteMux(t, NtfyConfig{BaseURL: ntfySrv.URL, Topic: "t"}, NotificationsConfig{})
 	body := bytes.NewBufferString(`{"name":"My.Show","dir":"/dl","id":1}`)
 	req := httptest.NewRequest("POST", "/notify-complete", body)
 	rr := httptest.NewRecorder()
@@ -1623,7 +1623,7 @@ func TestNotifyComplete_Auth_MissingHeader(t *testing.T) {
 	}))
 	defer ntfySrv.Close()
 
-	cancelCfg := CancelConfig{HMACSecret: "supersecret"}
+	cancelCfg := NotificationsConfig{HMACSecret: "supersecret"}
 	mux := makeNotifyCompleteMux(t, NtfyConfig{BaseURL: ntfySrv.URL, Topic: "t"}, cancelCfg)
 	body := bytes.NewBufferString(`{"name":"My.Show","dir":"/dl","id":1}`)
 	req := httptest.NewRequest("POST", "/notify-complete", body)
@@ -1640,7 +1640,7 @@ func TestNotifyComplete_Auth_WrongToken(t *testing.T) {
 	}))
 	defer ntfySrv.Close()
 
-	cancelCfg := CancelConfig{HMACSecret: "supersecret"}
+	cancelCfg := NotificationsConfig{HMACSecret: "supersecret"}
 	mux := makeNotifyCompleteMux(t, NtfyConfig{BaseURL: ntfySrv.URL, Topic: "t"}, cancelCfg)
 	body := bytes.NewBufferString(`{"name":"My.Show","dir":"/dl","id":1}`)
 	req := httptest.NewRequest("POST", "/notify-complete", body)
@@ -1659,7 +1659,7 @@ func TestNotifyComplete_Auth_CorrectToken(t *testing.T) {
 	}))
 	defer ntfySrv.Close()
 
-	cancelCfg := CancelConfig{HMACSecret: "supersecret"}
+	cancelCfg := NotificationsConfig{HMACSecret: "supersecret"}
 	mux := makeNotifyCompleteMux(t, NtfyConfig{BaseURL: ntfySrv.URL, Topic: "t"}, cancelCfg)
 	body := bytes.NewBufferString(`{"name":"My.Show","dir":"/dl","id":1}`)
 	req := httptest.NewRequest("POST", "/notify-complete", body)
@@ -1679,7 +1679,7 @@ func TestNotifyComplete_EmptyName(t *testing.T) {
 	}))
 	defer ntfySrv.Close()
 
-	mux := makeNotifyCompleteMux(t, NtfyConfig{BaseURL: ntfySrv.URL, Topic: "t"}, CancelConfig{})
+	mux := makeNotifyCompleteMux(t, NtfyConfig{BaseURL: ntfySrv.URL, Topic: "t"}, NotificationsConfig{})
 	body := bytes.NewBufferString(`{"name":"","dir":"/dl","id":1}`)
 	req := httptest.NewRequest("POST", "/notify-complete", body)
 	rr := httptest.NewRecorder()
@@ -1697,7 +1697,7 @@ func TestNotifyComplete_BodyTooLarge(t *testing.T) {
 	}))
 	defer ntfySrv.Close()
 
-	mux := makeNotifyCompleteMux(t, NtfyConfig{BaseURL: ntfySrv.URL, Topic: "t"}, CancelConfig{})
+	mux := makeNotifyCompleteMux(t, NtfyConfig{BaseURL: ntfySrv.URL, Topic: "t"}, NotificationsConfig{})
 	// Build a valid JSON body that exceeds 1 MB.
 	huge := `{"name":"` + strings.Repeat("x", 2<<20) + `","dir":"/dl","id":1}`
 	req := httptest.NewRequest("POST", "/notify-complete", strings.NewReader(huge))
@@ -1722,13 +1722,356 @@ func TestNotifyComplete_SizeIsUnknown(t *testing.T) {
 		BaseURL:       ntfySrv.URL,
 		Topic:         "t",
 		CompletedBody: "{{.Size}}",
-	}, CancelConfig{})
+	}, NotificationsConfig{})
 	req := httptest.NewRequest("POST", "/notify-complete", bytes.NewBufferString(`{"name":"My.Show","dir":"/dl","id":1}`))
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, "Unknown", string(body))
+}
+
+// --- /start helpers ---
+
+func historyWithNotifiedRecord(feed, guid, title string) *HistoryFile {
+	h := emptyHistory()
+	rec := NewHistoryRecord(feed, makeGofeedItem(title, guid), "notified", "", map[string]string{"show": "My Show"})
+	h.AddOrUpdateRecord(rec)
+	return h
+}
+
+// --- GET /start ---
+
+func TestGetStartHandler_RendersForm(t *testing.T) {
+	store := NewStartStore(time.Hour)
+	store.Register("test-id", StartMetadata{FeedName: "shows", GUID: "guid-1"})
+	h := historyWithNotifiedRecord("shows", "guid-1", "My Show S01E01")
+
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
+
+	mux := newWebMux(nil, nil, nil, nil, nil)
+	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), h, nil)
+
+	req := httptest.NewRequest("GET",
+		fmt.Sprintf("/start?id=test-id&expires=%d&sig=%s", expires, sig), nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	assert.Contains(t, body, "My Show S01E01", "title should appear in form")
+	assert.Contains(t, body, "shows", "feed name should appear in form")
+}
+
+func TestGetStartHandler_MissingParams(t *testing.T) {
+	store := NewStartStore(time.Hour)
+	cfg := makeCancelCfg("secret", "https://example.com")
+	mux := newWebMux(nil, nil, nil, nil, nil)
+	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), emptyHistory(), nil)
+
+	req := httptest.NewRequest("GET", "/start?id=test-id", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestGetStartHandler_BadSignature(t *testing.T) {
+	store := NewStartStore(time.Hour)
+	store.Register("test-id", StartMetadata{FeedName: "shows", GUID: "guid-1"})
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
+
+	mux := newWebMux(nil, nil, nil, nil, nil)
+	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), emptyHistory(), nil)
+
+	req := httptest.NewRequest("GET",
+		fmt.Sprintf("/start?id=test-id&expires=%d&sig=badsig", expires), nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestGetStartHandler_Expired(t *testing.T) {
+	store := NewStartStore(time.Hour)
+	store.Register("test-id", StartMetadata{FeedName: "shows", GUID: "guid-1"})
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
+
+	mux := newWebMux(nil, nil, nil, nil, nil)
+	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), emptyHistory(), nil)
+
+	req := httptest.NewRequest("GET",
+		fmt.Sprintf("/start?id=test-id&expires=%d&sig=%s", expires, sig), nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusGone, rr.Code)
+}
+
+func TestGetStartHandler_NotFoundInStore(t *testing.T) {
+	store := NewStartStore(time.Hour)
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
+
+	mux := newWebMux(nil, nil, nil, nil, nil)
+	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), emptyHistory(), nil)
+
+	req := httptest.NewRequest("GET",
+		fmt.Sprintf("/start?id=ghost-id&expires=%d&sig=%s", expires, sig), nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestGetStartHandler_NotFoundInHistory(t *testing.T) {
+	store := NewStartStore(time.Hour)
+	store.Register("test-id", StartMetadata{FeedName: "shows", GUID: "guid-missing"})
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
+
+	mux := newWebMux(nil, nil, nil, nil, nil)
+	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), emptyHistory(), nil)
+
+	req := httptest.NewRequest("GET",
+		fmt.Sprintf("/start?id=test-id&expires=%d&sig=%s", expires, sig), nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestGetStartHandler_DoesNotConsumeEntry(t *testing.T) {
+	store := NewStartStore(time.Hour)
+	store.Register("test-id", StartMetadata{FeedName: "shows", GUID: "guid-1"})
+	h := historyWithNotifiedRecord("shows", "guid-1", "Keep Me")
+
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
+
+	mux := newWebMux(nil, nil, nil, nil, nil)
+	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), h, nil)
+
+	req := httptest.NewRequest("GET",
+		fmt.Sprintf("/start?id=test-id&expires=%d&sig=%s", expires, sig), nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	_, ok := store.Peek("test-id")
+	assert.True(t, ok, "entry must still be present after GET")
+}
+
+// --- POST /start ---
+
+func TestPostStartHandler_Valid(t *testing.T) {
+	store := NewStartStore(time.Hour)
+	store.Register("test-id", StartMetadata{FeedName: "shows", GUID: "guid-1"})
+	h := historyWithNotifiedRecord("shows", "guid-1", "My Show S01E01")
+
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
+
+	called := false
+	var gotRec HistoryRecord
+	mux := newWebMux(nil, nil, nil, nil, nil)
+	registerStartRoutes(mux, store, cfg, makeRetryFunc(&called, &gotRec, 42, nil), h, nil)
+
+	body := makeCancelFormBody("test-id", expires, sig)
+	req := httptest.NewRequest("POST", "/start", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.True(t, called, "retry should have been called")
+	assert.Equal(t, "shows", gotRec.Feed)
+	assert.Equal(t, "guid-1", gotRec.GUID)
+}
+
+func TestPostStartHandler_MissingParams(t *testing.T) {
+	store := NewStartStore(time.Hour)
+	cfg := makeCancelCfg("secret", "https://example.com")
+	mux := newWebMux(nil, nil, nil, nil, nil)
+	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), emptyHistory(), nil)
+
+	body := strings.NewReader("id=test-id") // missing expires and sig
+	req := httptest.NewRequest("POST", "/start", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestPostStartHandler_BadSignature(t *testing.T) {
+	store := NewStartStore(time.Hour)
+	store.Register("test-id", StartMetadata{FeedName: "shows", GUID: "guid-1"})
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
+
+	mux := newWebMux(nil, nil, nil, nil, nil)
+	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), emptyHistory(), nil)
+
+	body := makeCancelFormBody("test-id", expires, "badsig")
+	req := httptest.NewRequest("POST", "/start", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestPostStartHandler_Expired(t *testing.T) {
+	store := NewStartStore(time.Hour)
+	store.Register("test-id", StartMetadata{FeedName: "shows", GUID: "guid-1"})
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
+
+	mux := newWebMux(nil, nil, nil, nil, nil)
+	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), emptyHistory(), nil)
+
+	body := makeCancelFormBody("test-id", expires, sig)
+	req := httptest.NewRequest("POST", "/start", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusGone, rr.Code)
+}
+
+func TestPostStartHandler_NotFoundInStore(t *testing.T) {
+	store := NewStartStore(time.Hour)
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
+
+	mux := newWebMux(nil, nil, nil, nil, nil)
+	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), emptyHistory(), nil)
+
+	body := makeCancelFormBody("ghost-id", expires, sig)
+	req := httptest.NewRequest("POST", "/start", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestPostStartHandler_NotFoundInHistory(t *testing.T) {
+	store := NewStartStore(time.Hour)
+	store.Register("test-id", StartMetadata{FeedName: "shows", GUID: "guid-missing"})
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
+
+	called := false
+	mux := newWebMux(nil, nil, nil, nil, nil)
+	registerStartRoutes(mux, store, cfg, makeRetryFunc(&called, nil, 42, nil), emptyHistory(), nil)
+
+	body := makeCancelFormBody("test-id", expires, sig)
+	req := httptest.NewRequest("POST", "/start", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	assert.False(t, called, "retry must not be called for an unknown record")
+}
+
+func TestPostStartHandler_RetryError(t *testing.T) {
+	store := NewStartStore(time.Hour)
+	store.Register("test-id", StartMetadata{FeedName: "shows", GUID: "guid-1"})
+	h := historyWithNotifiedRecord("shows", "guid-1", "My Show S01E01")
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
+
+	mux := newWebMux(nil, nil, nil, nil, nil)
+	registerStartRoutes(mux, store, cfg,
+		makeRetryFunc(new(bool), nil, 0, fmt.Errorf("boom: no torrent URL")), h, nil)
+
+	body := makeCancelFormBody("test-id", expires, sig)
+	req := httptest.NewRequest("POST", "/start", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.NotEqual(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "boom: no torrent URL")
+
+	// A retry failure must not consume the store entry so the user can retry.
+	_, ok := store.Peek("test-id")
+	assert.True(t, ok, "store entry must survive a failed retry")
+}
+
+func TestPostStartHandler_DoesNotConsumeStoreEntryOnSuccess(t *testing.T) {
+	store := NewStartStore(time.Hour)
+	store.Register("test-id", StartMetadata{FeedName: "shows", GUID: "guid-1"})
+	h := historyWithNotifiedRecord("shows", "guid-1", "My Show S01E01")
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
+
+	mux := newWebMux(nil, nil, nil, nil, nil)
+	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), h, nil)
+
+	body := makeCancelFormBody("test-id", expires, sig)
+	req := httptest.NewRequest("POST", "/start", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// StartStore deliberately has no consume method: retryHistoryItem's own
+	// outcome guard makes a replayed /start link idempotent.
+	_, ok := store.Peek("test-id")
+	assert.True(t, ok, "StartStore never consumes entries; idempotency comes from retryHistoryItem")
+}
+
+// --- newCancelMux /start wiring ---
+
+func TestNewCancelMux_StartReachable(t *testing.T) {
+	store := NewStartStore(time.Hour)
+	store.Register("test-id", StartMetadata{FeedName: "shows", GUID: "guid-1"})
+	h := historyWithNotifiedRecord("shows", "guid-1", "My Show S01E01")
+	cfg := makeCancelCfg("secret", "https://example.com")
+	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
+
+	mux := newCancelMux(nil, cfg, nil, nil, store, makeRetryFunc(new(bool), nil, 42, nil), h, nil)
+
+	req := httptest.NewRequest("GET",
+		fmt.Sprintf("/start?id=test-id&expires=%d&sig=%s", expires, sig), nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestNewCancelMux_NilStartStoreStartReturns404(t *testing.T) {
+	cfg := makeCancelCfg("", "")
+	mux := newCancelMux(nil, cfg, nil, nil, nil, nil, nil, nil)
+
+	req := httptest.NewRequest("GET", "/start?id=x&expires=1&sig=y", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestNewCancelMux_NilRetryStartPostReturns404(t *testing.T) {
+	store := NewStartStore(time.Hour)
+	cfg := makeCancelCfg("secret", "https://example.com")
+	// non-nil startStore, nil retry -> POST /start must not be registered
+	mux := newCancelMux(nil, cfg, nil, nil, store, nil, emptyHistory(), nil)
+
+	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
+	body := makeCancelFormBody("test-id", expires, sig)
+	req := httptest.NewRequest("POST", "/start", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code,
+		"POST /start must not be registered when retry is nil")
 }
 
 func TestStartWebServer_LogsName(t *testing.T) {

--- a/docker-compose-gluetun.yaml
+++ b/docker-compose-gluetun.yaml
@@ -21,7 +21,7 @@ services:
       - LOG_LEVEL=info
       - HISTORY_FILE=       # path to history JSON file (e.g. /config/history.json)
       - PRIVATE_LISTEN=     # set to host:port or bare port to enable the history web UI (private)
-      - PUBLIC_LISTEN=      # public-facing /cancel, /notify-complete, and /healthz only (e.g. 0.0.0.0:8080)
+      - PUBLIC_LISTEN=      # public-facing /cancel, /start, /notify-complete, and /healthz only (e.g. 0.0.0.0:8080)
                             # port-forward from your firewall/NAS to this port
       - TORRENT_CACHE_DIR=  # directory to cache fetched .torrent files (e.g. /config/torrent-cache)
     # Uncomment and set the port to match PUBLIC_LISTEN (and/or PRIVATE_LISTEN).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,21 +11,22 @@ services:
       - LOG_LEVEL=info
       - HISTORY_FILE=       # path to history JSON file (e.g. /config/history.json)
       - PRIVATE_LISTEN=     # host:port or bare port — enables history UI (private/internal listener)
-      - PUBLIC_LISTEN=      # host:port or bare port — public-facing /cancel, /notify-complete,
+      - PUBLIC_LISTEN=      # host:port or bare port — public-facing /cancel, /start, /notify-complete,
                             # and /healthz only. Set PUBLIC_LISTEN and port-forward from your firewall
-                            # to expose /cancel without exposing the history UI.
+                            # to expose /cancel and /start without exposing the history UI.
                             # Example: PUBLIC_LISTEN=0.0.0.0:8080
-                            # If only PRIVATE_LISTEN is set, /cancel is served there too (Traefik mode).
+                            # If only PRIVATE_LISTEN is set, /cancel and /start are served there too
+                            # (Traefik mode).
       - TORRENT_CACHE_DIR=  # directory to cache fetched .torrent files (e.g. /config/torrent-cache)
     volumes:
       - /volume1/docker/transmission/rss4transmission:/config
-    # Option A — Traefik routes only /cancel and /healthz externally (PUBLIC_LISTEN not needed):
+    # Option A — Traefik routes only /cancel, /start, and /healthz externally (PUBLIC_LISTEN not needed):
     networks:
       - internal
       - traefik
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.rss4tx.rule=Host(`rss4transmission.yourdomain.com`) && (PathPrefix(`/cancel`) || PathPrefix(`/healthz`))"
+      - "traefik.http.routers.rss4tx.rule=Host(`rss4transmission.yourdomain.com`) && (PathPrefix(`/cancel`) || PathPrefix(`/start`) || PathPrefix(`/healthz`))"
       - "traefik.http.routers.rss4tx.entrypoints=websecure"
       - "traefik.http.routers.rss4tx.tls.certresolver=letsencrypt"
       - "traefik.http.services.rss4tx.loadbalancer.server.port=8080"

--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -16,6 +16,33 @@ All feeds support these options:
 | `NoValidateCert` | Skip TLS certificate validation for this feed's URL |
 | `NoSubmit` | Dry-run: log matches but do not send to Transmission |
 | `NoNotify` | Skip ntfy notifications for this feed (see [Notifications](notifications.md)) |
+| `Action` | `download` (default) submits matches to Transmission automatically. `notify` sends a push notification instead and waits for manual confirmation (see [Notify-only feeds](#notify-only-feeds)). |
+
+`Action: notify` and `NoNotify: true` cannot be combined on the same feed — a feed that never
+notifies and never auto-downloads would produce matches nobody can act on.
+
+### Notify-only feeds
+
+Setting `Action: notify` on a feed changes what happens when an item matches: instead of being
+submitted to Transmission right away, the match is recorded and a push notification is sent (see
+[Notifications](notifications.md)) with a link to a confirmation page. Visiting that page and
+clicking "Start Download" is what actually submits the torrent.
+
+```yaml
+Feeds:
+  - Name: TalkShowUS
+    URL: https://rss.example.com/feed
+    Action: notify
+    Extractor: talkshow
+    Identity: [edition, episode, segment]
+```
+
+This requires `watch` to be run with `--history-file` and a listener (`--private-listen` and/or
+`--public-listen`) configured — the notify link resolves to a history record, and the in-memory
+token store that backs it only exists while `watch` is running. `once` cannot serve `/start` links
+at all, since there is no long-running process to hold the token. A feed with `Action: notify` but
+no `--history-file` configured logs a startup warning, since its matches would never be
+downloadable.
 
 `Feeds` is a list, so feeds are always processed in the order they appear in the config file. As
 soon as one item is actually dispatched (submitted to Transmission or downloaded to disk with

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -2,12 +2,16 @@
 
 ## Overview
 
-RSS4Transmission supports four kinds of push notifications via [ntfy](https://ntfy.sh):
+RSS4Transmission supports five kinds of push notifications via [ntfy](https://ntfy.sh):
 
 - **Torrent started** — sent by rss4transmission immediately after submitting a torrent to
   Transmission. Includes a **More Info** action button that opens a browser confirmation
   page showing torrent details and live download progress. Confirming removes the torrent from
   Transmission.
+- **Torrent found** — sent instead of "Torrent started" for feeds configured with
+  `Action: notify` (see [Notify-only feeds](feeds.md#notify-only-feeds)). Includes a **Start
+  Download** action button that opens a confirmation page; nothing is submitted to Transmission
+  until you confirm there. See [Start Endpoint](#start-endpoint) below.
 - **Torrent completed** — sent via the `POST /notify-complete` endpoint, which is called by
   `bin/torrent-complete.sh` running as Transmission's "torrent done" hook. The endpoint renders
   your configured templates and sends the notification to ntfy.
@@ -17,9 +21,9 @@ RSS4Transmission supports four kinds of push notifications via [ntfy](https://nt
   (e.g. a YAML parse error), so a bad edit is visible immediately without tailing logs.
 - **Port closed / reopened** — see [Port Notifications](#port-notifications) below.
 
-## ntfy and Cancel Configuration
+## ntfy and Notifications Configuration
 
-Add `Ntfy` and `Cancel` blocks to your config file:
+Add `Ntfy` and `Notifications` blocks to your config file:
 
 ```yaml
 Ntfy:
@@ -28,10 +32,10 @@ Ntfy:
   AlertTopic: <your-alert-topic-name>      # ntfy topic to publish to (config-reload / port alerts)
   Token:      tk_<your-access-token>       # ntfy access token
 
-Cancel:
+Notifications:
   HMACSecret: <random-32-byte-hex>                   # generate: openssl rand -hex 32
   BaseURL:    https://rss4transmission.yourdomain.com # externally reachable URL
-  TokenTTLH:  24                                     # cancel link TTL in hours (default: 24)
+  TokenTTLH:  24                                     # cancel/start link TTL in hours (default: 24), shared by both
 
 # Only needed to enable the port-open check/alerts when Gluetun is NOT configured
 # (with Gluetun configured, the check runs automatically). See Port Notifications below.
@@ -50,6 +54,9 @@ PortCheck:
 | `Ntfy.CompletedTitle` | `"Torrent Complete"` | `text/template` string for the completed notification title |
 | `Ntfy.CompletedBody` | `"{{.Title}}\n{{.Dir}}"` | `text/template` string for the completed notification body |
 | `Ntfy.CompletedPriority` | `default` | ntfy priority for completed notifications |
+| `Ntfy.SeenTitle` | `"Torrent Found"` | `text/template` string for the notify-only "found" notification title (`Action: notify` feeds) |
+| `Ntfy.SeenBody` | `"{{.Title}}\n{{.Size}}"` | `text/template` string for the notify-only "found" notification body |
+| `Ntfy.SeenPriority` | `default` | ntfy priority for notify-only "found" notifications |
 | `Ntfy.AlertTopic` | — | ntfy topic to publish config-reload and port-state notifications to |
 | `Ntfy.ConfigReloadedTitle` | `"Config Reloaded"` | `text/template` string for the reload-success notification title |
 | `Ntfy.ConfigReloadedBody` | `"{{.ConfigFile}}"` | `text/template` string for the reload-success notification body |
@@ -64,20 +71,22 @@ PortCheck:
 | `Ntfy.PortOpenedBody` | `"{{.Reason}}"` | `text/template` string for the port-reopened notification body |
 | `Ntfy.PortOpenedPriority` | `default` | ntfy priority for port-reopened notifications |
 | `PortCheck.Enabled` | `false` | Enables the periodic port-open check when Gluetun is **not** configured (see [Port Notifications](#port-notifications)) |
-| `Cancel.HMACSecret` | — | Secret key for signing cancel URLs (HMAC-SHA256) |
-| `Cancel.BaseURL` | — | Public base URL of rss4transmission (used in cancel links) |
-| `Cancel.TokenTTLH` | `24` | Hours before a cancel link expires |
+| `Notifications.HMACSecret` | — | Secret key for signing cancel/start URLs (HMAC-SHA256) |
+| `Notifications.BaseURL` | — | Public base URL of rss4transmission (used in cancel/start links) |
+| `Notifications.TokenTTLH` | `24` | Hours before a cancel or start link expires (shared by both) |
 
-Cancel links are omitted from notifications when `Cancel.HMACSecret` or `Cancel.BaseURL` is not
-configured — the torrent started notification is still sent, just without the cancel action.
-Ntfy notifications are entirely disabled when `Ntfy.BaseURL` is not set. `Ntfy.Topic` and
-`Ntfy.AlertTopic` gate their respective notification groups independently: torrent
-started/completed notifications require `Topic`, config-reload and port-state notifications
-require `AlertTopic`, and either can be configured without the other.
+Cancel/start links are omitted from notifications when `Notifications.HMACSecret` or
+`Notifications.BaseURL` is not configured — the torrent started/found notification is still sent,
+just without the action link. Ntfy notifications are entirely disabled when `Ntfy.BaseURL` is not
+set. `Ntfy.Topic` and `Ntfy.AlertTopic` gate their respective notification groups independently:
+torrent started/found/completed notifications require `Topic`, config-reload and port-state
+notifications require `AlertTopic`, and either can be configured without the other.
 
-> **Breaking rename:** `Ntfy.ConfigTopic` was renamed to `Ntfy.AlertTopic`. If your config sets
+> **Breaking renames:** `Ntfy.ConfigTopic` was renamed to `Ntfy.AlertTopic`. If your config sets
 > `ConfigTopic`, rename it to `AlertTopic` — it now gates both config-reload and port-state
-> notifications together.
+> notifications together. Separately, the `Cancel` config section was renamed to `Notifications`
+> (`Cancel.HMACSecret` → `Notifications.HMACSecret`, etc.) since it's now shared by both the
+> `/cancel` and `/start` endpoints.
 
 ## Notification Templates
 
@@ -97,8 +106,9 @@ are available:
 | `{{.GUID}}` | `string` | RSS item GUID | Empty for completions |
 | `{{.Link}}` | `string` | RSS item URL (web page) | Empty for completions |
 | `{{.Published}}` | `*time.Time` | RSS item publication time | May be `nil`; guard with `{{if .Published}}` |
-| `{{.TorrentID}}` | `int64` | Transmission torrent ID | |
-| `{{.CancelURL}}` | `string` | Signed cancel link | Empty when cancel is not configured |
+| `{{.TorrentID}}` | `int64` | Transmission torrent ID | `0` for "found" notifications, since nothing has been submitted yet |
+| `{{.CancelURL}}` | `string` | Signed cancel link | Empty when cancel is not configured; only populated for started notifications |
+| `{{.StartURL}}` | `string` | Signed start link | Empty when start is not configured; only populated for found notifications (`Action: notify` feeds) |
 
 Valid `Priority` values: `min`, `low`, `default`, `high`, `max`.
 
@@ -198,20 +208,20 @@ There are two deployment models.
 
 **Model 1 — Traefik (or other reverse proxy)**
 
-Use `--private-listen` to start a single web server and let Traefik route only `/cancel` and
-`/healthz` externally:
+Use `--private-listen` to start a single web server and let Traefik route only `/cancel`, `/start`,
+and `/healthz` externally:
 
 ```bash
 rss4transmission watch --config config.yaml --private-listen :8080
 ```
 
 The [docker-compose.yaml](../docker-compose.yaml) example defaults to this model. Its Traefik
-labels route only those two paths externally while keeping the history page (`/`) internal.
+labels route only those paths externally while keeping the history page (`/`) internal.
 
 **Model 2 — Direct port-forward (no reverse proxy)**
 
 Use `--public-listen` to start a separate public-facing listener that serves only `/cancel`,
-`/notify-complete`, and `/healthz`, keeping the history page on `--private-listen`
+`/start`, `/notify-complete`, and `/healthz`, keeping the history page on `--private-listen`
 (internal only):
 
 ```bash
@@ -236,6 +246,26 @@ ports:
 
 When using [docker-compose-gluetun.yaml](../docker-compose-gluetun.yaml), set `PUBLIC_LISTEN`
 and uncomment the `ports` block to forward the cancel port from your firewall or NAS.
+
+## Start Endpoint
+
+The `/start` endpoint serves a confirmation page for feeds configured with `Action: notify` (see
+[Notify-only feeds](feeds.md#notify-only-feeds)): the user reviews the torrent details and clicks
+"Start Download" to submit it to Transmission. It shares deployment, listener, and token
+configuration with `/cancel` — everything in [Cancel Endpoint](#cancel-endpoint) above (Traefik
+vs. direct port-forward, `Notifications.HMACSecret`/`BaseURL`/`TokenTTLH`) applies equally to
+`/start`.
+
+`/start` additionally requires `--history-file`: the link's token only carries a feed name and
+GUID, which is resolved to the full torrent details (and re-submitted) via the history record. The
+in-memory token → (feed, GUID) mapping lives only for the lifetime of the running `watch` process
+— it is not persisted, so a `/start` link stops working across a restart, and `once` (which does
+not run a long-lived server) can never serve it. `watch` logs a startup warning for any
+`Action: notify` feed if `--history-file` is not provided.
+
+Unlike `/cancel`, confirming `/start` is safely repeatable: `retryHistoryItem` already rejects a
+record whose outcome is `dispatched`/`downloaded`, so re-visiting or re-submitting the same link
+after a successful start is a no-op rather than a duplicate submission.
 
 ## History Web UI
 
@@ -308,6 +338,7 @@ environment:
 | `/torrent` | ✓ (requires `--history-file`) | ✓ (requires `--history-file`) | — |
 | `/forget` | ✓ (requires `--history-file`) | ✓ (requires `--history-file`) | — |
 | `/cancel` | ✓ | — | ✓ |
+| `/start` | ✓ (requires `--history-file`) | — | ✓ (requires `--history-file`) |
 | `/notify-complete` | ✓ | — | ✓ |
 | `/healthz` | ✓ | ✓ | ✓ |
 
@@ -318,15 +349,15 @@ details to the `/notify-complete` endpoint, which renders your configured `Compl
 `CompletedBody`, and `CompletedPriority` templates before sending to ntfy.
 
 Set `RSS4TRANSMISSION_URL` to the base URL of your rss4transmission server (same host:port as
-`--public-listen` or `--private-listen`). If `Cancel.HMACSecret` is configured, also set
-`CANCEL_HMAC_SECRET` to the same value — the endpoint will then require
+`--public-listen` or `--private-listen`). If `Notifications.HMACSecret` is configured, also set
+`HMAC_SECRET` to the same value — the endpoint will then require
 `Authorization: Bearer <secret>` and reject unauthenticated requests with `401`.
 
 ```yaml
 # Transmission container environment
 environment:
   - RSS4TRANSMISSION_URL=http://rss4transmission:8080
-  - CANCEL_HMAC_SECRET=<same value as Cancel.HMACSecret in config.yaml>
+  - HMAC_SECRET=<same value as Notifications.HMACSecret in config.yaml>
 ```
 
 The endpoint accepts `POST /notify-complete` with a JSON body:

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -270,7 +270,7 @@ after a successful start is a no-op rather than a duplicate submission.
 ## History Web UI
 
 Pass `--history-file` to enable history recording. rss4transmission records the outcome of
-every feed item it processes (dispatched, downloaded, skipped, excluded, error).
+every feed item it processes (dispatched, downloaded, notified, skipped, excluded, error).
 
 Pass `--private-listen` to start the web UI. That flag accepts a bare port number (binds to
 `127.0.0.1`) or a full `host:port` address (including IPv6 `[::1]:port`).
@@ -303,14 +303,14 @@ share an `Extractor` can extract identical-looking labels for an item that isn't
 so only a label value that satisfies a feed's own `Require` counts as evidence. Any remaining tie
 breaks alphabetically by feed name.
 
-Rows with outcome `skipped`, `excluded`, or `error` show a **Torrent** button when a `.torrent`
-URL was captured for that item, letting you manually re-submit it to Transmission without waiting
-for the feed to re-offer it. Clicking it re-fetches the `.torrent` fresh, submits it exactly like
-an automatic dispatch, and sends the normal "torrent started" ntfy notification (including a
-working Cancel link) on success. The button requires the item's feed to still be present in the
-config — it's hidden or fails with an error otherwise — and disappears once an item is
-successfully torrented. The action lives at `POST /torrent`, served only alongside the history
-page (`--private-listen`); it is never reachable on `--public-listen`.
+Rows with outcome `notified`, `skipped`, `excluded`, or `error` show a **Torrent** button when a
+`.torrent` URL was captured for that item, letting you manually re-submit it to Transmission
+without waiting for the feed to re-offer it. Clicking it re-fetches the `.torrent` fresh, submits
+it exactly like an automatic dispatch, and sends the normal "torrent started" ntfy notification
+(including a working Cancel link) on success. The button requires the item's feed to still be
+present in the config — it's hidden or fails with an error otherwise — and disappears once an
+item is successfully torrented. The action lives at `POST /torrent`, served only alongside the
+history page (`--private-listen`); it is never reachable on `--public-listen`.
 
 Every row also shows a **Forget** button, which removes that item's `(feed, guid)` pair from
 both the seen cache and the history page. Use it to retest a config change — for example after


### PR DESCRIPTION
## Summary
- New per-feed `Action` field (`download` default, or `notify`): a `notify` feed sends a "Torrent Found" push notification instead of auto-submitting to Transmission, with a link to a new `/start` confirmation page where the user manually starts the download.
- `/start` is a thin, token-gated wrapper around the existing `retryHistoryItem` retry path, so the history page's existing "Torrent" button also works on `notified` rows for free, and repeated `/start` clicks are naturally idempotent (no separate consume-once store needed).
- The `Cancel` config section is renamed to `Notifications`, since `HMACSecret`/`BaseURL`/`TokenTTLH` are now shared by both `/cancel` and `/start`. `bin/torrent-complete.sh`'s `CANCEL_HMAC_SECRET` env var is renamed to `HMAC_SECRET` to match.
- `docs/feeds.md` and `docs/notifications.md` updated to cover `Action`, the new `Ntfy.Seen*` templates, the `/start` endpoint, and the config/env var renames.

## Test plan
- [x] `make unittest` (full suite, fresh cache) — green
- [x] `go vet ./...` — clean
- [x] `gofmt -l` — clean
- [x] `make lint` (golangci-lint) — 0 issues
- [x] `go mod tidy` — no diff
- [x] `make build-race` — builds clean
- [x] Manual smoke test: run `watch` with `--history-file`, `--private-listen`, `Notifications.HMACSecret`/`BaseURL` set, `Ntfy.Topic` set, and a feed with `Action: notify`; confirm a matching item sends a notification (not a Transmission submission), the `/start` link renders and submits correctly, and the history row flips from `notified` to `dispatched`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)