### PR TITLE
Make VPN rotation actually rotate, and watch upload speed separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ Pre-built images are available on [DockerHub](https://hub.docker.com/r/synfinati
   polled every 5 minutes and logged/alerted on (also available without Gluetun via
   `PortCheck.Enabled`)
 - **VPN speed testing & egress rotation** — periodically measures real speedtest.net throughput
-  over the Gluetun tunnel and asks Gluetun to re-pick an egress when the link is slow, gated by a
-  cooldown, a daily cap, and a never-rotate-while-downloading rule; results are persisted, shown
+  over the Gluetun tunnel and asks Gluetun to re-pick an egress when the link is slow in either
+  direction — a separate `MinUploadMbps` floor catches an exit that downloads fine while uploading
+  nothing, which is what silently wrecks a ratio on a private tracker — gated by a cooldown, a
+  daily cap, and a never-rotate-while-downloading rule; results are persisted, shown
   on a `/speedtest` page, and exported on a Prometheus-style `/metrics` endpoint. Every rotation
   can send a pair of ntfy alerts — one when it's requested and one naming the new exit IP once the
   tunnel is back up. The `/speedtest` page also has **Run speedtest now** and **Rotate VPN now**

--- a/cmd/rss4transmission/config.go
+++ b/cmd/rss4transmission/config.go
@@ -39,10 +39,14 @@ var ConfigDefaults = map[string]interface{}{
 	"SeenCacheDays":           30,
 	"Notifications.TokenTTLH": 24,
 
-	"SpeedTest.Enabled":            false,
-	"SpeedTest.Interval":           "1h",
-	"SpeedTest.Proxy":              "http://gluetun:8888",
-	"SpeedTest.MinDownloadMbps":    100.0,
+	"SpeedTest.Enabled":         false,
+	"SpeedTest.Interval":        "1h",
+	"SpeedTest.Proxy":           "http://gluetun:8888",
+	"SpeedTest.MinDownloadMbps": 100.0,
+	// 0 disables the upload floor. It has to default off: checking it costs a
+	// second measurement leg (DownloadOnly must be false), and an exit that
+	// uploads slowly is only a problem if you are seeding.
+	"SpeedTest.MinUploadMbps":      0.0,
 	"SpeedTest.Cooldown":           "2h",
 	"SpeedTest.MaxRotationsPerDay": 6,
 	"SpeedTest.CaptureSeconds":     5,
@@ -138,6 +142,7 @@ type SpeedTestConfig struct {
 	Interval           string  `koanf:"Interval"`
 	Proxy              string  `koanf:"Proxy"`
 	MinDownloadMbps    float64 `koanf:"MinDownloadMbps"`
+	MinUploadMbps      float64 `koanf:"MinUploadMbps"`
 	Cooldown           string  `koanf:"Cooldown"`
 	MaxRotationsPerDay int     `koanf:"MaxRotationsPerDay"`
 	CaptureSeconds     int     `koanf:"CaptureSeconds"`
@@ -178,6 +183,13 @@ func (s *SpeedTestConfig) Validate() error {
 	}
 	if u.Scheme == "" || u.Host == "" {
 		return fmt.Errorf("SpeedTest.Proxy %q must be a full URL, e.g. http://gluetun:8888", s.Proxy)
+	}
+
+	// Nothing measures upload under DownloadOnly, so UploadMbps stays at zero
+	// and every measurement would look like it was below the floor.
+	if s.MinUploadMbps > 0 && s.DownloadOnly {
+		return fmt.Errorf(
+			"SpeedTest.MinUploadMbps requires SpeedTest.DownloadOnly: false so upload is measured")
 	}
 
 	// Back-to-back tests would saturate the very link we are measuring.

--- a/cmd/rss4transmission/config_test.go
+++ b/cmd/rss4transmission/config_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mmcdole/gofeed"
@@ -464,5 +465,30 @@ Feeds:
 	}
 	if rc.Config.Feeds[0].Extractor != "demo" {
 		t.Errorf("expected previous config to survive a bad reload, got Extractor=%q", rc.Config.Feeds[0].Extractor)
+	}
+}
+
+// An upload floor is meaningless without an upload measurement: DownloadOnly
+// leaves UploadMbps at zero, which would read as "always below the floor" and
+// rotate the VPN on every single measurement.
+func TestSpeedTestConfig_UploadFloorRequiresUploadTest(t *testing.T) {
+	cfg := SpeedTestConfig{
+		Enabled: true, Interval: "1h", Cooldown: "2h", Proxy: "http://gluetun:8888",
+		MinDownloadMbps: 100, MinUploadMbps: 5, CaptureSeconds: 5, DownloadOnly: true,
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() = nil with MinUploadMbps set and DownloadOnly true, want an error")
+	}
+	for _, want := range []string{"MinUploadMbps", "DownloadOnly"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name %q", err, want)
+		}
+	}
+
+	cfg.DownloadOnly = false
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate() = %q with the upload test enabled, want nil", err)
 	}
 }

--- a/cmd/rss4transmission/gluetun.go
+++ b/cmd/rss4transmission/gluetun.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -111,6 +112,39 @@ func (g *Gluetun) newRequest(method, url string, body io.Reader) (*http.Request,
 	return req, nil
 }
 
+// control performs a request against Gluetun's control server and returns the
+// response body. A non-2xx reply is an error naming the status and what the
+// server said: Gluetun answers a request it will not serve -- unauthenticated,
+// or authenticated for a role that does not include this route -- with a
+// plain-text body, which otherwise surfaces as an unhelpful JSON parse error,
+// or on a request whose body nobody parses, not at all.
+func (g *Gluetun) control(method, path string, body io.Reader) ([]byte, error) {
+	req, err := g.newRequest(method, g.URL+path, body)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req) // nolint:gosec
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read body: %s", err.Error())
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		said := strings.TrimSpace(string(bodyBytes))
+		if len(said) > 256 {
+			said = said[:256] + "..."
+		}
+		return nil, fmt.Errorf("%s %s: %s: %s", method, path, resp.Status, said)
+	}
+	return bodyBytes, nil
+}
+
 var ForceRotate bool // flag to force rotation again due to failure
 
 // checkVpnTunnel restarts / rotates the VPN tunnel as necessary. It returns
@@ -180,21 +214,9 @@ type PortResponse struct {
 
 // getPort returns the forwarded port from Gluetun
 func (g *Gluetun) getPort() (int64, error) {
-	req, err := g.newRequest(http.MethodGet, fmt.Sprintf("%s/v1/portforward", g.URL), nil)
+	bodyBytes, err := g.control(http.MethodGet, "/v1/portforward", nil)
 	if err != nil {
 		return int64(0), err
-	}
-	resp, err := http.DefaultClient.Do(req) // nolint:gosec
-	if err != nil {
-		return int64(0), err
-	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
-
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return int64(0), fmt.Errorf("unable to read body: %s", err.Error())
 	}
 
 	pr := PortResponse{}
@@ -214,21 +236,9 @@ type StatusResponse struct {
 
 // getStatus returns the status of the VPN tunnel from Gluetun
 func (g *Gluetun) getStatus() (VPNStatus, error) {
-	req, err := g.newRequest(http.MethodGet, fmt.Sprintf("%s/v1/vpn/status", g.URL), nil)
+	bodyBytes, err := g.control(http.MethodGet, "/v1/vpn/status", nil)
 	if err != nil {
 		return VPNDown, err
-	}
-	resp, err := http.DefaultClient.Do(req) // nolint:gosec
-	if err != nil {
-		return VPNDown, err
-	}
-
-	defer func() {
-		_ = resp.Body.Close()
-	}()
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return VPNDown, fmt.Errorf("unable to read body: %s", err.Error())
 	}
 
 	sr := StatusResponse{}
@@ -252,15 +262,8 @@ func (g *Gluetun) restartVPN() error {
 	body := []byte("{\"status\":\"stopped\"}")
 
 	log.Infof("restarting VPN tunnel")
-	req, err := g.newRequest(http.MethodPut, fmt.Sprintf("%s/v1/vpn/status", g.URL), bytes.NewReader(body))
-	if err != nil {
-		return err
-	}
-	resp, err := http.DefaultClient.Do(req) // nolint:gosec
-	if err != nil {
-		return err
-	}
-	return resp.Body.Close()
+	_, err := g.control(http.MethodPut, "/v1/vpn/status", bytes.NewReader(body))
+	return err
 }
 
 // updatePort queries Gluetun and updates the peer port in Transmission if it changed
@@ -288,20 +291,9 @@ func (g *Gluetun) updatePort() error {
 }
 
 func (g *Gluetun) getPublicIp() (string, error) {
-	req, err := g.newRequest(http.MethodGet, fmt.Sprintf("%s/v1/publicip/ip", g.URL), nil)
+	bodyBytes, err := g.control(http.MethodGet, "/v1/publicip/ip", nil)
 	if err != nil {
 		return "", err
-	}
-	resp, err := http.DefaultClient.Do(req) // nolint:gosec
-	if err != nil {
-		return "", err
-	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("unable to read body: %s", err.Error())
 	}
 
 	type IPResponse struct {
@@ -462,7 +454,7 @@ func (g *Gluetun) rotate() error {
 	// leave" is half of what makes the post-rotation report useful.
 	previousIP, ipErr := g.getPublicIp()
 	if ipErr != nil {
-		log.WithError(ipErr).Debug("Unable to read the pre-rotation public IP")
+		log.WithError(ipErr).Warn("Unable to read the pre-rotation public IP")
 	}
 
 	err := g.restartVPN()
@@ -472,8 +464,6 @@ func (g *Gluetun) rotate() error {
 
 	status := VPNDown
 	for i := 0; status != VPNUp && i < 10; i++ {
-		i += 1
-
 		status, err = g.getStatus()
 		if err != nil {
 			log.WithError(err).Errorf("Unable to GetStatus")

--- a/cmd/rss4transmission/gluetun.go
+++ b/cmd/rss4transmission/gluetun.go
@@ -230,6 +230,13 @@ func (g *Gluetun) getPort() (int64, error) {
 	return pr.Ports[0], nil
 }
 
+const (
+	// stopConfirmChecks bounds the wait for Gluetun to acknowledge a stop.
+	stopConfirmChecks = 5
+	// vpnUpChecks bounds the wait for the tunnel to reconnect after a restart.
+	vpnUpChecks = 10
+)
+
 type StatusResponse struct {
 	Status string `json:"status"`
 }
@@ -250,18 +257,78 @@ func (g *Gluetun) getStatus() (VPNStatus, error) {
 	case "running":
 		return VPNUp, nil
 	case "stopped":
-		log.Infof("VPN tunnel is down")
+		log.Debug("VPN tunnel is down")
 		return VPNDown, nil
 	default:
 		return VPNDown, fmt.Errorf("unsupported status: %s", sr.Status)
 	}
 }
 
-// restartVPN tells Gluetun to stop OpenVPN which will cause it to be auto-restarted
+// restartVPN cycles the VPN tunnel so Gluetun reconnects, picking a new exit.
+//
+// Gluetun does not restart itself: `{"status":"stopped"}` stops the tunnel and
+// leaves it stopped indefinitely. The start has to be a second, explicit call,
+// and skipping it does not merely fail to rotate -- it takes the tunnel down
+// and keeps it there, with Transmission's traffic blocked behind a killswitch
+// that is doing its job.
 func (g *Gluetun) restartVPN() error {
-	body := []byte("{\"status\":\"stopped\"}")
+	log.Infof("stopping VPN tunnel")
+	if err := g.setVPNStatus("stopped"); err != nil {
+		// A rejected stop leaves the tunnel up and serving traffic, so there is
+		// nothing to start and nothing to clean up.
+		return fmt.Errorf("unable to stop the tunnel: %s", err.Error())
+	}
 
-	log.Infof("restarting VPN tunnel")
+	// Gluetun can report the old state briefly after accepting the stop, so
+	// confirm rather than sleeping a fixed interval: this costs one request
+	// when the stop lands immediately, which is the usual case.
+	switch status, known := g.waitForStatus(VPNDown, stopConfirmChecks); {
+	case known && status == VPNUp:
+		return fmt.Errorf("Gluetun still reports the tunnel running after the stop request")
+	case !known:
+		// The tunnel may well be down, and a tunnel left down blocks
+		// Transmission behind the killswitch indefinitely. Starting one that
+		// turns out to be running is much the cheaper mistake.
+		log.Warn("Unable to confirm the VPN tunnel stopped; starting it anyway")
+	}
+
+	log.Infof("starting VPN tunnel")
+	if err := g.setVPNStatus("running"); err != nil {
+		return fmt.Errorf("tunnel stopped, but unable to start it again: %s", err.Error())
+	}
+	return nil
+}
+
+// waitForStatus polls Gluetun until it reports want, and returns the last
+// status it managed to read along with whether it read one at all.
+//
+// The first check happens before the first sleep, so a state change that has
+// already landed costs a single request. The "did we read anything" half
+// matters after a stop request: "still running" and "no idea" call for
+// opposite responses, and collapsing them would either abandon a rotation
+// needlessly or leave the tunnel down.
+func (g *Gluetun) waitForStatus(want VPNStatus, checks int) (VPNStatus, bool) {
+	last, known := VPNDown, false
+	for i := 0; i < checks; i++ {
+		if i > 0 {
+			time.Sleep(g.statusPollDelay)
+		}
+		status, err := g.getStatus()
+		if err != nil {
+			log.WithError(err).Errorf("Unable to GetStatus")
+			continue
+		}
+		last, known = status, true
+		if status == want {
+			return status, true
+		}
+	}
+	return last, known
+}
+
+// setVPNStatus asks Gluetun to move the tunnel to the given state.
+func (g *Gluetun) setVPNStatus(status string) error {
+	body := []byte(fmt.Sprintf("{\"status\":%q}", status))
 	_, err := g.control(http.MethodPut, "/v1/vpn/status", bytes.NewReader(body))
 	return err
 }
@@ -457,23 +524,11 @@ func (g *Gluetun) rotate() error {
 		log.WithError(ipErr).Warn("Unable to read the pre-rotation public IP")
 	}
 
-	err := g.restartVPN()
-	if err != nil {
+	if err := g.restartVPN(); err != nil {
 		return fmt.Errorf("unable to RestartVPN(): %s", err.Error())
 	}
 
-	status := VPNDown
-	for i := 0; status != VPNUp && i < 10; i++ {
-		status, err = g.getStatus()
-		if err != nil {
-			log.WithError(err).Errorf("Unable to GetStatus")
-			time.Sleep(g.statusPollDelay)
-		} else if status == VPNDown {
-			time.Sleep(g.statusPollDelay)
-		}
-	}
-
-	if status != VPNUp {
+	if status, _ := g.waitForStatus(VPNUp, vpnUpChecks); status != VPNUp {
 		return fmt.Errorf("aborting rotation: VPN Failed to come back up")
 	}
 

--- a/cmd/rss4transmission/gluetun_test.go
+++ b/cmd/rss4transmission/gluetun_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -331,13 +332,15 @@ func TestRequestRotate_IgnoresEmptyReason(t *testing.T) {
 }
 
 func TestRotate_ClearsPendingRequest(t *testing.T) {
+	vpn := newVPNState()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.Method == http.MethodPut {
+			vpn.put(r)
 			w.WriteHeader(http.StatusOK)
 			return
 		}
-		_, _ = w.Write([]byte(`{"status":"running"}`))
+		_, _ = w.Write([]byte(vpn.statusBody()))
 	}))
 	defer ts.Close()
 
@@ -403,13 +406,40 @@ func TestRequestRotate_ConcurrentAccess(t *testing.T) {
 // --- post-rotation exit IP reporting ---
 
 // newRotateServer fakes the Gluetun endpoints rotate() touches. Each call to
+// vpnState tracks what a fake control server reports, mirroring Gluetun: a PUT
+// sets the tunnel state and it stays there until the next PUT. Gluetun does not
+// restart itself, so a fake that always answers "running" would hide exactly
+// the bug these tests exist to catch.
+type vpnState struct{ running atomic.Bool }
+
+func newVPNState() *vpnState {
+	v := &vpnState{}
+	v.running.Store(true)
+	return v
+}
+
+func (v *vpnState) put(r *http.Request) {
+	var req StatusResponse
+	_ = json.NewDecoder(r.Body).Decode(&req)
+	v.running.Store(req.Status == "running")
+}
+
+func (v *vpnState) statusBody() string {
+	if v.running.Load() {
+		return `{"status":"running"}`
+	}
+	return `{"status":"stopped"}`
+}
+
 // /v1/publicip/ip returns the next entry in ips, sticking on the last one, so a
 // test can describe "the IP changed on the second poll" as a list.
 func newRotateServer(ips []string) *httptest.Server {
 	var n int32
+	vpn := newVPNState()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.Method == http.MethodPut {
+			vpn.put(r)
 			w.WriteHeader(http.StatusOK)
 			return
 		}
@@ -421,7 +451,7 @@ func newRotateServer(ips []string) *httptest.Server {
 			_, _ = w.Write([]byte(`{"public_ip":"` + ips[i] + `"}`))
 			return
 		}
-		_, _ = w.Write([]byte(`{"status":"running"}`))
+		_, _ = w.Write([]byte(vpn.statusBody()))
 	}))
 }
 
@@ -528,6 +558,7 @@ func TestRotate_NoHookOnFailure(t *testing.T) {
 
 // getPublicIp failing must not block the rotation itself.
 func TestRotate_SucceedsWhenPublicIPUnavailable(t *testing.T) {
+	vpn := newVPNState()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/publicip/ip" {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -535,10 +566,11 @@ func TestRotate_SucceedsWhenPublicIPUnavailable(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		if r.Method == http.MethodPut {
+			vpn.put(r)
 			w.WriteHeader(http.StatusOK)
 			return
 		}
-		_, _ = w.Write([]byte(`{"status":"running"}`))
+		_, _ = w.Write([]byte(vpn.statusBody()))
 	}))
 	defer ts.Close()
 
@@ -782,13 +814,21 @@ func TestRotate_FailsFastWhenRestartRejected(t *testing.T) {
 // The retry loop incremented i twice per pass, so it gave up after 5 polls
 // instead of 10 -- half the intended window for the tunnel to come back.
 func TestRotate_PollsStatusTenTimes(t *testing.T) {
+	var started bool
 	var statusPolls int
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPut:
+			var req StatusResponse
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			started = started || req.Status == "running"
 			_, _ = w.Write([]byte(`{}`))
 		case r.URL.Path == "/v1/vpn/status":
-			statusPolls++
+			// The tunnel never comes back, so every poll after the start is
+			// one of the ten this test is counting.
+			if started {
+				statusPolls++
+			}
 			_, _ = w.Write([]byte(`{"status":"stopped"}`))
 		default:
 			_, _ = w.Write([]byte(`{"public_ip":"1.2.3.4"}`))
@@ -802,5 +842,210 @@ func TestRotate_PollsStatusTenTimes(t *testing.T) {
 	}
 	if statusPolls != 10 {
 		t.Errorf("polled status %d times, want 10", statusPolls)
+	}
+}
+
+// gluetunServer models Gluetun's control server: PUT /v1/vpn/status sets the
+// tunnel state and GET reports it. Gluetun does *not* restart itself after a
+// stop, which is the behaviour that matters here.
+type gluetunServer struct {
+	mu        sync.Mutex
+	running   bool
+	puts      []string
+	events    []string
+	stopErr   int // non-zero => answer the stop with this status code
+	statusErr int // non-zero => answer every GET status with this status code
+	stopLag   int // how many GETs still report "running" after a stop request
+	lagLeft   int
+}
+
+func newGluetunServer(t *testing.T, s *gluetunServer) *httptest.Server {
+	t.Helper()
+	s.running = true
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		switch {
+		case r.URL.Path == "/v1/vpn/status" && r.Method == http.MethodPut:
+			var req StatusResponse
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("undecodable PUT body: %v", err)
+			}
+			if req.Status == "stopped" && s.stopErr != 0 {
+				w.WriteHeader(s.stopErr)
+				_, _ = w.Write([]byte("Forbidden"))
+				return
+			}
+			s.puts = append(s.puts, req.Status)
+			s.events = append(s.events, "put:"+req.Status)
+			s.running = req.Status == "running"
+			if req.Status == "stopped" {
+				s.lagLeft = s.stopLag
+			}
+			_, _ = w.Write([]byte(`{"outcome":"` + req.Status + `"}`))
+		case r.URL.Path == "/v1/vpn/status":
+			s.events = append(s.events, "get")
+			if s.statusErr != 0 {
+				w.WriteHeader(s.statusErr)
+				_, _ = w.Write([]byte("Internal Server Error"))
+				return
+			}
+			state := "stopped"
+			if s.running {
+				state = "running"
+			}
+			// Gluetun can still report the old state for a moment after
+			// accepting a stop.
+			if s.lagLeft > 0 {
+				s.lagLeft--
+				state = "running"
+			}
+			_, _ = w.Write([]byte(`{"status":"` + state + `"}`))
+		default:
+			_, _ = w.Write([]byte(`{"public_ip":"1.2.3.4"}`))
+		}
+	}))
+}
+
+func (s *gluetunServer) sentPuts() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.puts...)
+}
+
+func (s *gluetunServer) sentEvents() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.events...)
+}
+
+// Gluetun stops on request and stays stopped. Asking it to stop and then
+// waiting for it to come back on its own leaves the tunnel down and the
+// rotation reporting "VPN Failed to come back up" -- the start has to be a
+// second, explicit call.
+func TestRestartVPN_StopsThenStarts(t *testing.T) {
+	state := &gluetunServer{}
+	ts := newGluetunServer(t, state)
+	defer ts.Close()
+
+	g := newTestGluetun(ts.URL)
+	if err := g.restartVPN(); err != nil {
+		t.Fatalf("restartVPN returned error: %v", err)
+	}
+
+	want := []string{"stopped", "running"}
+	got := state.sentPuts()
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("PUT statuses = %v, want %v", got, want)
+	}
+	if !state.running {
+		t.Error("tunnel left stopped after restartVPN")
+	}
+}
+
+// A rejected stop means the tunnel is still up and serving traffic. Starting
+// what was never stopped is at best pointless, so the error has to stop there.
+func TestRestartVPN_NoStartAfterFailedStop(t *testing.T) {
+	state := &gluetunServer{stopErr: http.StatusForbidden}
+	ts := newGluetunServer(t, state)
+	defer ts.Close()
+
+	g := newTestGluetun(ts.URL)
+	if err := g.restartVPN(); err == nil {
+		t.Fatal("restartVPN succeeded despite a rejected stop")
+	}
+	if got := state.sentPuts(); len(got) != 0 {
+		t.Errorf("sent %v after a rejected stop, want nothing", got)
+	}
+}
+
+// End to end against the modelled server: the tunnel is up again and the
+// rotation reports the exit IP.
+func TestRotate_BringsTunnelBackUp(t *testing.T) {
+	state := &gluetunServer{}
+	ts := newGluetunServer(t, state)
+	defer ts.Close()
+
+	var got RotationOutcome
+	g := newTestGluetun(ts.URL)
+	g.OnRotated = func(o RotationOutcome) { got = o }
+
+	if err := g.rotate(); err != nil {
+		t.Fatalf("rotate returned error: %v", err)
+	}
+	if !state.running {
+		t.Error("tunnel left stopped after a successful rotation")
+	}
+	if got.NewIP != "1.2.3.4" {
+		t.Errorf("NewIP = %q, want 1.2.3.4", got.NewIP)
+	}
+}
+
+// The start must not be issued until Gluetun confirms the tunnel actually
+// stopped. Checking is better than sleeping a fixed interval: it costs nothing
+// when the stop lands immediately, and it does not guess wrong when it doesn't.
+func TestRestartVPN_WaitsForTheStopToLand(t *testing.T) {
+	state := &gluetunServer{stopLag: 2}
+	ts := newGluetunServer(t, state)
+	defer ts.Close()
+
+	g := newTestGluetun(ts.URL)
+	if err := g.restartVPN(); err != nil {
+		t.Fatalf("restartVPN returned error: %v", err)
+	}
+
+	// stopLag: 2 means the third GET is the first to report "stopped", so the
+	// start must not appear before it.
+	want := []string{"put:stopped", "get", "get", "get", "put:running"}
+	got := state.sentEvents()
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Errorf("events = %v, want %v", got, want)
+	}
+}
+
+// A tunnel that never stops is a tunnel that is still up and carrying traffic.
+// Abandon the rotation rather than issue a start against a running tunnel.
+func TestRestartVPN_AbortsWhenTheTunnelNeverStops(t *testing.T) {
+	state := &gluetunServer{stopLag: 100}
+	ts := newGluetunServer(t, state)
+	defer ts.Close()
+
+	g := newTestGluetun(ts.URL)
+	err := g.restartVPN()
+	if err == nil {
+		t.Fatal("restartVPN succeeded while the tunnel stayed up")
+	}
+	if !strings.Contains(err.Error(), "running") {
+		t.Errorf("error does not say the tunnel is still running: %s", err)
+	}
+	for _, p := range state.sentPuts() {
+		if p == "running" {
+			t.Error("issued a start against a tunnel that never stopped")
+		}
+	}
+}
+
+// When the status cannot be read at all, the tunnel may well be down -- and a
+// tunnel left down blocks Transmission behind the killswitch indefinitely.
+// Starting one that turns out to be running is the cheaper mistake.
+func TestRestartVPN_StartsAnywayWhenStatusIsUnreadable(t *testing.T) {
+	state := &gluetunServer{statusErr: http.StatusInternalServerError}
+	ts := newGluetunServer(t, state)
+	defer ts.Close()
+
+	g := newTestGluetun(ts.URL)
+	if err := g.restartVPN(); err != nil {
+		t.Fatalf("restartVPN returned error: %v", err)
+	}
+
+	var started bool
+	for _, p := range state.sentPuts() {
+		if p == "running" {
+			started = true
+		}
+	}
+	if !started {
+		t.Error("left the tunnel stopped when the status could not be read")
 	}
 }

--- a/cmd/rss4transmission/gluetun_test.go
+++ b/cmd/rss4transmission/gluetun_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -698,5 +699,108 @@ func TestRotate_ReportsClosedPortSource(t *testing.T) {
 	}
 	if got.Source != RotationSourceClosedPort {
 		t.Errorf("Source = %q, want %q", got.Source, RotationSourceClosedPort)
+	}
+}
+
+// Gluetun's control server answers an unauthorized request with a plain-text
+// body and a 401. Parsing that as JSON produced "invalid character 'U'", which
+// says nothing about the real problem -- and restartVPN() did not look at the
+// status at all, so a rejected PUT read as a successful one and the rotation
+// went on to wait for a tunnel it had never asked to stop. Every control call
+// must fail loudly, naming the status and what the server said.
+func TestControlCalls_RejectNon2xx(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+		body string
+		call func(*Gluetun) error
+	}{
+		{"getPort", http.StatusUnauthorized, "Unauthorized",
+			func(g *Gluetun) error { _, err := g.getPort(); return err }},
+		{"getStatus", http.StatusUnauthorized, "Unauthorized",
+			func(g *Gluetun) error { _, err := g.getStatus(); return err }},
+		{"getPublicIp", http.StatusUnauthorized, "Unauthorized",
+			func(g *Gluetun) error { _, err := g.getPublicIp(); return err }},
+		// The role that grants the GET routes need not grant the PUT, so this
+		// is the one that fails on a working-looking deployment.
+		{"restartVPN", http.StatusForbidden, "Forbidden",
+			func(g *Gluetun) error { return g.restartVPN() }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.code)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer ts.Close()
+
+			err := tc.call(newTestGluetun(ts.URL))
+			if err == nil {
+				t.Fatal("no error for a rejected control request")
+			}
+			if !strings.Contains(err.Error(), fmt.Sprintf("%d", tc.code)) {
+				t.Errorf("error does not name the HTTP status: %s", err)
+			}
+			if !strings.Contains(err.Error(), tc.body) {
+				t.Errorf("error does not repeat what the server said: %s", err)
+			}
+		})
+	}
+}
+
+// A rejected restartVPN() must abort the rotation immediately rather than
+// polling for 30 seconds -- the tunnel was never asked to stop.
+func TestRotate_FailsFastWhenRestartRejected(t *testing.T) {
+	var statusPolls int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut:
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte("Forbidden"))
+		case r.URL.Path == "/v1/vpn/status":
+			statusPolls++
+			_, _ = w.Write([]byte(`{"status":"running"}`))
+		default:
+			_, _ = w.Write([]byte(`{"public_ip":"1.2.3.4"}`))
+		}
+	}))
+	defer ts.Close()
+
+	g := newTestGluetun(ts.URL)
+	err := g.rotate()
+	if err == nil {
+		t.Fatal("rotate() succeeded despite a rejected restart")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("error does not name the rejection: %s", err)
+	}
+	if statusPolls != 0 {
+		t.Errorf("polled status %d times after a rejected restart, want 0", statusPolls)
+	}
+}
+
+// The retry loop incremented i twice per pass, so it gave up after 5 polls
+// instead of 10 -- half the intended window for the tunnel to come back.
+func TestRotate_PollsStatusTenTimes(t *testing.T) {
+	var statusPolls int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut:
+			_, _ = w.Write([]byte(`{}`))
+		case r.URL.Path == "/v1/vpn/status":
+			statusPolls++
+			_, _ = w.Write([]byte(`{"status":"stopped"}`))
+		default:
+			_, _ = w.Write([]byte(`{"public_ip":"1.2.3.4"}`))
+		}
+	}))
+	defer ts.Close()
+
+	g := newTestGluetun(ts.URL)
+	if err := g.rotate(); err == nil {
+		t.Fatal("rotate() succeeded while the tunnel stayed down")
+	}
+	if statusPolls != 10 {
+		t.Errorf("polled status %d times, want 10", statusPolls)
 	}
 }

--- a/cmd/rss4transmission/speedtest.go
+++ b/cmd/rss4transmission/speedtest.go
@@ -65,6 +65,29 @@ type (
 	rotateRequestFunc   func(source, reason string) bool
 )
 
+// belowThreshold reports which throughput floor this result missed, or "" when
+// it met them all. Download is tested first: it is the more common failure and
+// makes the more useful reason line when both legs are bad.
+//
+// Upload matters on its own because the two fail independently -- an exit can
+// carry download at full rate and upload nothing at all, which is invisible to
+// MinDownloadMbps and fatal on a tracker that measures ratio.
+func belowThreshold(cfg SpeedTestConfig, r SpeedResult) string {
+	if r.DownloadMbps < cfg.MinDownloadMbps {
+		return fmt.Sprintf("download %.1f Mbps below %.1f Mbps threshold",
+			r.DownloadMbps, cfg.MinDownloadMbps)
+	}
+
+	// A zero floor disables the check, which is the default: without
+	// DownloadOnly: false there is no upload measurement to compare against.
+	if cfg.MinUploadMbps > 0 && r.UploadMbps < cfg.MinUploadMbps {
+		return fmt.Sprintf("upload %.1f Mbps below %.1f Mbps threshold",
+			r.UploadMbps, cfg.MinUploadMbps)
+	}
+
+	return ""
+}
+
 // shouldRotate is the whole rotation policy, kept pure so every branch is
 // table-testable. now is passed in rather than read from the clock.
 //
@@ -79,12 +102,10 @@ func shouldRotate(cfg SpeedTestConfig, r SpeedResult, lastRotation time.Time,
 		return false, ""
 	}
 
-	if r.DownloadMbps >= cfg.MinDownloadMbps {
+	reason := belowThreshold(cfg, r)
+	if reason == "" {
 		return false, ""
 	}
-
-	reason := fmt.Sprintf("download %.1f Mbps below %.1f Mbps threshold",
-		r.DownloadMbps, cfg.MinDownloadMbps)
 
 	if !lastRotation.IsZero() {
 		if cooldown := cfg.CooldownDuration(); now.Sub(lastRotation) < cooldown {

--- a/cmd/rss4transmission/speedtest_test.go
+++ b/cmd/rss4transmission/speedtest_test.go
@@ -33,6 +33,7 @@ func TestShouldRotate(t *testing.T) {
 	tests := []struct {
 		name           string
 		result         SpeedResult
+		minUploadMbps  float64 // 0 leaves the upload check disabled
 		lastRotation   time.Time
 		rotationsToday int
 		wantRotate     bool
@@ -96,10 +97,59 @@ func TestShouldRotate(t *testing.T) {
 			rotationsToday: 99,
 			wantRotate:     false,
 		},
+		{
+			// The case this knob exists for: some exits carry download fine
+			// but upload nothing at all, which is fatal on a ratio tracker
+			// and completely invisible to MinDownloadMbps.
+			name:          "fast download but dead upload rotates",
+			result:        SpeedResult{At: now, DownloadMbps: 400, UploadMbps: 0},
+			minUploadMbps: 5,
+			wantRotate:    true,
+			wantReasonHas: "upload",
+		},
+		{
+			// speedtest-go reports a tiny negative rate for an upload leg
+			// that moved nothing; it must read as slow, not as fast.
+			name:          "negative upload rotates",
+			result:        SpeedResult{At: now, DownloadMbps: 400, UploadMbps: -0.04},
+			minUploadMbps: 5,
+			wantRotate:    true,
+			wantReasonHas: "upload",
+		},
+		{
+			name:          "upload at the threshold does not rotate",
+			result:        SpeedResult{At: now, DownloadMbps: 400, UploadMbps: 5},
+			minUploadMbps: 5,
+			wantRotate:    false,
+		},
+		{
+			// Default config: no upload floor, so a zero upload -- which is
+			// also what DownloadOnly records -- must never rotate.
+			name:       "zero upload does not rotate while the check is disabled",
+			result:     SpeedResult{At: now, DownloadMbps: 400, UploadMbps: 0},
+			wantRotate: false,
+		},
+		{
+			// Download is checked first: it is the more common failure and
+			// makes the better reason line.
+			name:          "both below threshold reports the download",
+			result:        SpeedResult{At: now, DownloadMbps: 12.5, UploadMbps: 0},
+			minUploadMbps: 5,
+			wantRotate:    true,
+			wantReasonHas: "download",
+		},
+		{
+			name:          "errored result does not rotate on its zero upload",
+			result:        SpeedResult{At: now, Error: "proxy refused"},
+			minUploadMbps: 5,
+			wantRotate:    false,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			cfg := cfg
+			cfg.MinUploadMbps = tc.minUploadMbps
 			got, reason := shouldRotate(cfg, tc.result, tc.lastRotation, tc.rotationsToday, now)
 			if got != tc.wantRotate {
 				t.Errorf("shouldRotate = %v (%q), want %v", got, reason, tc.wantRotate)

--- a/cmd/rss4transmission/speedweb.go
+++ b/cmd/rss4transmission/speedweb.go
@@ -57,8 +57,13 @@ type speedPageData struct {
 	Rotations []speedPageRotation
 	Latest    *SpeedResult
 	ExitIP    string
-	CanRun    bool // render the "Run speedtest now" button
-	CanRotate bool // render the "Rotate VPN now" button
+	// ShowUpload renders the upload tile. It is driven by whether any recent
+	// measurement carries an upload leg rather than by the latest value: the
+	// failure worth seeing is an exit whose upload has dropped to zero, and
+	// keying off the latest value alone would hide exactly that.
+	ShowUpload bool
+	CanRun     bool // render the "Run speedtest now" button
+	CanRotate  bool // render the "Rotate VPN now" button
 }
 
 // speedActions are the operations the /speedtest page's buttons invoke. A nil
@@ -201,6 +206,13 @@ func buildSpeedPageData(speed *SpeedFile) speedPageData {
 	if latest, ok := speed.LatestSuccessful(); ok {
 		data.Latest = &latest
 		data.ExitIP = latest.ExitIP
+	}
+
+	for _, r := range results {
+		if r.OK() && r.UploadMbps > 0 {
+			data.ShowUpload = true
+			break
+		}
 	}
 
 	rotations := speed.GetRotations()

--- a/cmd/rss4transmission/speedweb_test.go
+++ b/cmd/rss4transmission/speedweb_test.go
@@ -473,3 +473,14 @@ func TestSpeedPage_HidesLastUploadWhenNeverMeasured(t *testing.T) {
 		t.Error("summary reports an upload that was never measured")
 	}
 }
+
+// The two pages cross-link to each other, and the link belongs in the same
+// place on both: its own line under the record count, not trailing the count
+// sentence.
+func TestSpeedPage_LinksHistoryOnItsOwnLine(t *testing.T) {
+	_, body := getBody(t, speedMux(t, tempSpeedFile(t), nil), "/speedtest")
+
+	if !strings.Contains(body, `<p id="nav"><a href="/">History</a></p>`) {
+		t.Error("VPN page does not carry the History link on its own nav line")
+	}
+}

--- a/cmd/rss4transmission/speedweb_test.go
+++ b/cmd/rss4transmission/speedweb_test.go
@@ -447,3 +447,29 @@ func TestSpeedPage_ShowsRotationSource(t *testing.T) {
 		t.Errorf("page does not name the rotation source %q", RotationSourceClosedPort)
 	}
 }
+
+// A dead upload leg is the failure MinUploadMbps exists to catch, so the
+// summary has to surface it next to the download rather than burying it in a
+// table column.
+func TestSpeedPage_ShowsLastUploadWhenMeasured(t *testing.T) {
+	s := tempSpeedFile(t)
+	s.AddResult(SpeedResult{At: time.Now().Add(-time.Hour), DownloadMbps: 400, UploadMbps: 42})
+	s.AddResult(SpeedResult{At: time.Now(), DownloadMbps: 400, UploadMbps: -0.04})
+
+	_, body := getBody(t, speedMux(t, s, nil), "/speedtest")
+	if !strings.Contains(strings.ToLower(body), "last upload") {
+		t.Error("summary does not report the last upload")
+	}
+}
+
+// With DownloadOnly there is no upload leg at all, and a permanent "0.0 Mbps"
+// tile would read as a dead link rather than a disabled test.
+func TestSpeedPage_HidesLastUploadWhenNeverMeasured(t *testing.T) {
+	s := tempSpeedFile(t)
+	s.AddResult(SpeedResult{At: time.Now(), DownloadMbps: 400})
+
+	_, body := getBody(t, speedMux(t, s, nil), "/speedtest")
+	if strings.Contains(strings.ToLower(body), "last upload") {
+		t.Error("summary reports an upload that was never measured")
+	}
+}

--- a/cmd/rss4transmission/web/speedtest.html
+++ b/cmd/rss4transmission/web/speedtest.html
@@ -80,6 +80,16 @@
             <span class="value muted">&mdash;</span>
             {{- end }}
         </div>
+        {{- if .ShowUpload }}
+        <div>
+            <span class="label">Last upload</span>
+            {{- if .Latest }}
+            <span class="value ok">{{ mbps .Latest.UploadMbps }} Mbps</span>
+            {{- else }}
+            <span class="value muted">&mdash;</span>
+            {{- end }}
+        </div>
+        {{- end }}
         <div>
             <span class="label">Exit IP</span>
             <span class="value">{{ if .ExitIP }}{{ .ExitIP }}{{ else }}&mdash;{{ end }}</span>

--- a/cmd/rss4transmission/web/speedtest.html
+++ b/cmd/rss4transmission/web/speedtest.html
@@ -9,6 +9,8 @@
         h1 { color: #ccc; margin-bottom: 0.25em; }
         h2 { color: #ccc; font-size: 1.1em; margin-top: 2em; }
         p { color: #888; margin-top: 0; }
+        #nav { margin: 0 0 1em 0; }
+        #nav a { color: #6aa8e0; text-decoration: underline; }
         a { color: #6aa8e0; }
 
         #summary {
@@ -69,7 +71,8 @@
 </head>
 <body>
     <h1>VPN Speed</h1>
-    <p>{{ len .Rows }} measurement(s) &mdash; auto-refreshes every 60 seconds. <a href="/">History</a></p>
+    <p id="count">{{ len .Rows }} measurement(s) &mdash; auto-refreshes every 60 seconds.</p>
+    <p id="nav"><a href="/">History</a></p>
 
     <div id="summary">
         <div>

--- a/docs/speedtest.md
+++ b/docs/speedtest.md
@@ -120,8 +120,14 @@ Pass `--save` to append the result to `ResultsFile`.
 ## How rotation works
 
 Gluetun has no "switch to a different server" API. The only mechanism is to stop the VPN and
-let it auto-restart, which makes Gluetun re-pick from its filter set — the same thing
-`RotateTime` already does.
+start it again, which makes Gluetun re-pick from its filter set — the same thing `RotateTime`
+already does.
+
+Both halves are explicit: Gluetun stays stopped until it is told to start, so the stop is
+confirmed before the start is issued. If the stop is refused, or Gluetun still reports the tunnel
+running, the rotation is abandoned and the tunnel is left alone. If the status cannot be read at
+all, the start is issued anyway — a tunnel left down blocks Transmission behind the killswitch,
+which is far worse than starting one that was already running.
 
 A rotation is only *requested* by the speed monitor; it is carried out by the port-check loop on
 its next 5-minute tick, which also resyncs the new forwarded peer port into Transmission. Expect

--- a/docs/speedtest.md
+++ b/docs/speedtest.md
@@ -36,6 +36,7 @@ SpeedTest:
   Interval:           1h                     # how often to measure
   Proxy:              http://gluetun:8888    # gluetun's HTTP proxy
   MinDownloadMbps:    100                    # rotate below this
+  MinUploadMbps:      0                      # 0 disables the upload floor
   Cooldown:           2h                     # minimum time between rotations
   MaxRotationsPerDay: 6                      # 0 means unlimited
   CaptureSeconds:     5                      # bounds bandwidth used per test
@@ -52,12 +53,13 @@ SpeedTest:
 | `Enabled` | Master switch. Defaults to `false`. |
 | `Interval` | Measurement cadence. Must be longer than `CaptureSeconds`. |
 | `Proxy` | Full URL of Gluetun's HTTP proxy. Required when enabled. |
-| `MinDownloadMbps` | Measurements below this make a rotation eligible. |
+| `MinDownloadMbps` | Download measurements below this make a rotation eligible. |
+| `MinUploadMbps` | Same for upload. `0` (default) disables it; needs `DownloadOnly: false`. |
 | `Cooldown` | Suppresses a rotation this soon after the previous one. |
 | `MaxRotationsPerDay` | Cap on rotations in the trailing 24 hours; `0` disables the cap. |
 | `CaptureSeconds` | Duration of each transfer leg. This is what controls bandwidth cost. |
 | `Threads` | Parallel connections. Raise if a single stream can't saturate the link. |
-| `DownloadOnly` | Skip the upload test. Roughly a 10% bandwidth saving. |
+| `DownloadOnly` | Skip the upload test: ~10% less bandwidth, but a dead upload leg goes unseen. |
 | `SkipWhenActive` | Record a "skipped" result instead of measuring while torrents download. |
 | `ServerID` | Pin a speedtest.net server ID instead of taking the nearest one. |
 | `ResultsFile` | JSON file of measurements and rotation events. Required when enabled. |
@@ -77,6 +79,29 @@ scales with your line speed, not with the test count alone:
 `Enabled` defaults to `false` and `DownloadOnly` to `true` for this reason. If ~6 GB/day is too
 much, raise `Interval` to `6h`; decision quality barely changes, because `Cooldown` and
 `MaxRotationsPerDay` already dominate how often a rotation can actually fire.
+
+### Watching upload separately
+
+The two directions fail independently. An exit can carry download at full rate while uploading
+essentially nothing — the measurements table shows `-0.0` in the **Up** column, which is what
+speedtest-go reports for a leg that moved no data. `MinDownloadMbps` cannot see this, so the
+daemon happily sits on a dead exit.
+
+That matters if you seed on a private tracker: nothing uploads, and your ratio decays while every
+download-side metric looks healthy. Setting a floor rotates away from such an exit:
+
+```yaml
+SpeedTest:
+  DownloadOnly:  false   # required: nothing measures upload without it
+  MinUploadMbps: 5
+```
+
+Pick a floor well under your real upstream — the point is to catch *dead*, not merely slow. A
+line that normally uploads 40 Mbps is well served by `5`.
+
+`MinUploadMbps` with `DownloadOnly: true` is rejected at startup rather than silently rotating on
+every measurement: with no upload leg, `UploadMbps` stays at zero and would always read as below
+the floor.
 
 ## Verifying the setup
 
@@ -105,7 +130,8 @@ up to a 5-minute delay between the decision and the restart.
 A rotation is requested only when **all** of these hold:
 
 1. The measurement succeeded — a failed or skipped run never triggers a rotation.
-2. Download throughput was below `MinDownloadMbps`.
+2. Throughput was below a configured floor: download below `MinDownloadMbps`, or upload below
+   `MinUploadMbps`. Download is reported when both are.
 3. At least `Cooldown` has passed since the last rotation — of any kind, including one you asked
    for from the page.
 4. Fewer than `MaxRotationsPerDay` **automatic** rotations occurred in the trailing 24 hours.


### PR DESCRIPTION
Three fixes, found while debugging why a rotation never actually rotated.

## Rotation never restarted the VPN

`restartVPN()` sent `PUT {"status":"stopped"}` on the belief that Gluetun would
bring the tunnel back on its own:

```go
// restartVPN tells Gluetun to stop OpenVPN which will cause it to be auto-restarted
```

It doesn't. Gluetun stops the tunnel and leaves it stopped indefinitely. So
every rotation took the VPN down, waited for a reconnect that was never coming,
reported `VPN Failed to come back up`, and left Transmission blocked behind the
killswitch until someone restarted Gluetun by hand. Confirmed in production —
`ifconfig` inside the container showed no `tun0`/`wg0` at all, and every status
poll for 30 seconds read `stopped`.

The start is now a second, explicit call, with the stop confirmed first rather
than a fixed sleep — Gluetun answers the status GET immediately after accepting
a stop, so confirmation costs one request in the normal case. The two ways
confirmation can fail need opposite responses, so `waitForStatus()` returns the
last status it read *and* whether it read one at all:

| Situation | Action | Why |
|---|---|---|
| Stop rejected | Abort, no start | Tunnel is up and serving traffic |
| Confirmed still `running` | Abort, no start | Same — the rotation just didn't happen |
| Status unreadable | Warn, **start anyway** | A tunnel left down blocks Transmission behind the killswitch |

The existing rotate tests could not have caught this: their fakes answered
`{"status":"running"}` unconditionally, encoding the same wrong assumption as
the code. They now share a `vpnState` tracker where a PUT sets the state and it
stays there.

## Gluetun control-server errors were swallowed

`restartVPN()` ended in `return resp.Body.Close()` — a `401` or `403` was
indistinguishable from success, which is how an unauthorized control server
masqueraded as a flaky VPN. There was no `StatusCode` check anywhere in
`gluetun.go`; the GET calls parsed the plain-text rejection body as JSON and
surfaced `invalid character 'U'`.

All four control calls go through one `control()` helper that errors on non-2xx
with the status and the response body:

```
unable to RestartVPN(): PUT /v1/vpn/status: 403 Forbidden: Forbidden
```

Two fixes to the same path: the status retry loop had `i++` in the header *and*
`i += 1` in the body, giving up after 5 polls instead of 10; and the
pre-rotation public-IP failure logged at `Debug`, where nobody would see it.

## `MinUploadMbps`

Some VPN exits carry download fine but move almost nothing upstream.
`MinDownloadMbps` can't see that, and on a private tracker it quietly wrecks
your ratio.

`SpeedTest.MinUploadMbps` is a separate floor checked alongside the download one
— a measurement below *either* triggers a rotation. It defaults to `0`, which
disables the check, so existing configs are unaffected. Combining it with
`DownloadOnly: true` is rejected at startup, since nothing would measure upload
and every measurement would read as below the floor.

The `/speedtest` page gains a **Last upload** tile, rendered only once upload has
actually been measured so a `DownloadOnly` deployment doesn't show a permanent
zero.

## Testing

`make precheck` is clean (vet, tests, fmt, tidy, lint, govulncheck), and
`make test-race` passes.

New tests cover: the stop-then-start sequence and its ordering against the
confirmation; abort-when-the-tunnel-never-stops; start-anyway-when-status-is-
unreadable; a full `rotate()` against a Gluetun model that doesn't self-restart;
all four control calls rejecting non-2xx with the status and body in the error;
no status polling after a rejected restart; the reconnect loop polling ten
times; six `shouldRotate` cases for the upload floor; the startup rejection of
`MinUploadMbps` with `DownloadOnly`; and the page showing/hiding the upload tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)