### PR TITLE
Log one INFO line per processed torrent

### DIFF
--- a/cmd/rss4transmission/history.go
+++ b/cmd/rss4transmission/history.go
@@ -165,9 +165,16 @@ func (h *HistoryFile) SaveHistory(d time.Duration) error {
 	return os.WriteFile(h.filename, data, 0644) //nolint:gosec
 }
 
-// recordHistory is a convenience method on RunContext that creates a HistoryRecord
-// and adds it to the history file. It is a no-op when ctx.History is nil.
+// recordHistory is a convenience method on RunContext that logs a single INFO
+// line describing how a processed item was handled, and adds a HistoryRecord
+// to the history file when one is configured. The log always fires — it's the
+// only visibility into per-item outcomes when --history-file isn't set.
 func (ctx *RunContext) recordHistory(feedName string, item *gofeed.Item, outcome, reason string, labels map[string]string) {
+	if reason != "" {
+		log.Infof("[%s] %s: %s (%s)", feedName, outcome, item.Title, reason)
+	} else {
+		log.Infof("[%s] %s: %s", feedName, outcome, item.Title)
+	}
 	if ctx.History != nil {
 		ctx.History.AddOrUpdateRecord(NewHistoryRecord(feedName, item, outcome, reason, labels))
 	}

--- a/cmd/rss4transmission/history_test.go
+++ b/cmd/rss4transmission/history_test.go
@@ -5,11 +5,26 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/mmcdole/gofeed"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 )
+
+// withTestLogHook temporarily replaces the package-global log with a null
+// logger wired to a logrus test hook, restoring the original on cleanup.
+func withTestLogHook(t *testing.T) *test.Hook {
+	t.Helper()
+	orig := log
+	testLog, hook := test.NewNullLogger()
+	testLog.SetLevel(logrus.InfoLevel)
+	log = testLog
+	t.Cleanup(func() { log = orig })
+	return hook
+}
 
 func makeGofeedItem(title, guid string) *gofeed.Item {
 	return &gofeed.Item{Title: title, GUID: guid}
@@ -580,6 +595,45 @@ func TestRecordHistory_NilHistory_NoPanic(t *testing.T) {
 	ctx := &RunContext{} // History is nil
 	item := makeGofeedItem("Show", "guid1")
 	ctx.recordHistory("feed", item, "dispatched", "", nil) // must not panic
+}
+
+// TestRecordHistory_LogsOneInfoLineWithOutcome verifies the log fires even
+// when ctx.History is nil (--history-file not configured), since an operator
+// tailing logs shouldn't need history recording enabled to see what happened.
+func TestRecordHistory_LogsOneInfoLineWithOutcome(t *testing.T) {
+	hook := withTestLogHook(t)
+	ctx := &RunContext{} // History is nil
+	item := makeGofeedItem("Show S01E01", "guid1")
+	ctx.recordHistory("myfeed", item, "dispatched", "", nil)
+
+	entries := hook.AllEntries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(entries))
+	}
+	if entries[0].Level != logrus.InfoLevel {
+		t.Errorf("Level = %v, want Info", entries[0].Level)
+	}
+	msg := entries[0].Message
+	for _, want := range []string{"myfeed", "Show S01E01", "dispatched"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("log message %q does not contain %q", msg, want)
+		}
+	}
+}
+
+func TestRecordHistory_LogsReasonWhenPresent(t *testing.T) {
+	hook := withTestLogHook(t)
+	ctx := &RunContext{}
+	item := makeGofeedItem("Show S01E01", "guid1")
+	ctx.recordHistory("myfeed", item, "skipped", "outranked by better candidate in this run", nil)
+
+	entries := hook.AllEntries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(entries))
+	}
+	if !strings.Contains(entries[0].Message, "outranked by better candidate in this run") {
+		t.Errorf("log message %q does not contain the reason", entries[0].Message)
+	}
 }
 
 func TestRecordHistory_WithHistory_AddsRecord(t *testing.T) {

--- a/cmd/rss4transmission/once_test.go
+++ b/cmd/rss4transmission/once_test.go
@@ -284,6 +284,34 @@ func TestProcessFeed_ExcludedItemsRecordExtractedTitleLabels(t *testing.T) {
 		"excluded records should carry title-extracted labels, same as skipped/dispatched records")
 }
 
+// Regression: processFeed's decisions (excluded, skipped, dispatched, etc.)
+// used to be visible only via the optional history file. This confirms the
+// real call path (not just a direct recordHistory unit call) produces one
+// INFO log line per processed item, so an operator without --history-file
+// configured can still see what happened by tailing logs.
+func TestProcessFeed_ExcludedItem_LogsOneInfoLine(t *testing.T) {
+	hook := withTestLogHook(t)
+	extractor := &ExtractorSet{Labels: map[string]LabelDef{
+		"series": {Regexp: `(?i)(MotoGP|Moto2|Moto3)`},
+	}}
+	feedCfg := Feed{
+		Name:    "testfeed",
+		Exclude: []string{"Highlights"},
+	}
+	rss := &gofeed.Feed{Items: []*gofeed.Item{
+		{Title: "MotoGP.Round06.Highlights", GUID: "guid1"},
+	}}
+
+	ctx := &RunContext{Cache: emptyCache()} // no History configured
+	cmd := &OnceCmd{}
+	cmd.processFeed(ctx, "testfeed", feedCfg, rss, extractor)
+
+	entries := hook.AllEntries()
+	require.Len(t, entries, 1)
+	assert.Contains(t, entries[0].Message, "excluded")
+	assert.Contains(t, entries[0].Message, "MotoGP.Round06.Highlights")
+}
+
 // Regression: excluded items were never added to the seen cache, so an item
 // that stays in the RSS feed (e.g. a perpetual "Highlights" upload) got
 // re-evaluated and re-recorded to history on every single run. That's


### PR DESCRIPTION
## Summary
- Add an unconditional INFO log inside `ctx.recordHistory()`, the single choke point every processing decision (excluded, skipped, error, downloaded, notified, dispatched) already flows through — so per-item outcomes are visible by tailing logs even when `--history-file` isn't configured.
- Log includes feed name, outcome, item title, and the reason (when present).

## Test plan
- [x] Added `TestRecordHistory_LogsOneInfoLineWithOutcome` and `TestRecordHistory_LogsReasonWhenPresent` (history_test.go), using a `logrus/hooks/test` null logger to assert the log fires once, at Info level, and contains the reason.
- [x] Added `TestProcessFeed_ExcludedItem_LogsOneInfoLine` (once_test.go) to confirm the real `processFeed` call path (not just a direct `recordHistory` call) produces the log line.
- [x] `make test` and `make lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)