### PR TITLE
Add a Transmission page to the web UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,10 +117,17 @@ starts a separate public-facing server for `/cancel`, `/healthz`, and `/notify-c
 In the gluetun docker-compose, expose the port explicitly via the `ports:` block; in the plain
 docker-compose `network_mode: host` already exposes all ports.
 
-The private server serves three pages: `/` (titled **Torrents**, `web/history.html`), `/speedtest`
-and `/rotations` (both in `speedweb.go`, registered only when a `SpeedFile` exists). They share the
-nav bar in `web/nav.html`, a `{{ define "nav" }}` partial parsed into each page's template set and
-given the current page name as its dot; it needs a `speedtestEnabled` func in that set's FuncMap.
+The private server serves four pages: `/` (titled **Torrents**, `web/history.html`), `/speedtest`
+and `/rotations` (both in `speedweb.go`, registered only when a `SpeedFile` exists), and
+`/transmission` (`transmissionweb.go`, registered unless `Transmission.WebUI` is false). The
+Transmission page frames the Transmission web client, served through the `/transmission/` reverse
+proxy in the same file: the proxy injects the configured Basic auth and strips `X-Frame-Options`
+and CSP `frame-ancestors` from responses.
+
+All four pages share the nav bar in `web/nav.html`, a `{{ define "nav" }}` partial parsed into each
+page's template set and given the current page name as its dot. It needs the funcs that
+`navConfig.navFuncs()` (`web.go`) returns in that set's FuncMap, so every template set that parses
+`navTmpl` must merge them in.
 
 **Config defaults** are defined as a `map[string]interface{}` in `config.go` and loaded before the YAML
 file, so koanf's merge semantics provide defaults without nil-checks in code.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Pre-built images are available on [DockerHub](https://hub.docker.com/r/synfinati
   outcome and extracted labels; skipped, excluded, and error items can be re-submitted to
   Transmission with a Torrent button. Cross-links the **VPN Speed** and **Rotations** pages when
   speed testing is enabled
+- **Embedded Transmission client** — the **Transmission** page shows the Transmission web client
+  in a frame, so one nav bar covers both tools. A built-in reverse proxy reaches Transmission on
+  your behalf and signs in with the configured credentials, which works even when the browser
+  cannot resolve `Transmission.Host`. Turn it off with `Transmission.WebUI: false`
 - **Gluetun VPN integration** — automatically restarts the VPN and syncs the peer port into
   Transmission when running behind [Gluetun](https://github.com/qdm12/gluetun); port state is
   polled every 5 minutes and logged/alerted on (also available without Gluetun via

--- a/cmd/rss4transmission/config.go
+++ b/cmd/rss4transmission/config.go
@@ -36,6 +36,7 @@ var ConfigDefaults = map[string]interface{}{
 	"Transmission.Path":       "/transmission/rpc",
 	"Transmission.Username":   "admin",
 	"Transmission.Password":   "admin",
+	"Transmission.WebUI":      true,
 	"SeenCacheDays":           30,
 	"Notifications.TokenTTLH": 24,
 
@@ -225,6 +226,12 @@ type Transmission struct {
 	Path     string `koanf:"Path"`
 	Username string `koanf:"Username"`
 	Password string `koanf:"Password"` // nolint:gosec
+	// WebUI serves the Transmission page and its reverse proxy on the
+	// private listener. Turn it off when Transmission is already reachable
+	// through a proxy of your own, or when the private port is not
+	// trustworthy: the proxy attaches the credentials above to every
+	// request it forwards.
+	WebUI bool `koanf:"WebUI"`
 }
 
 type GluetunConfig struct {

--- a/cmd/rss4transmission/config_test.go
+++ b/cmd/rss4transmission/config_test.go
@@ -492,3 +492,43 @@ func TestSpeedTestConfig_UploadFloorRequiresUploadTest(t *testing.T) {
 		t.Errorf("Validate() = %q with the upload test enabled, want nil", err)
 	}
 }
+
+// The Transmission web page and its reverse proxy are on by default. A
+// deployment that already fronts Transmission with its own proxy turns them
+// off with Transmission.WebUI: false.
+func TestTransmissionWebUI_Default(t *testing.T) {
+	got, ok := ConfigDefaults["Transmission.WebUI"]
+	if !ok {
+		t.Fatal("ConfigDefaults missing \"Transmission.WebUI\"")
+	}
+	if got != true {
+		t.Errorf("ConfigDefaults[\"Transmission.WebUI\"] = %v (%T), want true", got, got)
+	}
+}
+
+func TestLoadConfig_TransmissionWebUI(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{"unset falls back to the default", "Transmission:\n  Host: gluetun\n", true},
+		{"explicit false wins", "Transmission:\n  Host: gluetun\n  WebUI: false\n", false},
+		{"explicit true wins", "Transmission:\n  Host: gluetun\n  WebUI: true\n", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfgFile := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(cfgFile, []byte(tt.yaml), 0600); err != nil {
+				t.Fatal(err)
+			}
+			rc := &RunContext{}
+			if _, err := rc.loadConfig(cfgFile); err != nil {
+				t.Fatalf("loadConfig returned error: %v", err)
+			}
+			if got := rc.Config.Transmission.WebUI; got != tt.want {
+				t.Errorf("Transmission.WebUI = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/rss4transmission/speedweb.go
+++ b/cmd/rss4transmission/speedweb.go
@@ -126,18 +126,21 @@ type speedActions struct {
 // not have to care whether SpeedTest is enabled; the two pages are not, because
 // a page with nothing to show is worse than a 404.
 func registerSpeedRoutes(mux *http.ServeMux, speed *SpeedFile, portOpen portOpenFunc,
-	exitIP exitIPFunc, actions speedActions,
+	exitIP exitIPFunc, actions speedActions, nav navConfig,
 ) {
 	if speed != nil {
 		// Both pages share the nav partial and the same formatting helpers.
 		// speedtestEnabled is what the nav uses to decide whether to link the
 		// VPN pages at all; on these two pages it is true by construction,
 		// since neither route is registered without a speed store.
+		nav.Speedtest = true
 		funcs := template.FuncMap{
-			"mbps":             func(v float64) string { return fmt.Sprintf("%.1f", v) },
-			"ms":               func(v float64) string { return fmt.Sprintf("%.1f", v) },
-			"fmtTime":          func(t time.Time) string { return t.Local().Format("2006-01-02 15:04:05") },
-			"speedtestEnabled": func() bool { return true },
+			"mbps":    func(v float64) string { return fmt.Sprintf("%.1f", v) },
+			"ms":      func(v float64) string { return fmt.Sprintf("%.1f", v) },
+			"fmtTime": func(t time.Time) string { return t.Local().Format("2006-01-02 15:04:05") },
+		}
+		for name, fn := range nav.navFuncs() {
+			funcs[name] = fn
 		}
 		tmpl := template.Must(template.Must(
 			template.New("speedtest").Funcs(funcs).Parse(navTmpl)).Parse(speedTmpl))

--- a/cmd/rss4transmission/speedweb_test.go
+++ b/cmd/rss4transmission/speedweb_test.go
@@ -13,7 +13,7 @@ import (
 func speedMux(t *testing.T, s *SpeedFile, portOpen func() (bool, bool)) *http.ServeMux {
 	t.Helper()
 	mux := http.NewServeMux()
-	registerSpeedRoutes(mux, s, portOpen, nil, speedActions{})
+	registerSpeedRoutes(mux, s, portOpen, nil, speedActions{}, navConfig{})
 	return mux
 }
 
@@ -144,7 +144,7 @@ func TestMetrics_EmptyStore(t *testing.T) {
 
 func TestMetrics_NilStore(t *testing.T) {
 	mux := http.NewServeMux()
-	registerSpeedRoutes(mux, nil, nil, nil, speedActions{})
+	registerSpeedRoutes(mux, nil, nil, nil, speedActions{}, navConfig{})
 	code, _ := getBody(t, mux, "/metrics")
 	if code != http.StatusOK {
 		t.Errorf("status = %d with a nil store, want 200", code)
@@ -207,7 +207,7 @@ func TestRotationsPage_FlagsUnchangedExit(t *testing.T) {
 
 func TestSpeedTestPage_NilStoreNotRegistered(t *testing.T) {
 	mux := http.NewServeMux()
-	registerSpeedRoutes(mux, nil, nil, nil, speedActions{})
+	registerSpeedRoutes(mux, nil, nil, nil, speedActions{}, navConfig{})
 	code, _ := getBody(t, mux, "/speedtest")
 	if code != http.StatusNotFound {
 		t.Errorf("status = %d with a nil store, want 404", code)
@@ -219,7 +219,7 @@ func TestSpeedTestPage_NilStoreNotRegistered(t *testing.T) {
 func TestHistoryPage_LinksSpeedtestWhenEnabled(t *testing.T) {
 	h := &HistoryFile{Records: []HistoryRecord{}, guidIndex: map[string]int{}}
 
-	_, on := getBody(t, newWebMux(h, nil, nil, nil, nil, true), "/")
+	_, on := getBody(t, newWebMux(h, nil, nil, nil, nil, navConfig{Speedtest: true}), "/")
 	for _, want := range []string{`href="/speedtest"`, `href="/rotations"`} {
 		if !strings.Contains(navLine(t, on), want) {
 			t.Errorf("torrents page missing the %s link when speedtest is enabled", want)
@@ -231,7 +231,7 @@ func TestHistoryPage_LinksSpeedtestWhenEnabled(t *testing.T) {
 
 	// Both VPN pages are registered together, so neither is linked when the
 	// speed store is absent and both routes would 404.
-	_, off := getBody(t, newWebMux(h, nil, nil, nil, nil, false), "/")
+	_, off := getBody(t, newWebMux(h, nil, nil, nil, nil, navConfig{}), "/")
 	for _, unwanted := range []string{`href="/speedtest"`, `href="/rotations"`} {
 		if strings.Contains(off, unwanted) {
 			t.Errorf("torrents page links %s when the route is not registered", unwanted)
@@ -269,7 +269,7 @@ func TestPortMonitor_LastOpenReflectsLastCheck(t *testing.T) {
 func actionMux(t *testing.T, actions speedActions) *http.ServeMux {
 	t.Helper()
 	mux := http.NewServeMux()
-	registerSpeedRoutes(mux, tempSpeedFile(t), nil, nil, actions)
+	registerSpeedRoutes(mux, tempSpeedFile(t), nil, nil, actions, navConfig{})
 	return mux
 }
 
@@ -399,7 +399,7 @@ func TestSpeedRotate_NotRegisteredWithoutFunc(t *testing.T) {
 
 func TestSpeedTestPage_RendersOnlyAvailableButtons(t *testing.T) {
 	mux := http.NewServeMux()
-	registerSpeedRoutes(mux, tempSpeedFile(t), nil, nil, speedActions{Run: func() bool { return true }})
+	registerSpeedRoutes(mux, tempSpeedFile(t), nil, nil, speedActions{Run: func() bool { return true }}, navConfig{})
 	_, body := getBody(t, mux, "/speedtest")
 	if !strings.Contains(body, `id="btn-run"`) {
 		t.Error("page is missing the run button")
@@ -409,7 +409,7 @@ func TestSpeedTestPage_RendersOnlyAvailableButtons(t *testing.T) {
 	}
 
 	mux = http.NewServeMux()
-	registerSpeedRoutes(mux, tempSpeedFile(t), nil, nil, speedActions{Rotate: func() bool { return true }})
+	registerSpeedRoutes(mux, tempSpeedFile(t), nil, nil, speedActions{Rotate: func() bool { return true }}, navConfig{})
 	_, body = getBody(t, mux, "/speedtest")
 	if !strings.Contains(body, `id="btn-rotate"`) {
 		t.Error("page is missing the rotate button")
@@ -538,7 +538,7 @@ func TestSpeedTestPage_ExitIPTileUsesGluetun(t *testing.T) {
 	})
 
 	mux := http.NewServeMux()
-	registerSpeedRoutes(mux, s, nil, func() (string, bool) { return "185.9.9.9", true }, speedActions{})
+	registerSpeedRoutes(mux, s, nil, func() (string, bool) { return "185.9.9.9", true }, speedActions{}, navConfig{})
 	_, body := getBody(t, mux, "/speedtest")
 
 	tile := summarySection(t, body)
@@ -586,7 +586,7 @@ func TestSpeedTestPage_ExitIPTileUnknown(t *testing.T) {
 	s.AddResult(SpeedResult{At: time.Now(), DownloadMbps: 412.5, ExitIP: "45.12.3.9"})
 
 	mux := http.NewServeMux()
-	registerSpeedRoutes(mux, s, nil, func() (string, bool) { return "", false }, speedActions{})
+	registerSpeedRoutes(mux, s, nil, func() (string, bool) { return "", false }, speedActions{}, navConfig{})
 	_, body := getBody(t, mux, "/speedtest")
 
 	tile := summarySection(t, body)
@@ -801,7 +801,7 @@ func TestRotationsPage_EmptyStore(t *testing.T) {
 // worse than a 404 -- the same call the /speedtest route makes.
 func TestRotationsPage_NilStoreNotRegistered(t *testing.T) {
 	mux := http.NewServeMux()
-	registerSpeedRoutes(mux, nil, nil, nil, speedActions{})
+	registerSpeedRoutes(mux, nil, nil, nil, speedActions{}, navConfig{})
 
 	if code, _ := getBody(t, mux, "/rotations"); code != http.StatusNotFound {
 		t.Errorf("status = %d without a speed store, want 404", code)

--- a/cmd/rss4transmission/transmissionweb.go
+++ b/cmd/rss4transmission/transmissionweb.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"html/template"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+)
+
+//go:embed web/transmission.html
+var transmissionTmpl string
+
+// proxyMethods are the HTTP methods the reverse proxy forwards. The web client
+// needs GET for its assets and POST for the RPC endpoint. The rest are here so
+// a browser preflight or a stray HEAD does not fall through to the history
+// page's catch-all. Anything else gets a 405 from the mux.
+var proxyMethods = []string{
+	http.MethodGet, http.MethodHead, http.MethodPost,
+	http.MethodPut, http.MethodDelete, http.MethodOptions,
+}
+
+// transmissionOrigin builds the scheme://host:port that the reverse proxy
+// forwards to. It is the same origin the RPC client uses, minus the RPC path,
+// because the proxy forwards every path unchanged.
+func transmissionOrigin(https bool, host string, port int) (*url.URL, error) {
+	if host == "" {
+		return nil, fmt.Errorf("Transmission.Host is empty")
+	}
+	proto := "http"
+	if https {
+		proto = "https"
+	}
+	return url.Parse(fmt.Sprintf("%s://%s:%d", proto, host, port))
+}
+
+// transmissionProxyTarget returns the origin the Transmission page must proxy
+// to, or nil when the page is turned off or the config cannot produce a usable
+// origin. A nil result means the routes are not registered and the nav item is
+// not shown.
+func transmissionProxyTarget(cfg Transmission) *url.URL {
+	if !cfg.WebUI {
+		return nil
+	}
+	target, err := transmissionOrigin(cfg.HTTPS, cfg.Host, cfg.Port)
+	if err != nil {
+		log.WithError(err).Warn("Transmission.WebUI is on but the Transmission page cannot be served")
+		return nil
+	}
+	return target
+}
+
+// registerTransmissionRoutes adds the Transmission page and the reverse proxy
+// that feeds its iframe.
+//
+//   - GET /transmission is the page: the shared nav bar plus a full-height
+//     iframe.
+//   - /transmission/ is the proxy, on every method, because the web client
+//     sends POST /transmission/rpc.
+//
+// The proxy exists because the browser usually cannot reach Transmission
+// itself: Transmission.Host is a Docker service name in the common
+// deployments. Proxying also makes the frame same-origin and lets us attach
+// the configured credentials, so the browser never prompts inside the frame.
+//
+// These routes are for the private mux only. Like GET /, they are
+// unauthenticated, and they give their caller full control of Transmission.
+//
+// The two patterns do not collide: Go matches the exact "/transmission"
+// pattern before the "/transmission/" subtree, so the page is not swallowed by
+// the proxy.
+//
+// The proxy is registered once per method rather than as a bare
+// "/transmission/" pattern. The history page owns "GET /", and Go rejects a
+// pattern that matches more methods on a more specific path as a conflict.
+func registerTransmissionRoutes(mux *http.ServeMux, target *url.URL, user, pass string, nav navConfig) {
+	nav.Transmission = true
+	funcs := nav.navFuncs()
+	tmpl := template.Must(template.Must(
+		template.New("transmission").Funcs(funcs).Parse(navTmpl)).Parse(transmissionTmpl))
+
+	mux.HandleFunc("GET /transmission", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := tmpl.Execute(w, nil); err != nil {
+			log.WithError(err).Error("Failed to render transmission template")
+		}
+	})
+
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(target)
+			// SetURL joins target.Path onto the inbound path. target has no
+			// path, so the inbound path reaches the upstream unchanged.
+			pr.Out.Host = target.Host
+			if user != "" {
+				pr.Out.SetBasicAuth(user, pass)
+			}
+		},
+		ModifyResponse: func(resp *http.Response) error {
+			stripFramingHeaders(resp.Header)
+			return nil
+		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			log.WithError(err).Warnf("Transmission proxy failed for %s", r.URL.Path)
+			http.Error(w, "Transmission is unreachable", http.StatusBadGateway)
+		},
+	}
+	for _, method := range proxyMethods {
+		mux.Handle(method+" /transmission/", proxy)
+	}
+}
+
+// stripFramingHeaders removes the two response headers that would stop the
+// browser from showing Transmission inside our iframe. Other CSP directives
+// are kept, so a policy that also restricts scripts still applies.
+func stripFramingHeaders(h http.Header) {
+	h.Del("X-Frame-Options")
+
+	csp := h.Get("Content-Security-Policy")
+	if csp == "" {
+		return
+	}
+	kept := []string{}
+	for _, directive := range strings.Split(csp, ";") {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(directive)), "frame-ancestors") {
+			continue
+		}
+		if strings.TrimSpace(directive) == "" {
+			continue
+		}
+		kept = append(kept, strings.TrimSpace(directive))
+	}
+	if len(kept) == 0 {
+		h.Del("Content-Security-Policy")
+		return
+	}
+	h.Set("Content-Security-Policy", strings.Join(kept, "; "))
+}

--- a/cmd/rss4transmission/transmissionweb_test.go
+++ b/cmd/rss4transmission/transmissionweb_test.go
@@ -1,0 +1,340 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// ---- nav item ----
+
+func TestNav_LinksTransmissionWhenEnabled(t *testing.T) {
+	h := &HistoryFile{Records: []HistoryRecord{}, guidIndex: map[string]int{}}
+
+	_, on := getBody(t, newWebMux(h, nil, nil, nil, nil, navConfig{Transmission: true}), "/")
+	if !strings.Contains(navLine(t, on), `href="/transmission"`) {
+		t.Errorf("torrents page nav is missing the Transmission link\ngot:\n%s", navLine(t, on))
+	}
+
+	_, off := getBody(t, newWebMux(h, nil, nil, nil, nil, navConfig{}), "/")
+	if strings.Contains(navLine(t, off), `href="/transmission"`) {
+		t.Errorf("torrents page links /transmission when the route is not registered\ngot:\n%s", navLine(t, off))
+	}
+}
+
+// The VPN pages parse the same partial from a different template set, so they
+// need the same func in their FuncMap.
+func TestNav_SpeedPagesLinkTransmission(t *testing.T) {
+	sf := &SpeedFile{}
+	mux := http.NewServeMux()
+	registerSpeedRoutes(mux, sf, nil, nil, speedActions{}, navConfig{Transmission: true})
+
+	for _, page := range []string{"/speedtest", "/rotations"} {
+		_, body := getBody(t, mux, page)
+		if !strings.Contains(navLine(t, body), `href="/transmission"`) {
+			t.Errorf("%s nav is missing the Transmission link\ngot:\n%s", page, navLine(t, body))
+		}
+	}
+}
+
+// ---- transmissionOrigin ----
+
+func TestTransmissionOrigin(t *testing.T) {
+	tests := []struct {
+		name  string
+		https bool
+		host  string
+		port  int
+		want  string
+	}{
+		{"plain http", false, "gluetun", 9091, "http://gluetun:9091"},
+		{"https", true, "tx.example.com", 443, "https://tx.example.com:443"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := transmissionOrigin(tt.https, tt.host, tt.port)
+			if err != nil {
+				t.Fatalf("transmissionOrigin returned error: %v", err)
+			}
+			if got.String() != tt.want {
+				t.Errorf("transmissionOrigin() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTransmissionOrigin_RejectsEmptyHost(t *testing.T) {
+	if _, err := transmissionOrigin(false, "", 9091); err == nil {
+		t.Error("transmissionOrigin with an empty host returned nil error, want failure")
+	}
+}
+
+// ---- page ----
+
+// upstreamMux builds a mux with the Transmission routes pointed at srv.
+func withUpstream(t *testing.T, srv *httptest.Server, user, pass string) *http.ServeMux {
+	t.Helper()
+	target, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("bad upstream URL: %v", err)
+	}
+	mux := http.NewServeMux()
+	registerTransmissionRoutes(mux, target, user, pass, navConfig{Transmission: true})
+	return mux
+}
+
+func TestTransmissionPage_FramesTheProxy(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	defer srv.Close()
+
+	code, body := getBody(t, withUpstream(t, srv, "admin", "admin"), "/transmission")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if !strings.Contains(body, `src="/transmission/web/"`) {
+		t.Errorf("page does not frame /transmission/web/\ngot:\n%s", body)
+	}
+	if !strings.Contains(navLine(t, body), `<span class="here">Transmission</span>`) {
+		t.Errorf("page nav does not mark Transmission as current\ngot:\n%s", navLine(t, body))
+	}
+}
+
+func TestTransmissionRoutes_NotRegistered(t *testing.T) {
+	mux := http.NewServeMux()
+	for _, path := range []string{"/transmission", "/transmission/web/"} {
+		if code, _ := getBody(t, mux, path); code != http.StatusNotFound {
+			t.Errorf("%s status = %d without the routes, want 404", path, code)
+		}
+	}
+}
+
+// On the real private mux the history page is the catch-all for "/", so an
+// unregistered /transmission renders the torrents page instead of 404ing. What
+// matters is that nothing reaches Transmission.
+func TestTransmissionRoutes_NotRegisteredOnHistoryMux(t *testing.T) {
+	h := &HistoryFile{Records: []HistoryRecord{}, guidIndex: map[string]int{}}
+	mux := newWebMux(h, nil, nil, nil, nil, navConfig{})
+
+	for _, path := range []string{"/transmission", "/transmission/web/"} {
+		code, body := getBody(t, mux, path)
+		if code != http.StatusOK {
+			t.Errorf("%s status = %d, want the torrents page", path, code)
+		}
+		if !strings.Contains(body, "<title>RSS4Transmission Torrents</title>") {
+			t.Errorf("%s did not render the torrents page", path)
+		}
+	}
+}
+
+// ---- proxy ----
+
+func TestTransmissionProxy_ForwardsPathAndQuery(t *testing.T) {
+	var gotURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.String()
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = w.Write([]byte("upstream body"))
+	}))
+	defer srv.Close()
+
+	code, body := getBody(t, withUpstream(t, srv, "", ""), "/transmission/web/index.html?x=1")
+	if gotURL != "/transmission/web/index.html?x=1" {
+		t.Errorf("upstream saw %q, want the path and query unchanged", gotURL)
+	}
+	if code != http.StatusTeapot {
+		t.Errorf("status = %d, want 418 passed through", code)
+	}
+	if body != "upstream body" {
+		t.Errorf("body = %q, want the upstream body", body)
+	}
+}
+
+func TestTransmissionProxy_ForwardsRPCPost(t *testing.T) {
+	var gotMethod, gotBody, gotSession string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		gotSession = r.Header.Get("X-Transmission-Session-Id")
+		w.Header().Set("X-Transmission-Session-Id", "fresh-id")
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer srv.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/transmission/rpc", strings.NewReader(`{"method":"session-get"}`))
+	req.Header.Set("X-Transmission-Session-Id", "stale-id")
+	rec := httptest.NewRecorder()
+	withUpstream(t, srv, "", "").ServeHTTP(rec, req)
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("upstream method = %q, want POST", gotMethod)
+	}
+	if gotBody != `{"method":"session-get"}` {
+		t.Errorf("upstream body = %q, want the request body", gotBody)
+	}
+	if gotSession != "stale-id" {
+		t.Errorf("upstream session id = %q, want stale-id", gotSession)
+	}
+	if got := rec.Header().Get("X-Transmission-Session-Id"); got != "fresh-id" {
+		t.Errorf("response session id = %q, want fresh-id", got)
+	}
+	if rec.Code != http.StatusConflict {
+		t.Errorf("status = %d, want 409 passed through", rec.Code)
+	}
+}
+
+func TestTransmissionProxy_InjectsBasicAuth(t *testing.T) {
+	tests := []struct {
+		name     string
+		user     string
+		pass     string
+		wantUser string
+		wantAuth bool
+	}{
+		{"credentials configured", "admin", "s3cret", "admin", true},
+		{"no username means no header", "", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotUser, gotPass string
+			var gotAuth bool
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotUser, gotPass, gotAuth = r.BasicAuth()
+			}))
+			defer srv.Close()
+
+			getBody(t, withUpstream(t, srv, tt.user, tt.pass), "/transmission/web/")
+
+			if gotAuth != tt.wantAuth {
+				t.Fatalf("upstream saw Basic auth = %v, want %v", gotAuth, tt.wantAuth)
+			}
+			if gotAuth && (gotUser != tt.wantUser || gotPass != tt.pass) {
+				t.Errorf("upstream credentials = %q/%q, want %q/%q", gotUser, gotPass, tt.wantUser, tt.pass)
+			}
+		})
+	}
+}
+
+// Transmission must not be able to break out of the frame. The proxy owns the
+// response, so it removes the two headers that block framing and leaves the
+// rest of the policy alone.
+func TestTransmissionProxy_StripsFramingHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Content-Security-Policy", "frame-ancestors 'none'; default-src 'self'")
+	}))
+	defer srv.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "/transmission/web/", nil)
+	rec := httptest.NewRecorder()
+	withUpstream(t, srv, "", "").ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("X-Frame-Options"); got != "" {
+		t.Errorf("X-Frame-Options = %q, want it removed", got)
+	}
+	csp := rec.Header().Get("Content-Security-Policy")
+	if strings.Contains(csp, "frame-ancestors") {
+		t.Errorf("Content-Security-Policy = %q, want frame-ancestors removed", csp)
+	}
+	if !strings.Contains(csp, "default-src 'self'") {
+		t.Errorf("Content-Security-Policy = %q, want the other directives kept", csp)
+	}
+}
+
+func TestTransmissionProxy_DropsCSPWhenOnlyFrameAncestors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Security-Policy", "frame-ancestors 'none'")
+	}))
+	defer srv.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "/transmission/web/", nil)
+	rec := httptest.NewRecorder()
+	withUpstream(t, srv, "", "").ServeHTTP(rec, req)
+
+	if _, ok := rec.Header()["Content-Security-Policy"]; ok {
+		t.Errorf("Content-Security-Policy = %q, want the empty header removed",
+			rec.Header().Get("Content-Security-Policy"))
+	}
+}
+
+// ---- target selection ----
+
+func TestTransmissionProxyTarget(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Transmission
+		want string
+	}{
+		{
+			name: "enabled",
+			cfg:  Transmission{WebUI: true, Host: "gluetun", Port: 9091},
+			want: "http://gluetun:9091",
+		},
+		{
+			name: "disabled by config",
+			cfg:  Transmission{WebUI: false, Host: "gluetun", Port: 9091},
+			want: "",
+		},
+		{
+			name: "enabled but unusable host",
+			cfg:  Transmission{WebUI: true, Host: "", Port: 9091},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := transmissionProxyTarget(tt.cfg)
+			if tt.want == "" {
+				if got != nil {
+					t.Errorf("transmissionProxyTarget() = %q, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("transmissionProxyTarget() = nil, want %q", tt.want)
+			}
+			if got.String() != tt.want {
+				t.Errorf("transmissionProxyTarget() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The real private mux already serves "GET /" for the history page. Go rejects
+// a "/transmission/" pattern next to it, because that pattern matches more
+// methods on a more specific path. Register the proxy per method instead.
+func TestTransmissionRoutes_CoexistWithHistoryMux(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(r.Method))
+	}))
+	defer srv.Close()
+	target, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("bad upstream URL: %v", err)
+	}
+
+	h := &HistoryFile{Records: []HistoryRecord{}, guidIndex: map[string]int{}}
+	mux := newWebMux(h, nil, nil, nil, nil, navConfig{Transmission: true})
+	registerTransmissionRoutes(mux, target, "", "", navConfig{Transmission: true})
+
+	if code, _ := getBody(t, mux, "/"); code != http.StatusOK {
+		t.Errorf("history page status = %d, want 200", code)
+	}
+	if code, _ := getBody(t, mux, "/transmission"); code != http.StatusOK {
+		t.Errorf("transmission page status = %d, want 200", code)
+	}
+
+	// Every method the web client uses has to reach the upstream.
+	for _, method := range []string{http.MethodGet, http.MethodHead, http.MethodPost,
+		http.MethodPut, http.MethodDelete, http.MethodOptions} {
+		req := httptest.NewRequest(method, "/transmission/rpc", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("%s /transmission/rpc status = %d, want 200", method, rec.Code)
+		}
+	}
+}

--- a/cmd/rss4transmission/watch.go
+++ b/cmd/rss4transmission/watch.go
@@ -230,6 +230,12 @@ func setupWebServers(cmd *WatchCmd, ctx *RunContext, removeT removeFunc, getProg
 	retryHistory retryFunc, feedConfigured func(string) bool, feedGroups func(string) []Group,
 	forgetHistory forgetFunc, accessLog *logrus.Logger,
 ) {
+	// A nil target means the Transmission page is off, so the routes are not
+	// registered and the nav bar does not link them.
+	txTarget := transmissionProxyTarget(ctx.Config.Transmission)
+	nav := navConfig{Speedtest: ctx.Speed != nil, Transmission: txTarget != nil}
+	tx := ctx.Config.Transmission
+
 	if cmd.PublicListen != "" {
 		// Split-listener mode: /cancel, /start, /notify-complete, and /healthz on the
 		// public port, history on a separate private port. Cancel/start routes are NOT
@@ -257,8 +263,11 @@ func setupWebServers(cmd *WatchCmd, ctx *RunContext, removeT removeFunc, getProg
 			if ctx.History == nil {
 				log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
 			}
-			privMux := newWebMux(ctx.History, retryHistory, feedConfigured, feedGroups, forgetHistory, ctx.Speed != nil)
-			registerSpeedRoutes(privMux, ctx.Speed, ctx.PeerPortOpen, ctx.ExitIP, ctx.SpeedActions)
+			privMux := newWebMux(ctx.History, retryHistory, feedConfigured, feedGroups, forgetHistory, nav)
+			registerSpeedRoutes(privMux, ctx.Speed, ctx.PeerPortOpen, ctx.ExitIP, ctx.SpeedActions, nav)
+			if txTarget != nil {
+				registerTransmissionRoutes(privMux, txTarget, tx.Username, tx.Password, nav)
+			}
 			go startWebServer("private", privMux, histAddr)
 		}
 	} else if cmd.PrivateListen != "" {
@@ -270,8 +279,11 @@ func setupWebServers(cmd *WatchCmd, ctx *RunContext, removeT removeFunc, getProg
 		if ctx.History == nil {
 			log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
 		}
-		mux := newWebMux(ctx.History, retryHistory, feedConfigured, feedGroups, forgetHistory, ctx.Speed != nil)
-		registerSpeedRoutes(mux, ctx.Speed, ctx.PeerPortOpen, ctx.ExitIP, ctx.SpeedActions)
+		mux := newWebMux(ctx.History, retryHistory, feedConfigured, feedGroups, forgetHistory, nav)
+		registerSpeedRoutes(mux, ctx.Speed, ctx.PeerPortOpen, ctx.ExitIP, ctx.SpeedActions, nav)
+		if txTarget != nil {
+			registerTransmissionRoutes(mux, txTarget, tx.Username, tx.Password, nav)
+		}
 		if ctx.CancelStore != nil {
 			registerCancelRoutes(mux, ctx.CancelStore, ctx.Config.Notifications, removeT, getProgress, accessLog)
 			ctx.CancelRoutesEnabled = true

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -47,6 +47,23 @@ var historyTmpl string
 //go:embed web/nav.html
 var navTmpl string
 
+// navConfig says which optional nav items exist. The shared nav partial only
+// links a page whose routes were actually registered, so a link never leads to
+// a 404.
+type navConfig struct {
+	Speedtest    bool
+	Transmission bool
+}
+
+// navFuncs returns the FuncMap entries that web/nav.html needs. Every template
+// set that parses navTmpl must merge these in.
+func (n navConfig) navFuncs() template.FuncMap {
+	return template.FuncMap{
+		"speedtestEnabled":    func() bool { return n.Speedtest },
+		"transmissionEnabled": func() bool { return n.Transmission },
+	}
+}
+
 //go:embed web/cancel.html
 var cancelTmpl string
 
@@ -294,9 +311,9 @@ func groupHistoryRows(records []HistoryRecord, feedGroups func(name string) []Gr
 // ties in groupHistoryRows; a nil feedGroups falls back to alphabetical
 // ordering, same as if every feed had no groups.
 // The /healthz route is always registered.
-// speedtest reports whether registerSpeedRoutes will also be called on this
-// mux, so the history page only links /speedtest when that route exists.
-func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name string) bool, feedGroups func(name string) []Group, forget forgetFunc, speedtest bool) *http.ServeMux {
+// nav says which optional pages this mux will also serve, so the history page
+// only links a page whose routes exist.
+func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name string) bool, feedGroups func(name string) []Group, forget forgetFunc, nav navConfig) *http.ServeMux {
 	if feedConfigured == nil {
 		feedConfigured = func(string) bool { return true }
 	}
@@ -313,9 +330,11 @@ func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name s
 				return "skipped"
 			}
 		},
-		"feedConfigured":   feedConfigured,
-		"sub":              func(a, b int) int { return a - b },
-		"speedtestEnabled": func() bool { return speedtest },
+		"feedConfigured": feedConfigured,
+		"sub":            func(a, b int) int { return a - b },
+	}
+	for name, fn := range nav.navFuncs() {
+		funcMap[name] = fn
 	}
 	tmpl := template.Must(template.Must(
 		template.New("history").Funcs(funcMap).Parse(navTmpl)).Parse(historyTmpl))

--- a/cmd/rss4transmission/web/nav.html
+++ b/cmd/rss4transmission/web/nav.html
@@ -1,5 +1,6 @@
 {{- define "nav" -}}
-{{- /* The dot is the current page: "torrents", "speedtest" or "rotations".
+{{- /* The dot is the current page: "torrents", "speedtest", "rotations" or
+       "transmission".
        The page you are on is named but not linked, so the bar reads the same
        everywhere and still says where you are. The VPN pages only exist when a
        speed store is configured, so their links are gated on the same flag that
@@ -14,6 +15,11 @@
         &middot;
         {{- if eq . "rotations" }} <span class="here">Rotations</span>
         {{- else }} <a href="/rotations">Rotations</a>{{ end }}
+        {{- end }}
+        {{- if transmissionEnabled }}
+        &middot;
+        {{- if eq . "transmission" }} <span class="here">Transmission</span>
+        {{- else }} <a href="/transmission">Transmission</a>{{ end }}
         {{- end }}
     </p>
 {{- end -}}

--- a/cmd/rss4transmission/web/transmission.html
+++ b/cmd/rss4transmission/web/transmission.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>RSS4Transmission Transmission</title>
+    <style>
+        html, body { height: 100%; }
+        body {
+            font-family: monospace;
+            margin: 0;
+            background: #1a1a1a;
+            color: #e0e0e0;
+            display: flex;
+            flex-direction: column;
+        }
+        #nav { margin: 0; padding: 0.8em 1em; background: #2a2a2a; }
+        #nav a { color: #6aa8e0; text-decoration: underline; }
+        #nav .here { color: #e0e0e0; }
+
+        /* The client owns everything below the nav bar. It keeps its own
+           scroll position, so the page itself never scrolls. */
+        iframe { flex: 1; width: 100%; border: 0; }
+    </style>
+</head>
+<body>
+    {{ template "nav" "transmission" }}
+    <iframe src="/transmission/web/" title="Transmission"></iframe>
+</body>
+</html>

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -23,7 +23,7 @@ import (
 // --- /healthz ---
 
 func TestHealthzHandler(t *testing.T) {
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	req := httptest.NewRequest("GET", "/healthz", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -78,7 +78,7 @@ func TestGetCancelHandler_RendersForm(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -103,7 +103,7 @@ func TestGetCancelHandler_RendersProgress(t *testing.T) {
 	// 2.5 GiB downloaded, 25% done
 	getProgress := makeProgressFunc(int64(2.5*float64(1<<30)), 0.25)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), getProgress, nil)
 
 	req := httptest.NewRequest("GET",
@@ -128,7 +128,7 @@ func TestGetCancelHandler_ProgressUnknownOnError(t *testing.T) {
 		return 0, 0, fmt.Errorf("transmission unavailable")
 	}
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), errProgress, nil)
 
 	req := httptest.NewRequest("GET",
@@ -143,7 +143,7 @@ func TestGetCancelHandler_ProgressUnknownOnError(t *testing.T) {
 func TestGetCancelHandler_MissingParams(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET", "/cancel?id=test-id", nil)
@@ -159,7 +159,7 @@ func TestGetCancelHandler_BadSignature(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -176,7 +176,7 @@ func TestGetCancelHandler_Expired(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -192,7 +192,7 @@ func TestGetCancelHandler_NotFound(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -210,7 +210,7 @@ func TestGetCancelHandler_DoesNotConsumeEntry(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	removed := false
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), nil)
 
@@ -237,7 +237,7 @@ func TestPostCancelHandler_Valid(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	removed := false
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -253,7 +253,7 @@ func TestPostCancelHandler_Valid(t *testing.T) {
 func TestPostCancelHandler_MissingParams(t *testing.T) {
 	store := NewStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := strings.NewReader("id=test-id") // missing expires and sig
@@ -271,7 +271,7 @@ func TestPostCancelHandler_BadSignature(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, "badsig")
@@ -289,7 +289,7 @@ func TestPostCancelHandler_Expired(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -306,7 +306,7 @@ func TestPostCancelHandler_NotFound(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	body := makeCancelFormBody("ghost-id", expires, sig)
@@ -387,7 +387,7 @@ func TestPostCancelHandler_RemoveErrorPreservesStoreEntry(t *testing.T) {
 	failRemove := func(_ context.Context, _ []int64) error {
 		return fmt.Errorf("transmission unreachable")
 	}
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, failRemove, noProgressFunc(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -408,7 +408,7 @@ func TestGetCancelHandler_ZeroBytesProgressBothUnknown(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	// brand-new torrent: 0 bytes downloaded, 0% done
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), makeProgressFunc(0, 0.0), nil)
 
 	req := httptest.NewRequest("GET",
@@ -458,7 +458,7 @@ func TestHistoryPage_RendersTorrentButtonForSkippedWithURL(t *testing.T) {
 		"skipped", "lost preference contest", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil, false)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil, navConfig{})
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -477,7 +477,7 @@ func TestHistoryPage_NotifiedOutcomeRendersWithOwnClass(t *testing.T) {
 		"notified", "", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, nil, nil, nil, nil, false)
+	mux := newWebMux(h, nil, nil, nil, nil, navConfig{})
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -490,7 +490,7 @@ func TestHistoryPage_NotifiedOutcomeRendersWithOwnClass(t *testing.T) {
 
 func TestHistoryPage_NotifiedOutcomeFilterPillPresentAndChecked(t *testing.T) {
 	h := emptyHistory()
-	mux := newWebMux(h, nil, nil, nil, nil, false)
+	mux := newWebMux(h, nil, nil, nil, nil, navConfig{})
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -508,7 +508,7 @@ func TestHistoryPage_RendersForgetButtonForSkipped(t *testing.T) {
 		"skipped", "lost preference contest", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, nil, nil, nil, makeForgetFunc(new(bool), nil, nil, true, nil), false)
+	mux := newWebMux(h, nil, nil, nil, makeForgetFunc(new(bool), nil, nil, true, nil), navConfig{})
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -529,7 +529,7 @@ func TestHistoryPage_RendersForgetButtonForDispatched(t *testing.T) {
 
 	// Unlike Torrent, Forget makes sense for dispatched/downloaded items too —
 	// a user may deliberately want to allow a re-download.
-	mux := newWebMux(h, nil, nil, nil, makeForgetFunc(new(bool), nil, nil, true, nil), false)
+	mux := newWebMux(h, nil, nil, nil, makeForgetFunc(new(bool), nil, nil, true, nil), navConfig{})
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -543,7 +543,7 @@ func TestHistoryPage_NoTorrentButtonWithoutURL(t *testing.T) {
 	rec := NewHistoryRecord("myfeed", makeGofeedItem("No Enclosure", "guid-2"), "excluded", "matched exclude", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil, false)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil, navConfig{})
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -559,7 +559,7 @@ func TestHistoryPage_NoTorrentButtonForDispatched(t *testing.T) {
 		"dispatched", "", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil, false)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil, navConfig{})
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -577,7 +577,7 @@ func TestHistoryPage_TorrentButtonShownWhenFeedConfiguredNil(t *testing.T) {
 
 	// A nil feedConfigured means "no filter" — button shows unconditionally,
 	// matching every existing caller that doesn't care about live config.
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil, false)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil, navConfig{})
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -594,7 +594,7 @@ func TestHistoryPage_TorrentButtonHiddenWhenFeedNotConfigured(t *testing.T) {
 	h.AddOrUpdateRecord(rec)
 
 	feedConfigured := func(name string) bool { return name == "still-here" }
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), feedConfigured, nil, nil, false)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), feedConfigured, nil, nil, navConfig{})
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -612,7 +612,7 @@ func TestHistoryPage_TorrentButtonShownWhenFeedStillConfigured(t *testing.T) {
 	h.AddOrUpdateRecord(rec)
 
 	feedConfigured := func(name string) bool { return name == "still-here" }
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), feedConfigured, nil, nil, false)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), feedConfigured, nil, nil, navConfig{})
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -849,7 +849,7 @@ func TestHistoryPage_GroupsRecordsSharingGUID(t *testing.T) {
 		makeGofeedItemWithEnclosure("BSB Title", "guid-1", "https://example.com/bsb.torrent"),
 		"skipped", "no group matched labels", nil))
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil, false)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil, navConfig{})
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -890,7 +890,7 @@ func TestHistoryPage_FeedGroupsBreaksNoGroupMatchedTie(t *testing.T) {
 		return nil
 	}
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, feedGroups, nil, false)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, feedGroups, nil, navConfig{})
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -912,7 +912,7 @@ func TestHistoryPage_UniqueGUIDRendersUngrouped(t *testing.T) {
 	h := emptyHistory()
 	h.AddOrUpdateRecord(NewHistoryRecord("myfeed", makeGofeedItem("Solo Title", "guid-solo"), "skipped", "excluded by regex", nil))
 
-	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil, false)
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil, navConfig{})
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
@@ -949,7 +949,7 @@ func TestPostTorrentHandler_Success(t *testing.T) {
 
 	called := false
 	var gotRec HistoryRecord
-	mux := newWebMux(h, makeRetryFunc(&called, &gotRec, 7, nil), nil, nil, nil, false)
+	mux := newWebMux(h, makeRetryFunc(&called, &gotRec, 7, nil), nil, nil, nil, navConfig{})
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -965,7 +965,7 @@ func TestPostTorrentHandler_Success(t *testing.T) {
 func TestPostTorrentHandler_UnknownRecord(t *testing.T) {
 	h := emptyHistory()
 	called := false
-	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, nil), nil, nil, nil, false)
+	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, nil), nil, nil, nil, navConfig{})
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("ghost-feed", "ghost-guid"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -982,7 +982,7 @@ func TestPostTorrentHandler_RetryError(t *testing.T) {
 	h.AddOrUpdateRecord(rec)
 
 	called := false
-	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, fmt.Errorf("boom: no torrent URL")), nil, nil, nil, false)
+	mux := newWebMux(h, makeRetryFunc(&called, nil, 0, fmt.Errorf("boom: no torrent URL")), nil, nil, nil, navConfig{})
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -999,7 +999,7 @@ func TestPostTorrentHandler_NotRegisteredWhenRetryNil(t *testing.T) {
 	rec := NewHistoryRecord("myfeed", makeGofeedItem("My Title", "guid-1"), "skipped", "", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, nil, nil, nil, nil, false)
+	mux := newWebMux(h, nil, nil, nil, nil, navConfig{})
 
 	req := httptest.NewRequest("POST", "/torrent", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -1046,7 +1046,7 @@ func TestPostForgetHandler_Success(t *testing.T) {
 
 	called := false
 	var gotFeed, gotGUID string
-	mux := newWebMux(h, nil, nil, nil, makeForgetFunc(&called, &gotFeed, &gotGUID, true, nil), false)
+	mux := newWebMux(h, nil, nil, nil, makeForgetFunc(&called, &gotFeed, &gotGUID, true, nil), navConfig{})
 
 	req := httptest.NewRequest("POST", "/forget", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -1062,7 +1062,7 @@ func TestPostForgetHandler_Success(t *testing.T) {
 func TestPostForgetHandler_UnknownRecord(t *testing.T) {
 	h := emptyHistory()
 	called := false
-	mux := newWebMux(h, nil, nil, nil, makeForgetFunc(&called, nil, nil, false, nil), false)
+	mux := newWebMux(h, nil, nil, nil, makeForgetFunc(&called, nil, nil, false, nil), navConfig{})
 
 	req := httptest.NewRequest("POST", "/forget", makeTorrentFormBody("ghost-feed", "ghost-guid"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -1079,7 +1079,7 @@ func TestPostForgetHandler_ForgetError(t *testing.T) {
 	h.AddOrUpdateRecord(rec)
 
 	called := false
-	mux := newWebMux(h, nil, nil, nil, makeForgetFunc(&called, nil, nil, false, fmt.Errorf("boom: cache write failed")), false)
+	mux := newWebMux(h, nil, nil, nil, makeForgetFunc(&called, nil, nil, false, fmt.Errorf("boom: cache write failed")), navConfig{})
 
 	req := httptest.NewRequest("POST", "/forget", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -1096,7 +1096,7 @@ func TestPostForgetHandler_NotRegisteredWhenForgetNil(t *testing.T) {
 	rec := NewHistoryRecord("myfeed", makeGofeedItem("My Title", "guid-1"), "skipped", "", nil)
 	h.AddOrUpdateRecord(rec)
 
-	mux := newWebMux(h, nil, nil, nil, nil, false)
+	mux := newWebMux(h, nil, nil, nil, nil, navConfig{})
 
 	req := httptest.NewRequest("POST", "/forget", makeTorrentFormBody("myfeed", "guid-1"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -1129,7 +1129,7 @@ func TestGetCancelHandler_AccessLog_InvalidToken(t *testing.T) {
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -1149,7 +1149,7 @@ func TestGetCancelHandler_AccessLog_MissingParams(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET", "/cancel?id=test-id", nil)
@@ -1169,7 +1169,7 @@ func TestGetCancelHandler_AccessLog_Expired(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -1190,7 +1190,7 @@ func TestGetCancelHandler_AccessLog_NotFound(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -1212,7 +1212,7 @@ func TestGetCancelHandler_AccessLog_Success(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	req := httptest.NewRequest("GET",
@@ -1233,7 +1233,7 @@ func TestGetCancelHandler_AccessLog_NilNoOp(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -1252,7 +1252,7 @@ func TestPostCancelHandler_AccessLog_InvalidToken(t *testing.T) {
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, "badsig")
@@ -1275,7 +1275,7 @@ func TestPostCancelHandler_AccessLog_Expired(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -1297,7 +1297,7 @@ func TestPostCancelHandler_AccessLog_NotFound(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
 	lg, buf := makeTestAccessLogger()
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(new(bool)), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("ghost-id", expires, sig)
@@ -1321,7 +1321,7 @@ func TestPostCancelHandler_AccessLog_Success(t *testing.T) {
 
 	lg, buf := makeTestAccessLogger()
 	removed := false
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, makeRemoveFunc(&removed), noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -1348,7 +1348,7 @@ func TestPostCancelHandler_AccessLog_TransmissionError(t *testing.T) {
 	failRemove2 := func(_ context.Context, _ []int64) error {
 		return fmt.Errorf("transmission unreachable")
 	}
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerCancelRoutes(mux, store, cfg, failRemove2, noProgressFunc(), lg)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -1781,7 +1781,7 @@ func TestGetStartHandler_RendersForm(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), h, nil)
 
 	req := httptest.NewRequest("GET",
@@ -1798,7 +1798,7 @@ func TestGetStartHandler_RendersForm(t *testing.T) {
 func TestGetStartHandler_MissingParams(t *testing.T) {
 	store := NewStartStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), emptyHistory(), nil)
 
 	req := httptest.NewRequest("GET", "/start?id=test-id", nil)
@@ -1814,7 +1814,7 @@ func TestGetStartHandler_BadSignature(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), emptyHistory(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -1831,7 +1831,7 @@ func TestGetStartHandler_Expired(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), emptyHistory(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -1847,7 +1847,7 @@ func TestGetStartHandler_NotFoundInStore(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), emptyHistory(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -1864,7 +1864,7 @@ func TestGetStartHandler_NotFoundInHistory(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), emptyHistory(), nil)
 
 	req := httptest.NewRequest("GET",
@@ -1883,7 +1883,7 @@ func TestGetStartHandler_DoesNotConsumeEntry(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), h, nil)
 
 	req := httptest.NewRequest("GET",
@@ -1909,7 +1909,7 @@ func TestPostStartHandler_Valid(t *testing.T) {
 
 	called := false
 	var gotRec HistoryRecord
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerStartRoutes(mux, store, cfg, makeRetryFunc(&called, &gotRec, 42, nil), h, nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -1927,7 +1927,7 @@ func TestPostStartHandler_Valid(t *testing.T) {
 func TestPostStartHandler_MissingParams(t *testing.T) {
 	store := NewStartStore(time.Hour)
 	cfg := makeCancelCfg("secret", "https://example.com")
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), emptyHistory(), nil)
 
 	body := strings.NewReader("id=test-id") // missing expires and sig
@@ -1945,7 +1945,7 @@ func TestPostStartHandler_BadSignature(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, _ := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), emptyHistory(), nil)
 
 	body := makeCancelFormBody("test-id", expires, "badsig")
@@ -1963,7 +1963,7 @@ func TestPostStartHandler_Expired(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", -time.Second)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), emptyHistory(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -1980,7 +1980,7 @@ func TestPostStartHandler_NotFoundInStore(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "ghost-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), emptyHistory(), nil)
 
 	body := makeCancelFormBody("ghost-id", expires, sig)
@@ -1999,7 +1999,7 @@ func TestPostStartHandler_NotFoundInHistory(t *testing.T) {
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
 	called := false
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerStartRoutes(mux, store, cfg, makeRetryFunc(&called, nil, 42, nil), emptyHistory(), nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)
@@ -2019,7 +2019,7 @@ func TestPostStartHandler_RetryError(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerStartRoutes(mux, store, cfg,
 		makeRetryFunc(new(bool), nil, 0, fmt.Errorf("boom: no torrent URL")), h, nil)
 
@@ -2044,7 +2044,7 @@ func TestPostStartHandler_DoesNotConsumeStoreEntryOnSuccess(t *testing.T) {
 	cfg := makeCancelCfg("secret", "https://example.com")
 	expires, sig := GenerateToken([]byte("secret"), "test-id", time.Hour)
 
-	mux := newWebMux(nil, nil, nil, nil, nil, false)
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
 	registerStartRoutes(mux, store, cfg, makeRetryFunc(new(bool), nil, 42, nil), h, nil)
 
 	body := makeCancelFormBody("test-id", expires, sig)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -165,7 +165,11 @@ Transmission:
   Password: admin
   HTTPS:    false
   Path:     /transmission/rpc
+  WebUI:    true        # serve the Transmission page on --private-listen
 ```
+
+`WebUI` controls the **Transmission** page of the web UI. See
+[Notifications & History](notifications.md#transmission-page).
 
 ## Gluetun Config
 

--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -139,6 +139,7 @@ Transmission:
   Password: admin
   HTTPS:    false
   Path:     /transmission/rpc
+  WebUI:    true        # serve the Transmission page of the web UI
 
 # Seen-cache: tracks what has already been downloaded
 SeenFile:      /config/seen.json

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -357,7 +357,8 @@ The history page is titled **Torrents** in the UI and shows each item's feed nam
 publication date, outcome, and extracted labels. Records are pruned on the same schedule as the
 seen cache (`SeenCacheDays`). When `SpeedTest` is enabled it carries a nav bar linking the
 **VPN Speed** (`/speedtest`) and **Rotations** (`/rotations`) pages; see
-[VPN Speed Testing](speedtest.md#viewing-results).
+[VPN Speed Testing](speedtest.md#viewing-results). The nav bar also links the
+[Transmission page](#transmission-page).
 
 When multiple sibling feeds share one RSS URL — for example, separate feeds for different
 categories of content that all happen to be published through the same feed URL — the same item
@@ -398,6 +399,35 @@ environment:
   - PUBLIC_LISTEN=0.0.0.0:8080     # optional; enables split-listener mode
 ```
 
+## Transmission Page
+
+The **Transmission** page (`/transmission`) shows the Transmission web client inside a frame, so
+the nav bar covers both tools. The page is on by default. Set `Transmission.WebUI: false` to
+remove the page, the nav item, and the proxy below. With the page off, `/transmission` falls
+through to the torrents page, the same as any other unknown path.
+
+The frame does not load Transmission directly. It loads `/transmission/`, a reverse proxy on the
+private listener that forwards every path and method to the `Transmission.Host`,
+`Transmission.Port` and `Transmission.HTTPS` you already configured. The proxy solves three
+problems:
+
+- The browser often cannot reach Transmission. In the Gluetun compose, `Transmission.Host` is
+  `gluetun`, a name that resolves inside the Docker network only. rss4transmission resolves it
+  instead.
+- Transmission asks for Basic auth. The proxy attaches `Transmission.Username` and
+  `Transmission.Password`, so no login prompt appears in the frame.
+- A `X-Frame-Options` or CSP `frame-ancestors` response header would blank the frame. The proxy
+  removes both. All other CSP directives pass through.
+
+**Do not expose `--private-listen` to an untrusted network.** The proxy gives its caller full
+control of Transmission, with your credentials attached. This is the same trust level the private
+listener already needs for `POST /torrent` and `POST /forget`. The proxy is never registered on
+`--public-listen`.
+
+`Transmission.Path` is not used by the proxy, because the proxy forwards the request path
+unchanged. If you set a custom `Path`, Transmission already sits behind a proxy of your own. Set
+`WebUI: false` and use that proxy.
+
 ## Routes Overview
 
 | Route | `--private-listen` (single) | `--private-listen` (split) | `--public-listen` (split) |
@@ -405,6 +435,8 @@ environment:
 | `/` (torrents page) | ✓ (requires `--history-file`) | ✓ (requires `--history-file`) | — |
 | `/torrent` | ✓ (requires `--history-file`) | ✓ (requires `--history-file`) | — |
 | `/forget` | ✓ (requires `--history-file`) | ✓ (requires `--history-file`) | — |
+| `/transmission` (page) | ✓ (requires `WebUI`) | ✓ (requires `WebUI`) | — |
+| `/transmission/` (proxy) | ✓ (requires `WebUI`) | ✓ (requires `WebUI`) | — |
 | `/cancel` | ✓ | — | ✓ |
 | `/start` | ✓ (requires `--history-file`) | — | ✓ (requires `--history-file`) |
 | `/notify-complete` | ✓ | — | ✓ |


### PR DESCRIPTION
The nav bar gains a fourth item. The page frames the Transmission web client, so one UI covers both tools.

The frame does not load Transmission directly. The browser usually cannot reach it: Transmission.Host is a Docker service name in the common deployments. The frame loads /transmission/ instead, a reverse proxy on the private listener that forwards every path and method to the configured host. The proxy also attaches the configured Basic credentials, so no login prompt appears in the frame, and it strips X-Frame-Options and CSP frame-ancestors, which would otherwise blank the frame.

Register the proxy once per method. A bare /transmission/ pattern conflicts with the history page's "GET /", because it matches more methods on a more specific path.

Add Transmission.WebUI, default true, to turn the page, the nav item and the proxy off.

Replace the speedtest bool that newWebMux and registerSpeedRoutes passed to the shared nav partial with a navConfig struct, so the partial can gate more than one optional item.