### PR TITLE
Move the rotation log to its own page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,11 @@ starts a separate public-facing server for `/cancel`, `/healthz`, and `/notify-c
 In the gluetun docker-compose, expose the port explicitly via the `ports:` block; in the plain
 docker-compose `network_mode: host` already exposes all ports.
 
+The private server serves three pages: `/` (titled **Torrents**, `web/history.html`), `/speedtest`
+and `/rotations` (both in `speedweb.go`, registered only when a `SpeedFile` exists). They share the
+nav bar in `web/nav.html`, a `{{ define "nav" }}` partial parsed into each page's template set and
+given the current page name as its dot; it needs a `speedtestEnabled` func in that set's FuncMap.
+
 **Config defaults** are defined as a `map[string]interface{}` in `config.go` and loaded before the YAML
 file, so koanf's merge semantics provide defaults without nil-checks in code.
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ Pre-built images are available on [DockerHub](https://hub.docker.com/r/synfinati
   transitions open/closed or is still closed 60s after startup; notification title, body, and
   priority are user-defined via `text/template` strings in the config file, with full access to
   torrent metadata (labels, size, feed name, GUID, and more)
-- **History web UI** — browsable record of every processed feed item with outcome and extracted
-  labels; skipped, excluded, and error items can be re-submitted to Transmission with a Torrent
-  button
+- **History web UI** — the **Torrents** page: a browsable record of every processed feed item with
+  outcome and extracted labels; skipped, excluded, and error items can be re-submitted to
+  Transmission with a Torrent button. Cross-links the **VPN Speed** and **Rotations** pages when
+  speed testing is enabled
 - **Gluetun VPN integration** — automatically restarts the VPN and syncs the peer port into
   Transmission when running behind [Gluetun](https://github.com/qdm12/gluetun); port state is
   polled every 5 minutes and logged/alerted on (also available without Gluetun via

--- a/cmd/rss4transmission/speedweb.go
+++ b/cmd/rss4transmission/speedweb.go
@@ -31,6 +31,9 @@ import (
 //go:embed web/speedtest.html
 var speedTmpl string
 
+//go:embed web/rotations.html
+var rotationsTmpl string
+
 // portOpenFunc reports the last observed state of the forwarded peer port.
 // known is false when no check has completed yet, in which case the
 // corresponding metric is omitted rather than published as a guess.
@@ -70,7 +73,12 @@ type speedPageData struct {
 	Rows      []speedPageRow
 	Rotations []speedPageRotation
 	Latest    *SpeedResult
-	ExitIP    string
+	// LastRotation is the most recent rotation event, or nil when the tunnel
+	// has never moved. The rotation log lives on /rotations now, so without
+	// this tile the page you land on would say nothing about when the egress
+	// last changed.
+	LastRotation *RotationEvent
+	ExitIP       string
 	// ExitIPSource names where ExitIP came from, and is empty when that is
 	// Gluetun. With Gluetun configured the tile is always Gluetun's answer, so
 	// saying so on every page load is noise; the annotation exists to flag the
@@ -86,6 +94,16 @@ type speedPageData struct {
 	CanRotate  bool // render the "Rotate VPN now" button
 }
 
+// rotationsPageData is the /rotations view: the same rotation rows the
+// /speedtest page used to carry at the bottom, plus the summary tiles that make
+// sense on their own page.
+type rotationsPageData struct {
+	Rotations    []speedPageRotation
+	LastRotation *RotationEvent
+	ExitIP       string
+	ExitIPSource string
+}
+
 // speedActions are the operations the /speedtest page's buttons invoke. A nil
 // func means the button is not rendered and its route is not registered, which
 // is how a measure-only deployment (no Gluetun) loses only the rotate button.
@@ -99,23 +117,32 @@ type speedActions struct {
 	Active activeDownloadsFunc // only consulted to decide whether Rotate needs confirming
 }
 
-// registerSpeedRoutes adds GET /speedtest, GET /metrics and the page's two
-// action routes to mux. All are intended for the private mux only: like GET /,
+// registerSpeedRoutes adds GET /speedtest, GET /rotations, GET /metrics and the
+// speedtest page's two action routes to mux. All are intended for the private mux only: like GET /,
 // they are unauthenticated and rely on --private-listen not being publicly
 // reachable.
 //
 // /metrics is registered even with a nil store so a scrape configuration does
-// not have to care whether SpeedTest is enabled; /speedtest is not, because a
-// page with nothing to show is worse than a 404.
+// not have to care whether SpeedTest is enabled; the two pages are not, because
+// a page with nothing to show is worse than a 404.
 func registerSpeedRoutes(mux *http.ServeMux, speed *SpeedFile, portOpen portOpenFunc,
 	exitIP exitIPFunc, actions speedActions,
 ) {
 	if speed != nil {
-		tmpl := template.Must(template.New("speedtest").Funcs(template.FuncMap{
-			"mbps":    func(v float64) string { return fmt.Sprintf("%.1f", v) },
-			"ms":      func(v float64) string { return fmt.Sprintf("%.1f", v) },
-			"fmtTime": func(t time.Time) string { return t.Local().Format("2006-01-02 15:04:05") },
-		}).Parse(speedTmpl))
+		// Both pages share the nav partial and the same formatting helpers.
+		// speedtestEnabled is what the nav uses to decide whether to link the
+		// VPN pages at all; on these two pages it is true by construction,
+		// since neither route is registered without a speed store.
+		funcs := template.FuncMap{
+			"mbps":             func(v float64) string { return fmt.Sprintf("%.1f", v) },
+			"ms":               func(v float64) string { return fmt.Sprintf("%.1f", v) },
+			"fmtTime":          func(t time.Time) string { return t.Local().Format("2006-01-02 15:04:05") },
+			"speedtestEnabled": func() bool { return true },
+		}
+		tmpl := template.Must(template.Must(
+			template.New("speedtest").Funcs(funcs).Parse(navTmpl)).Parse(speedTmpl))
+		rotTmpl := template.Must(template.Must(
+			template.New("rotations").Funcs(funcs).Parse(navTmpl)).Parse(rotationsTmpl))
 
 		mux.HandleFunc("GET /speedtest", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -124,6 +151,13 @@ func registerSpeedRoutes(mux *http.ServeMux, speed *SpeedFile, portOpen portOpen
 			data.CanRotate = actions.Rotate != nil
 			if err := tmpl.Execute(w, data); err != nil {
 				log.WithError(err).Error("Failed to render speedtest template")
+			}
+		})
+
+		mux.HandleFunc("GET /rotations", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			if err := rotTmpl.Execute(w, buildRotationsPageData(speed, exitIP)); err != nil {
+				log.WithError(err).Error("Failed to render rotations template")
 			}
 		})
 
@@ -208,10 +242,7 @@ func makeSpeedRotateHandler(actions speedActions) http.HandlerFunc {
 // buildSpeedPageData assembles the /speedtest view, newest entries first.
 func buildSpeedPageData(speed *SpeedFile, exitIP exitIPFunc) speedPageData {
 	results := speed.GetResults()
-	data := speedPageData{
-		Rows:      make([]speedPageRow, 0, len(results)),
-		Rotations: []speedPageRotation{},
-	}
+	data := speedPageData{Rows: make([]speedPageRow, 0, len(results))}
 
 	for i := len(results) - 1; i >= 0; i-- {
 		r := results[i]
@@ -254,16 +285,52 @@ func buildSpeedPageData(speed *SpeedFile, exitIP exitIPFunc) speedPageData {
 		}
 	}
 
+	data.Rotations = buildRotationRows(speed)
+	if last, ok := speed.LastRotation(); ok {
+		data.LastRotation = &last
+	}
+
+	return data
+}
+
+// buildRotationsPageData assembles the /rotations view, newest first.
+func buildRotationsPageData(speed *SpeedFile, exitIP exitIPFunc) rotationsPageData {
+	data := rotationsPageData{Rotations: buildRotationRows(speed)}
+
+	if last, ok := speed.LastRotation(); ok {
+		data.LastRotation = &last
+	}
+
+	// Same rule as the /speedtest tile: only Gluetun answers "which exit are we
+	// on", and speedtest.net's view stands in only when there is no Gluetun to
+	// ask -- labelled, because the two are not interchangeable (see exitIPFunc).
+	switch {
+	case exitIP != nil:
+		if ip, known := exitIP(); known {
+			data.ExitIP = ip
+		}
+	default:
+		if latest, ok := speed.LatestSuccessful(); ok {
+			data.ExitIP, data.ExitIPSource = latest.ExitIP, "speedtest.net"
+		}
+	}
+
+	return data
+}
+
+// buildRotationRows returns the rotation events newest first, each flagged with
+// whether it actually moved us.
+func buildRotationRows(speed *SpeedFile) []speedPageRotation {
 	rotations := speed.GetRotations()
+	rows := make([]speedPageRotation, 0, len(rotations))
 	for i := len(rotations) - 1; i >= 0; i-- {
 		e := rotations[i]
-		data.Rotations = append(data.Rotations, speedPageRotation{
+		rows = append(rows, speedPageRotation{
 			RotationEvent: e,
 			SameExit:      e.ToExitIP != "" && e.ToExitIP == e.FromExitIP,
 		})
 	}
-
-	return data
+	return rows
 }
 
 // renderMetrics emits the Prometheus text exposition format by hand. The repo

--- a/cmd/rss4transmission/speedweb_test.go
+++ b/cmd/rss4transmission/speedweb_test.go
@@ -159,16 +159,12 @@ func TestSpeedTestPage_RendersResults(t *testing.T) {
 		At: time.Now(), DownloadMbps: 412.5, UploadMbps: 38.1,
 		LatencyMs: 14, ServerName: "Los Angeles", Sponsor: "Acme", ExitIP: "185.9.9.9",
 	})
-	s.AddRotation(RotationEvent{
-		At: time.Now(), Reason: "too slow", BeforeMbps: 12.5,
-		FromExitIP: "1.1.1.1", ToExitIP: "2.2.2.2",
-	})
 
 	code, body := getBody(t, speedMux(t, s, nil), "/speedtest")
 	if code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", code)
 	}
-	for _, want := range []string{"412.5", "185.9.9.9", "Los Angeles", "too slow", "2.2.2.2"} {
+	for _, want := range []string{"412.5", "185.9.9.9", "Los Angeles"} {
 		if !strings.Contains(body, want) {
 			t.Errorf("page missing %q", want)
 		}
@@ -197,13 +193,13 @@ func TestSpeedTestPage_EmptyStore(t *testing.T) {
 
 // A rotation that landed on the same exit is the signal that rotating isn't
 // helping, so the page has to make it visible rather than just showing an IP.
-func TestSpeedTestPage_FlagsUnchangedExit(t *testing.T) {
+func TestRotationsPage_FlagsUnchangedExit(t *testing.T) {
 	s := tempSpeedFile(t)
 	s.AddRotation(RotationEvent{
 		At: time.Now(), Reason: "slow", FromExitIP: "1.1.1.1", ToExitIP: "1.1.1.1",
 	})
 
-	_, body := getBody(t, speedMux(t, s, nil), "/speedtest")
+	_, body := getBody(t, speedMux(t, s, nil), "/rotations")
 	if !strings.Contains(strings.ToLower(body), "same exit") {
 		t.Errorf("page does not flag an unchanged exit IP\ngot:\n%s", body)
 	}
@@ -224,13 +220,22 @@ func TestHistoryPage_LinksSpeedtestWhenEnabled(t *testing.T) {
 	h := &HistoryFile{Records: []HistoryRecord{}, guidIndex: map[string]int{}}
 
 	_, on := getBody(t, newWebMux(h, nil, nil, nil, nil, true), "/")
-	if !strings.Contains(on, `href="/speedtest"`) {
-		t.Errorf("history page missing the /speedtest link when enabled")
+	for _, want := range []string{`href="/speedtest"`, `href="/rotations"`} {
+		if !strings.Contains(navLine(t, on), want) {
+			t.Errorf("torrents page missing the %s link when speedtest is enabled", want)
+		}
+	}
+	if !strings.Contains(navLine(t, on), `<span class="here">Torrents</span>`) {
+		t.Errorf("torrents page nav does not mark the current page\ngot:\n%s", navLine(t, on))
 	}
 
+	// Both VPN pages are registered together, so neither is linked when the
+	// speed store is absent and both routes would 404.
 	_, off := getBody(t, newWebMux(h, nil, nil, nil, nil, false), "/")
-	if strings.Contains(off, `href="/speedtest"`) {
-		t.Errorf("history page links /speedtest when the route is not registered")
+	for _, unwanted := range []string{`href="/speedtest"`, `href="/rotations"`} {
+		if strings.Contains(off, unwanted) {
+			t.Errorf("torrents page links %s when the route is not registered", unwanted)
+		}
 	}
 }
 
@@ -435,14 +440,14 @@ func TestSpeedRotate_AlreadyInProgress(t *testing.T) {
 // The rotations table used to show only speedtest-driven rotations, so the
 // reason alone identified them. Now that schedule, closed-port and manual
 // rotations share the table, the page names the source outright.
-func TestSpeedPage_ShowsRotationSource(t *testing.T) {
+func TestRotationsPage_ShowsRotationSource(t *testing.T) {
 	s := tempSpeedFile(t)
 	s.AddRotation(RotationEvent{
 		At: time.Now(), Source: RotationSourceClosedPort,
 		Reason: "peer port closed for 3 consecutive checks", FromExitIP: "1.1.1.1", ToExitIP: "2.2.2.2",
 	})
 
-	_, body := getBody(t, speedMux(t, s, nil), "/speedtest")
+	_, body := getBody(t, speedMux(t, s, nil), "/rotations")
 	if !strings.Contains(body, RotationSourceClosedPort) {
 		t.Errorf("page does not name the rotation source %q", RotationSourceClosedPort)
 	}
@@ -474,15 +479,53 @@ func TestSpeedPage_HidesLastUploadWhenNeverMeasured(t *testing.T) {
 	}
 }
 
-// The two pages cross-link to each other, and the link belongs in the same
-// place on both: its own line under the record count, not trailing the count
-// sentence.
-func TestSpeedPage_LinksHistoryOnItsOwnLine(t *testing.T) {
+// Every page carries the same nav line under the record count, with the page
+// you are on named but not linked -- so the bar reads the same everywhere and
+// still says where you are.
+func TestNav_SpeedPageLinksTheOtherTwo(t *testing.T) {
 	_, body := getBody(t, speedMux(t, tempSpeedFile(t), nil), "/speedtest")
 
-	if !strings.Contains(body, `<p id="nav"><a href="/">History</a></p>`) {
-		t.Error("VPN page does not carry the History link on its own nav line")
+	nav := navLine(t, body)
+	for _, want := range []string{`<a href="/">Torrents</a>`, `<a href="/rotations">Rotations</a>`} {
+		if !strings.Contains(nav, want) {
+			t.Errorf("VPN page nav missing %s\ngot:\n%s", want, nav)
+		}
 	}
+	if strings.Contains(nav, `href="/speedtest"`) {
+		t.Errorf("VPN page nav links the page you are already on\ngot:\n%s", nav)
+	}
+	if !strings.Contains(nav, `<span class="here">VPN Speed</span>`) {
+		t.Errorf("VPN page nav does not mark the current page\ngot:\n%s", nav)
+	}
+}
+
+func TestNav_RotationsPageLinksTheOtherTwo(t *testing.T) {
+	_, body := getBody(t, speedMux(t, tempSpeedFile(t), nil), "/rotations")
+
+	nav := navLine(t, body)
+	for _, want := range []string{`<a href="/">Torrents</a>`, `<a href="/speedtest">VPN Speed</a>`} {
+		if !strings.Contains(nav, want) {
+			t.Errorf("rotations page nav missing %s\ngot:\n%s", want, nav)
+		}
+	}
+	if !strings.Contains(nav, `<span class="here">Rotations</span>`) {
+		t.Errorf("rotations page nav does not mark the current page\ngot:\n%s", nav)
+	}
+}
+
+// navLine returns just the nav paragraph, so an assertion about a link cannot
+// be satisfied by the page body.
+func navLine(t *testing.T, body string) string {
+	t.Helper()
+	start := strings.Index(body, `<p id="nav">`)
+	if start < 0 {
+		t.Fatalf("page has no nav line:\n%s", body)
+	}
+	end := strings.Index(body[start:], "</p>")
+	if end < 0 {
+		t.Fatalf("page has an unterminated nav line:\n%s", body)
+	}
+	return body[start : start+end]
 }
 
 // The headline Exit IP is what Gluetun says about itself. It must not fall back
@@ -635,11 +678,13 @@ func measurementsSection(t *testing.T, body string) string {
 	if start < 0 {
 		t.Fatalf("page has no measurements section:\n%s", body)
 	}
-	end := strings.Index(body[start+1:], "<h2>")
+	end := strings.Index(body[start:], "</table>")
 	if end < 0 {
-		t.Fatalf("page has no section after the measurements table:\n%s", body)
+		// The empty state has no table; everything after the heading is the
+		// section either way.
+		return body[start:]
 	}
-	return body[start : start+1+end]
+	return body[start : start+end]
 }
 
 // The Detail column carries the rotation verdict for a slow measurement, so a
@@ -674,4 +719,150 @@ func TestSpeedTestPage_ErrorOutranksRotationNoteInDetail(t *testing.T) {
 	if strings.Contains(table, "unreachable") {
 		t.Errorf("Detail column showed a rotation note over the error\ngot:\n%s", table)
 	}
+}
+
+// ---- rotations page ----
+
+// Measurements land every few minutes while rotations are rare, so keeping both
+// tables on one page buried the rotation log under hours of scrolling. It has
+// its own page now, and /speedtest carries measurements only.
+func TestSpeedTestPage_HasNoRotationsTable(t *testing.T) {
+	s := tempSpeedFile(t)
+	s.AddResult(SpeedResult{At: time.Now(), DownloadMbps: 412.5})
+	s.AddRotation(RotationEvent{
+		At: time.Now(), Source: RotationSourceSpeedtest, Reason: "too slow",
+		BeforeMbps: 12.5, FromExitIP: "1.1.1.1", ToExitIP: "2.2.2.2",
+	})
+
+	_, body := getBody(t, speedMux(t, s, nil), "/speedtest")
+	for _, unwanted := range []string{"<h2>Rotations</h2>", "too slow", "2.2.2.2"} {
+		if strings.Contains(body, unwanted) {
+			t.Errorf("VPN page still renders the rotation log (%q)\ngot:\n%s", unwanted, body)
+		}
+	}
+}
+
+func TestRotationsPage_RendersRotations(t *testing.T) {
+	s := tempSpeedFile(t)
+	s.AddRotation(RotationEvent{
+		At: time.Now(), Source: RotationSourceSpeedtest, Reason: "too slow",
+		BeforeMbps: 12.5, FromExitIP: "1.1.1.1", ToExitIP: "2.2.2.2",
+	})
+
+	code, body := getBody(t, speedMux(t, s, nil), "/rotations")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	for _, want := range []string{RotationSourceSpeedtest, "too slow", "12.5", "1.1.1.1", "2.2.2.2"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("rotations page missing %q\ngot:\n%s", want, body)
+		}
+	}
+}
+
+// Newest first, same as the measurements table: the last rotation is the one
+// you came to look at.
+func TestRotationsPage_NewestFirst(t *testing.T) {
+	s := tempSpeedFile(t)
+	s.AddRotation(RotationEvent{At: time.Now().Add(-time.Hour), Reason: "older"})
+	s.AddRotation(RotationEvent{At: time.Now(), Reason: "newer"})
+
+	_, body := getBody(t, speedMux(t, s, nil), "/rotations")
+	if strings.Index(body, "newer") > strings.Index(body, "older") {
+		t.Errorf("rotations are not newest first\ngot:\n%s", body)
+	}
+}
+
+// A rotation whose outcome has not been recorded yet still renders: the To
+// column says so rather than showing a blank cell.
+func TestRotationsPage_PendingOutcome(t *testing.T) {
+	s := tempSpeedFile(t)
+	s.StageRotation(RotationEvent{
+		At: time.Now(), Source: RotationSourceManual, Reason: "asked", FromExitIP: "1.1.1.1",
+	})
+
+	_, body := getBody(t, speedMux(t, s, nil), "/rotations")
+	if !strings.Contains(body, "pending") {
+		t.Errorf("rotations page does not mark an unfinished rotation\ngot:\n%s", body)
+	}
+}
+
+func TestRotationsPage_EmptyStore(t *testing.T) {
+	code, body := getBody(t, speedMux(t, tempSpeedFile(t), nil), "/rotations")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d on an empty store, want 200", code)
+	}
+	if !strings.Contains(body, "No rotations recorded yet.") {
+		t.Errorf("rotations page has no empty state\ngot:\n%s", body)
+	}
+}
+
+// Without a speed store there is nothing to show, and a page of nothing is
+// worse than a 404 -- the same call the /speedtest route makes.
+func TestRotationsPage_NilStoreNotRegistered(t *testing.T) {
+	mux := http.NewServeMux()
+	registerSpeedRoutes(mux, nil, nil, nil, speedActions{})
+
+	if code, _ := getBody(t, mux, "/rotations"); code != http.StatusNotFound {
+		t.Errorf("status = %d without a speed store, want 404", code)
+	}
+}
+
+// ---- last rotation tile ----
+
+// With the rotation log a page away, the summary has to say when the egress
+// last moved; otherwise the opening view says nothing about it at all.
+func TestSpeedPage_SummaryShowsLastRotation(t *testing.T) {
+	s := tempSpeedFile(t)
+	at := time.Date(2026, 3, 4, 5, 6, 7, 0, time.Local)
+	s.AddRotation(RotationEvent{At: at.Add(-time.Hour), Source: RotationSourceSchedule})
+	s.AddRotation(RotationEvent{At: at, Source: RotationSourceClosedPort, Reason: "port closed"})
+
+	_, body := getBody(t, speedMux(t, s, nil), "/speedtest")
+	summary := summarySection(t, body)
+
+	if !strings.Contains(strings.ToLower(summary), "last rotation") {
+		t.Errorf("summary does not report the last rotation\ngot:\n%s", summary)
+	}
+	if !strings.Contains(summary, "2026-03-04 05:06:07") {
+		t.Errorf("summary does not carry the last rotation's date and time\ngot:\n%s", summary)
+	}
+	if !strings.Contains(summary, RotationSourceClosedPort) {
+		t.Errorf("summary does not name what asked for the last rotation\ngot:\n%s", summary)
+	}
+}
+
+// A deployment that has never rotated says so, rather than printing an
+// epoch-zero timestamp that reads as a rotation in 1970.
+func TestSpeedPage_SummaryWithoutRotations(t *testing.T) {
+	s := tempSpeedFile(t)
+	s.AddResult(SpeedResult{At: time.Now(), DownloadMbps: 412.5})
+
+	summary := summarySection(t, mustBody(t, speedMux(t, s, nil), "/speedtest"))
+	if !strings.Contains(strings.ToLower(summary), "last rotation") {
+		t.Errorf("summary drops the tile when nothing has rotated\ngot:\n%s", summary)
+	}
+	if strings.Contains(summary, "1970-01-01") {
+		t.Errorf("summary shows a zero-time rotation\ngot:\n%s", summary)
+	}
+}
+
+// The count tile is the way to the rotation log now that it is off this page.
+func TestSpeedPage_RotationCountLinksToRotations(t *testing.T) {
+	s := tempSpeedFile(t)
+	s.AddRotation(RotationEvent{At: time.Now(), Source: RotationSourceManual})
+
+	summary := summarySection(t, mustBody(t, speedMux(t, s, nil), "/speedtest"))
+	if !strings.Contains(summary, `href="/rotations"`) {
+		t.Errorf("rotations tile does not link the rotation log\ngot:\n%s", summary)
+	}
+}
+
+func mustBody(t *testing.T, mux *http.ServeMux, path string) string {
+	t.Helper()
+	code, body := getBody(t, mux, path)
+	if code != http.StatusOK {
+		t.Fatalf("GET %s = %d, want 200", path, code)
+	}
+	return body
 }

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -40,6 +40,13 @@ import (
 //go:embed web/history.html
 var historyTmpl string
 
+// navTmpl is the nav bar every page shares. It is parsed into each page's
+// template set alongside the page itself, and needs a speedtestEnabled func in
+// that set's FuncMap to decide whether the VPN pages are linked.
+//
+//go:embed web/nav.html
+var navTmpl string
+
 //go:embed web/cancel.html
 var cancelTmpl string
 
@@ -310,7 +317,8 @@ func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name s
 		"sub":              func(a, b int) int { return a - b },
 		"speedtestEnabled": func() bool { return speedtest },
 	}
-	tmpl := template.Must(template.New("history").Funcs(funcMap).Parse(historyTmpl))
+	tmpl := template.Must(template.Must(
+		template.New("history").Funcs(funcMap).Parse(navTmpl)).Parse(historyTmpl))
 
 	mux := http.NewServeMux()
 

--- a/cmd/rss4transmission/web/history.html
+++ b/cmd/rss4transmission/web/history.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>RSS4Transmission History</title>
+    <title>RSS4Transmission Torrents</title>
     <style>
         body { font-family: monospace; margin: 2em; background: #1a1a1a; color: #e0e0e0; }
         h1 { color: #ccc; margin-bottom: 0.25em; }
@@ -62,6 +62,7 @@
         a { color: inherit; text-decoration: none; }
         #nav { margin: 0 0 1em 0; }
         #nav a { color: #6aa8e0; text-decoration: underline; }
+        #nav .here { color: #e0e0e0; }
         a:hover { text-decoration: underline; }
         .labels { font-size: 0.82em; color: #666; margin-top: 3px; }
         th:nth-child(1), td:nth-child(1) { width: 10em; white-space: nowrap; }
@@ -114,11 +115,9 @@
     </style>
 </head>
 <body>
-    <h1>RSS4Transmission History</h1>
+    <h1>Torrents</h1>
     <p id="count">{{ len . }} record(s) &mdash; auto-refreshes every 60 seconds.</p>
-{{- if speedtestEnabled }}
-    <p id="nav"><a href="/speedtest">VPN Speed</a></p>
-{{- end }}
+{{ template "nav" "torrents" }}
 
     <div id="filters">
         <span>

--- a/cmd/rss4transmission/web/nav.html
+++ b/cmd/rss4transmission/web/nav.html
@@ -1,0 +1,19 @@
+{{- define "nav" -}}
+{{- /* The dot is the current page: "torrents", "speedtest" or "rotations".
+       The page you are on is named but not linked, so the bar reads the same
+       everywhere and still says where you are. The VPN pages only exist when a
+       speed store is configured, so their links are gated on the same flag that
+       decides whether those routes were registered at all. */ -}}
+    <p id="nav">
+        {{- if eq . "torrents" }}<span class="here">Torrents</span>
+        {{- else }}<a href="/">Torrents</a>{{ end }}
+        {{- if speedtestEnabled }}
+        &middot;
+        {{- if eq . "speedtest" }} <span class="here">VPN Speed</span>
+        {{- else }} <a href="/speedtest">VPN Speed</a>{{ end }}
+        &middot;
+        {{- if eq . "rotations" }} <span class="here">Rotations</span>
+        {{- else }} <a href="/rotations">Rotations</a>{{ end }}
+        {{- end }}
+    </p>
+{{- end -}}

--- a/cmd/rss4transmission/web/rotations.html
+++ b/cmd/rss4transmission/web/rotations.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="60">
+    <title>RSS4Transmission VPN Rotations</title>
+    <style>
+        body { font-family: monospace; margin: 2em; background: #1a1a1a; color: #e0e0e0; }
+        h1 { color: #ccc; margin-bottom: 0.25em; }
+        h2 { color: #ccc; font-size: 1.1em; margin-top: 2em; }
+        p { color: #888; margin-top: 0; }
+        #nav { margin: 0 0 1em 0; }
+        #nav a { color: #6aa8e0; text-decoration: underline; }
+        #nav .here { color: #e0e0e0; }
+        a { color: #6aa8e0; }
+
+        #summary {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 2.5em;
+            background: #2a2a2a;
+            padding: 0.8em 1em;
+            margin-bottom: 1.5em;
+        }
+        #summary div { display: flex; flex-direction: column; gap: 0.2em; }
+        #summary .label { color: #888; font-size: 0.8em; text-transform: uppercase; }
+        #summary .value { color: #e0e0e0; font-size: 1.3em; }
+        #summary .source { color: #888; font-size: 0.65em; }
+
+        table { border-collapse: collapse; width: 100%; }
+        th, td { text-align: left; padding: 4px 10px; border-bottom: 1px solid #333; }
+        th { color: #aaa; font-weight: normal; border-bottom: 1px solid #555; }
+        td.num { text-align: right; }
+
+        .same-exit { color: #c8a44e; }
+        .muted { color: #777; }
+    </style>
+</head>
+<body>
+    <h1>VPN Rotations</h1>
+    <p id="count">{{ len .Rotations }} rotation(s) &mdash; auto-refreshes every 60 seconds.</p>
+    {{ template "nav" "rotations" }}
+
+    <div id="summary">
+        <div>
+            <span class="label">Last rotation</span>
+            {{- if .LastRotation }}
+            <span class="value">{{ fmtTime .LastRotation.At }}</span>
+            {{- if .LastRotation.Source }}
+            <span class="source">{{ .LastRotation.Source }}</span>
+            {{- end }}
+            {{- else }}
+            <span class="value muted">&mdash;</span>
+            {{- end }}
+        </div>
+        <div>
+            <span class="label">Exit IP</span>
+            <span class="value">{{ if .ExitIP }}{{ .ExitIP }}{{ if .ExitIPSource }} <span class="source">({{ .ExitIPSource }})</span>{{ end }}{{ else }}&mdash;{{ end }}</span>
+        </div>
+    </div>
+
+    {{- if .Rotations }}
+    <table>
+        <tr>
+            <th>When</th>
+            <th>Source</th>
+            <th>Reason</th>
+            <th class="num">Down at rotation</th>
+            <th>From</th>
+            <th>To</th>
+        </tr>
+        {{- range .Rotations }}
+        <tr>
+            <td>{{ fmtTime .At }}</td>
+            <td>{{ if .Source }}{{ .Source }}{{ else }}&mdash;{{ end }}</td>
+            <td>{{ .Reason }}</td>
+            <td class="num">{{ if .BeforeMbps }}{{ mbps .BeforeMbps }} Mbps{{ else }}&mdash;{{ end }}</td>
+            <td>{{ if .FromExitIP }}{{ .FromExitIP }}{{ else }}&mdash;{{ end }}</td>
+            {{- if .SameExit }}
+            <td class="same-exit">{{ .ToExitIP }} &mdash; same exit</td>
+            {{- else }}
+            <td>{{ if .ToExitIP }}{{ .ToExitIP }}{{ else }}<span class="muted">pending</span>{{ end }}</td>
+            {{- end }}
+        </tr>
+        {{- end }}
+    </table>
+    {{- else }}
+    <p class="muted">No rotations recorded yet.</p>
+    {{- end }}
+</body>
+</html>

--- a/cmd/rss4transmission/web/speedtest.html
+++ b/cmd/rss4transmission/web/speedtest.html
@@ -11,6 +11,7 @@
         p { color: #888; margin-top: 0; }
         #nav { margin: 0 0 1em 0; }
         #nav a { color: #6aa8e0; text-decoration: underline; }
+        #nav .here { color: #e0e0e0; }
         a { color: #6aa8e0; }
 
         #summary {
@@ -73,7 +74,7 @@
 <body>
     <h1>VPN Speed</h1>
     <p id="count">{{ len .Rows }} measurement(s) &mdash; auto-refreshes every 60 seconds.</p>
-    <p id="nav"><a href="/">History</a></p>
+    {{ template "nav" "speedtest" }}
 
     <div id="summary">
         <div>
@@ -100,7 +101,18 @@
         </div>
         <div>
             <span class="label">Rotations</span>
-            <span class="value">{{ len .Rotations }}</span>
+            <span class="value"><a href="/rotations">{{ len .Rotations }}</a></span>
+        </div>
+        <div>
+            <span class="label">Last rotation</span>
+            {{- if .LastRotation }}
+            <span class="value">{{ fmtTime .LastRotation.At }}</span>
+            {{- if .LastRotation.Source }}
+            <span class="source">{{ .LastRotation.Source }}</span>
+            {{- end }}
+            {{- else }}
+            <span class="value muted">&mdash;</span>
+            {{- end }}
         </div>
     </div>
 
@@ -161,35 +173,6 @@
     <p class="muted">No measurements recorded yet.</p>
     {{- end }}
 
-    <h2>Rotations</h2>
-    {{- if .Rotations }}
-    <table>
-        <tr>
-            <th>When</th>
-            <th>Source</th>
-            <th>Reason</th>
-            <th class="num">Down at rotation</th>
-            <th>From</th>
-            <th>To</th>
-        </tr>
-        {{- range .Rotations }}
-        <tr>
-            <td>{{ fmtTime .At }}</td>
-            <td>{{ if .Source }}{{ .Source }}{{ else }}&mdash;{{ end }}</td>
-            <td>{{ .Reason }}</td>
-            <td class="num">{{ if .BeforeMbps }}{{ mbps .BeforeMbps }} Mbps{{ else }}&mdash;{{ end }}</td>
-            <td>{{ if .FromExitIP }}{{ .FromExitIP }}{{ else }}&mdash;{{ end }}</td>
-            {{- if .SameExit }}
-            <td class="same-exit">{{ .ToExitIP }} &mdash; same exit</td>
-            {{- else }}
-            <td>{{ if .ToExitIP }}{{ .ToExitIP }}{{ else }}<span class="muted">pending</span>{{ end }}</td>
-            {{- end }}
-        </tr>
-        {{- end }}
-    </table>
-    {{- else }}
-    <p class="muted">No rotations recorded yet.</p>
-    {{- end }}
     {{- if or .CanRun .CanRotate }}
     <script>
         (function () {

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -353,8 +353,11 @@ rss4transmission watch --config config.yaml \
     --public-listen 0.0.0.0:8080
 ```
 
-The history page shows each item's feed name, title, publication date, outcome, and extracted
-labels. Records are pruned on the same schedule as the seen cache (`SeenCacheDays`).
+The history page is titled **Torrents** in the UI and shows each item's feed name, title,
+publication date, outcome, and extracted labels. Records are pruned on the same schedule as the
+seen cache (`SeenCacheDays`). When `SpeedTest` is enabled it carries a nav bar linking the
+**VPN Speed** (`/speedtest`) and **Rotations** (`/rotations`) pages; see
+[VPN Speed Testing](speedtest.md#viewing-results).
 
 When multiple sibling feeds share one RSS URL — for example, separate feeds for different
 categories of content that all happen to be published through the same feed URL — the same item
@@ -399,7 +402,7 @@ environment:
 
 | Route | `--private-listen` (single) | `--private-listen` (split) | `--public-listen` (split) |
 |---|---|---|---|
-| `/` (history page) | ✓ (requires `--history-file`) | ✓ (requires `--history-file`) | — |
+| `/` (torrents page) | ✓ (requires `--history-file`) | ✓ (requires `--history-file`) | — |
 | `/torrent` | ✓ (requires `--history-file`) | ✓ (requires `--history-file`) | — |
 | `/forget` | ✓ (requires `--history-file`) | ✓ (requires `--history-file`) | — |
 | `/cancel` | ✓ | — | ✓ |

--- a/docs/speedtest.md
+++ b/docs/speedtest.md
@@ -164,7 +164,7 @@ Rows that met the floors have no verdict and stay blank, and a failed or skipped
 reason instead.
 
 Note that with a narrow server filter such as `SERVER_CITIES=Los Angeles`, a restart can land on
-the same server. The `/speedtest` page flags rotations whose exit IP did not change, which is the
+the same server. The `/rotations` page flags rotations whose exit IP did not change, which is the
 signal to widen the filter rather than to rotate more. Both ends of that comparison come from
 Gluetun, read either side of the restart, so an unchanged pair really does mean an unchanged
 tunnel.
@@ -184,7 +184,7 @@ There are two different answers to "which exit are we on", and the `/speedtest` 
 because they do not always agree:
 
 - The **Exit IP** tile is Gluetun's own `GET /v1/publicip/ip`, refreshed on the port monitor's
-  5-minute check. This is the authoritative one, and it is what the rotation log's **From** and
+  5-minute check. This is the authoritative one, and it is what the `/rotations` log's **From** and
   **To** columns record. It is unlabeled because with Gluetun configured it is always Gluetun's
   answer; a measure-only deployment has nothing to ask, so its tile falls back to the last
   measurement and says `(speedtest.net)`.
@@ -209,11 +209,14 @@ the tunnel's peer either. Gluetun's own startup log is the only place that addre
 
 With `--private-listen` set, the private web server serves:
 
-- `GET /speedtest` — recent measurements, the current exit IP as reported by Gluetun, and the
-  rotation log. Every rotation is logged, not only the speedtest-driven ones: the **Source**
-  column reads `speedtest`, `schedule`
-  (`Gluetun.RotateTime` elapsed), `closed-port` (`Gluetun.ClosedPortChecks` exceeded) or `manual`
-  (the page's button). `rss4transmission_vpn_rotations_total` counts all four
+- `GET /speedtest` — recent measurements, the current exit IP as reported by Gluetun, and a
+  **Last rotation** tile giving the date, time and source of the most recent rotation
+- `GET /rotations` — the rotation log, on its own page because measurements arrive every
+  `Interval` while rotations are rare, and one combined page meant scrolling past hours of rows to
+  reach them. Every rotation is logged, not only the speedtest-driven ones: the **Source** column
+  reads `speedtest`, `schedule` (`Gluetun.RotateTime` elapsed), `closed-port`
+  (`Gluetun.ClosedPortChecks` exceeded) or `manual` (the page's button).
+  `rss4transmission_vpn_rotations_total` counts all four
 - `GET /metrics` — Prometheus text format, exposing:
 
 ```
@@ -233,8 +236,9 @@ never scraped as a dead link. `rss4transmission_speedtest_last_run_timestamp_sec
 every attempt including failures, which is how you tell "measuring badly" apart from "stopped
 measuring".
 
-Both endpoints are unauthenticated, like the history page; keep `--private-listen` off the
-public internet.
+All three endpoints are unauthenticated, like the torrents page at `/`; keep `--private-listen`
+off the public internet. Every page carries the same nav bar — **Torrents**, **VPN Speed**,
+**Rotations** — with the page you are on named but not linked.
 
 ### On-demand buttons
 


### PR DESCRIPTION
## Why

`/speedtest` rendered measurements and rotations on one page. Measurements arrive every `Interval`
while rotations are rare, so reaching the rotation log meant scrolling past hours of measurement
rows — the log was effectively buried.

## What changed

- **`GET /rotations`** (`web/rotations.html`) — the rotation table moves here intact: When /
  Source / Reason / Down at rotation / From / To, keeping the `same exit` highlight and the
  `pending` outcome state. Registered inside the same `speed != nil` block as `/speedtest`, so it
  404s identically when no speed store is configured.
- **`/speedtest` status bar** — new **Last rotation** tile with the date, time and source
  (`speedtest` / `schedule` / `closed-port` / `manual`), or an em dash when nothing has rotated, so
  the landing page still says when the egress last moved. The rotations count now links to the log.
- **Shared nav bar** (`web/nav.html`) — a `{{ define "nav" }}` partial parsed into both template
  sets, rendering `Torrents · VPN Speed · Rotations` with the current page named but unlinked. The
  two VPN links stay gated on the existing `speedtestEnabled` FuncMap entry, so `/` hides them when
  speed testing is off.
- **History page titled "Torrents"** — labels only. The route, `HistoryFile`, `--history-file` and
  `HISTORY_FILE` are unchanged.
- `speedweb.go`: `LastRotation` on `speedPageData`, a new `rotationsPageData`, and the rotation loop
  extracted into `buildRotationRows` shared by both page builders; reuses the existing
  `SpeedFile.LastRotation()`.

## Tests

12 new or re-targeted cases in `speedweb_test.go`, written first and confirmed failing before the
implementation: the new page and its empty / nil-store states, `/speedtest` no longer carrying a
rotation table, the Last rotation tile with and without rotations, and the nav bar on all three
pages.

`make test`, `golangci-lint`, `go mod tidy` and `govulncheck` are all clean; pages were rendered and
checked by eye.

## Docs

`docs/speedtest.md` endpoint list and same-exit guidance, `docs/notifications.md`, the README
feature bullet, and a CLAUDE.md note on the nav partial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)