### PR TITLE
Show the forwarded port and its open state on the VPN page

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Pre-built images are available on [DockerHub](https://hub.docker.com/r/synfinati
   on a `/speedtest` page, and exported on a Prometheus-style `/metrics` endpoint. Every rotation
   can send a pair of ntfy alerts — one when it's requested and one naming the new exit IP once the
   tunnel is back up. The `/speedtest` page also has **Run speedtest now** and **Rotate VPN now**
-  buttons for acting immediately instead of waiting for the next interval, and
+  buttons for acting immediately instead of waiting for the next interval; its header also shows
+  the port Gluetun forwards and whether Transmission sees that port as open, and
   `rss4transmission speedtest` runs a single on-demand measurement from the CLI
 - **Torrent file cache** — avoids re-fetching `.torrent` files on every watch-loop iteration;
   pruned automatically

--- a/cmd/rss4transmission/main.go
+++ b/cmd/rss4transmission/main.go
@@ -61,6 +61,7 @@ type RunContext struct {
 	History             *HistoryFile
 	Speed               *SpeedFile
 	PeerPortOpen        portOpenFunc
+	PeerPort            peerPortFunc
 	ExitIP              exitIPFunc
 	SpeedActions        speedActions
 	CancelStore         *Store

--- a/cmd/rss4transmission/portcheck.go
+++ b/cmd/rss4transmission/portcheck.go
@@ -34,6 +34,14 @@ type PortMonitor struct {
 	lastPublicIP string
 	publicIPErr  bool // the last refresh failed; used to log the transition once
 
+	// lastPeerPort is the port Gluetun last said it forwards, refreshed on
+	// every check. It is read from Gluetun's control server rather than from
+	// Gluetun.peerPort: that field is the port last pushed into Transmission,
+	// which is refreshed only when the port test reports closed and is reset
+	// by a rotation.
+	lastPeerPort int64
+	peerPortErr  bool // the last refresh failed; used to log the transition once
+
 	trigger chan struct{} // buffered(1): an out-of-band check request
 }
 
@@ -116,6 +124,7 @@ func (m *PortMonitor) check() (bool, error) {
 	// which exit we are on, and blanking the IP because of one would make the
 	// VPN page look like the tunnel went away.
 	m.refreshPublicIP()
+	m.refreshPeerPort()
 
 	if err != nil {
 		return false, err
@@ -166,6 +175,44 @@ func (m *PortMonitor) refreshPublicIP() {
 	if ip != "" {
 		m.lastPublicIP = ip
 	}
+}
+
+// refreshPeerPort asks Gluetun which port it forwards and caches the answer.
+// It must be called with m.mu held.
+//
+// A failed query keeps the previous port, for the same reason refreshPublicIP
+// keeps the previous address: an unreachable control server says nothing about
+// whether the forwarded port changed, and blanking it would read as "no port is
+// forwarded". The failure is logged only on the transition into it. A port of
+// zero or less is Gluetun saying it does not know the port yet, which is also
+// not a reason to drop a port we already saw.
+func (m *PortMonitor) refreshPeerPort() {
+	if m.Gluetun == nil {
+		return
+	}
+
+	port, err := m.Gluetun.getPort()
+	if err != nil {
+		if !m.peerPortErr {
+			log.WithError(err).Warn("Unable to read the forwarded port from Gluetun")
+			m.peerPortErr = true
+		}
+		return
+	}
+	m.peerPortErr = false
+
+	if port > 0 {
+		m.lastPeerPort = port
+	}
+}
+
+// LastPeerPort reports the port Gluetun last said it forwards. known is false
+// until Gluetun has answered once, and always when Gluetun is not configured,
+// so callers can say "not known yet" rather than render a zero port as fact.
+func (m *PortMonitor) LastPeerPort() (port int64, known bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastPeerPort, m.lastPeerPort > 0
 }
 
 // LastPublicIP reports the VPN exit IP Gluetun last claimed for itself. known

--- a/cmd/rss4transmission/portcheck_test.go
+++ b/cmd/rss4transmission/portcheck_test.go
@@ -399,7 +399,7 @@ func gluetunPeerPortServer(t *testing.T, port *int64) *httptest.Server {
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"ports":[%d]}`, *port)))
+			_, _ = fmt.Fprintf(w, `{"ports":[%d]}`, *port)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/cmd/rss4transmission/portcheck_test.go
+++ b/cmd/rss4transmission/portcheck_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -383,4 +384,106 @@ func TestPortMonitor_LastPublicIPUnknownWithoutGluetun(t *testing.T) {
 	got, known := m.LastPublicIP()
 	assert.False(t, known)
 	assert.Empty(t, got)
+}
+
+// gluetunPeerPortServer answers the port-forward and public-IP control routes.
+// port is read through a pointer so a test can change the forwarded port
+// between checks; a zero port makes /v1/portforward fail, which is how the
+// "Gluetun stopped answering" case is simulated.
+func gluetunPeerPortServer(t *testing.T, port *int64) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/portforward" {
+			if *port == 0 {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"ports":[%d]}`, *port)))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"public_ip":"1.2.3.4"}`))
+	}))
+}
+
+func newPeerPortMonitor(t *testing.T, port *int64) *PortMonitor {
+	t.Helper()
+	open := true
+	transmissionSrv := portTestTransmissionServer(t, &open)
+	t.Cleanup(transmissionSrv.Close)
+	gluetunSrv := gluetunPeerPortServer(t, port)
+	t.Cleanup(gluetunSrv.Close)
+
+	client := newTestTransmissionClient(t, transmissionSrv.URL)
+	g := &Gluetun{
+		URL:           gluetunSrv.URL,
+		Transmission:  client,
+		lastRotate:    time.Now(),
+		peerPort:      -1,
+		retryAttempts: 1,
+		retryDelay:    time.Millisecond,
+	}
+	return NewPortMonitor(client, g, NtfyConfig{})
+}
+
+func TestPortMonitor_LastPeerPortUnknownBeforeFirstCheck(t *testing.T) {
+	port := int64(54321)
+	m := newPeerPortMonitor(t, &port)
+
+	got, known := m.LastPeerPort()
+	assert.False(t, known)
+	assert.Zero(t, got)
+}
+
+func TestPortMonitor_CheckRecordsGluetunPeerPort(t *testing.T) {
+	port := int64(54321)
+	m := newPeerPortMonitor(t, &port)
+
+	_, err := m.check()
+	require.NoError(t, err)
+
+	got, known := m.LastPeerPort()
+	assert.True(t, known)
+	assert.Equal(t, int64(54321), got)
+
+	// A later check picks up a changed forwarded port.
+	port = 12345
+	_, err = m.check()
+	require.NoError(t, err)
+	got, known = m.LastPeerPort()
+	assert.True(t, known)
+	assert.Equal(t, int64(12345), got)
+}
+
+// An unreachable control server does not mean the forwarded port went away, so
+// the last port we did see is kept rather than blanked.
+func TestPortMonitor_CheckKeepsPeerPortWhenGluetunFails(t *testing.T) {
+	port := int64(54321)
+	m := newPeerPortMonitor(t, &port)
+
+	_, err := m.check()
+	require.NoError(t, err)
+
+	port = 0
+	_, err = m.check()
+	require.NoError(t, err)
+
+	got, known := m.LastPeerPort()
+	assert.True(t, known)
+	assert.Equal(t, int64(54321), got)
+}
+
+func TestPortMonitor_LastPeerPortUnknownWithoutGluetun(t *testing.T) {
+	open := true
+	transmissionSrv := portTestTransmissionServer(t, &open)
+	defer transmissionSrv.Close()
+
+	m := NewPortMonitor(newTestTransmissionClient(t, transmissionSrv.URL), nil, NtfyConfig{})
+	_, err := m.check()
+	require.NoError(t, err)
+
+	got, known := m.LastPeerPort()
+	assert.False(t, known)
+	assert.Zero(t, got)
 }

--- a/cmd/rss4transmission/speedweb.go
+++ b/cmd/rss4transmission/speedweb.go
@@ -39,6 +39,11 @@ var rotationsTmpl string
 // corresponding metric is omitted rather than published as a guess.
 type portOpenFunc func() (open bool, known bool)
 
+// peerPortFunc reports the port Gluetun says it forwards, as cached by the port
+// monitor. known is false until Gluetun has answered once, and always when
+// there is no Gluetun to ask.
+type peerPortFunc func() (port int64, known bool)
+
 // exitIPFunc reports the VPN exit IP Gluetun claims for itself, as cached by
 // the port monitor. known is false until Gluetun has answered once, and always
 // when there is no Gluetun to ask.
@@ -92,6 +97,14 @@ type speedPageData struct {
 	ShowUpload bool
 	CanRun     bool // render the "Run speedtest now" button
 	CanRotate  bool // render the "Rotate VPN now" button
+	// PeerPort is the port Gluetun forwards and PortOpen is what Transmission's
+	// port test made of it. Each carries its own Known flag: "not checked yet"
+	// is not "closed", and "Gluetun has not answered" is not "no port is
+	// forwarded", so an unknown renders as a dash instead of a verdict.
+	PeerPort      int64
+	PeerPortKnown bool
+	PortOpen      bool
+	PortOpenKnown bool
 }
 
 // rotationsPageData is the /rotations view: the same rotation rows the
@@ -126,7 +139,7 @@ type speedActions struct {
 // not have to care whether SpeedTest is enabled; the two pages are not, because
 // a page with nothing to show is worse than a 404.
 func registerSpeedRoutes(mux *http.ServeMux, speed *SpeedFile, portOpen portOpenFunc,
-	exitIP exitIPFunc, actions speedActions, nav navConfig,
+	peerPort peerPortFunc, exitIP exitIPFunc, actions speedActions, nav navConfig,
 ) {
 	if speed != nil {
 		// Both pages share the nav partial and the same formatting helpers.
@@ -149,7 +162,7 @@ func registerSpeedRoutes(mux *http.ServeMux, speed *SpeedFile, portOpen portOpen
 
 		mux.HandleFunc("GET /speedtest", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			data := buildSpeedPageData(speed, exitIP)
+			data := buildSpeedPageData(speed, portOpen, peerPort, exitIP)
 			data.CanRun = actions.Run != nil
 			data.CanRotate = actions.Rotate != nil
 			if err := tmpl.Execute(w, data); err != nil {
@@ -243,7 +256,9 @@ func makeSpeedRotateHandler(actions speedActions) http.HandlerFunc {
 }
 
 // buildSpeedPageData assembles the /speedtest view, newest entries first.
-func buildSpeedPageData(speed *SpeedFile, exitIP exitIPFunc) speedPageData {
+func buildSpeedPageData(speed *SpeedFile, portOpen portOpenFunc, peerPort peerPortFunc,
+	exitIP exitIPFunc,
+) speedPageData {
 	results := speed.GetResults()
 	data := speedPageData{Rows: make([]speedPageRow, 0, len(results))}
 
@@ -286,6 +301,15 @@ func buildSpeedPageData(speed *SpeedFile, exitIP exitIPFunc) speedPageData {
 			data.ShowUpload = true
 			break
 		}
+	}
+
+	// Both are nil in a measure-only deployment, which has no port monitor at
+	// all. Their tiles then render as unknown, which is the truth.
+	if portOpen != nil {
+		data.PortOpen, data.PortOpenKnown = portOpen()
+	}
+	if peerPort != nil {
+		data.PeerPort, data.PeerPortKnown = peerPort()
 	}
 
 	data.Rotations = buildRotationRows(speed)

--- a/cmd/rss4transmission/speedweb_test.go
+++ b/cmd/rss4transmission/speedweb_test.go
@@ -13,7 +13,7 @@ import (
 func speedMux(t *testing.T, s *SpeedFile, portOpen func() (bool, bool)) *http.ServeMux {
 	t.Helper()
 	mux := http.NewServeMux()
-	registerSpeedRoutes(mux, s, portOpen, nil, speedActions{}, navConfig{})
+	registerSpeedRoutes(mux, s, portOpen, nil, nil, speedActions{}, navConfig{})
 	return mux
 }
 
@@ -144,7 +144,7 @@ func TestMetrics_EmptyStore(t *testing.T) {
 
 func TestMetrics_NilStore(t *testing.T) {
 	mux := http.NewServeMux()
-	registerSpeedRoutes(mux, nil, nil, nil, speedActions{}, navConfig{})
+	registerSpeedRoutes(mux, nil, nil, nil, nil, speedActions{}, navConfig{})
 	code, _ := getBody(t, mux, "/metrics")
 	if code != http.StatusOK {
 		t.Errorf("status = %d with a nil store, want 200", code)
@@ -207,7 +207,7 @@ func TestRotationsPage_FlagsUnchangedExit(t *testing.T) {
 
 func TestSpeedTestPage_NilStoreNotRegistered(t *testing.T) {
 	mux := http.NewServeMux()
-	registerSpeedRoutes(mux, nil, nil, nil, speedActions{}, navConfig{})
+	registerSpeedRoutes(mux, nil, nil, nil, nil, speedActions{}, navConfig{})
 	code, _ := getBody(t, mux, "/speedtest")
 	if code != http.StatusNotFound {
 		t.Errorf("status = %d with a nil store, want 404", code)
@@ -269,7 +269,7 @@ func TestPortMonitor_LastOpenReflectsLastCheck(t *testing.T) {
 func actionMux(t *testing.T, actions speedActions) *http.ServeMux {
 	t.Helper()
 	mux := http.NewServeMux()
-	registerSpeedRoutes(mux, tempSpeedFile(t), nil, nil, actions, navConfig{})
+	registerSpeedRoutes(mux, tempSpeedFile(t), nil, nil, nil, actions, navConfig{})
 	return mux
 }
 
@@ -399,7 +399,7 @@ func TestSpeedRotate_NotRegisteredWithoutFunc(t *testing.T) {
 
 func TestSpeedTestPage_RendersOnlyAvailableButtons(t *testing.T) {
 	mux := http.NewServeMux()
-	registerSpeedRoutes(mux, tempSpeedFile(t), nil, nil, speedActions{Run: func() bool { return true }}, navConfig{})
+	registerSpeedRoutes(mux, tempSpeedFile(t), nil, nil, nil, speedActions{Run: func() bool { return true }}, navConfig{})
 	_, body := getBody(t, mux, "/speedtest")
 	if !strings.Contains(body, `id="btn-run"`) {
 		t.Error("page is missing the run button")
@@ -409,7 +409,7 @@ func TestSpeedTestPage_RendersOnlyAvailableButtons(t *testing.T) {
 	}
 
 	mux = http.NewServeMux()
-	registerSpeedRoutes(mux, tempSpeedFile(t), nil, nil, speedActions{Rotate: func() bool { return true }}, navConfig{})
+	registerSpeedRoutes(mux, tempSpeedFile(t), nil, nil, nil, speedActions{Rotate: func() bool { return true }}, navConfig{})
 	_, body = getBody(t, mux, "/speedtest")
 	if !strings.Contains(body, `id="btn-rotate"`) {
 		t.Error("page is missing the rotate button")
@@ -538,7 +538,7 @@ func TestSpeedTestPage_ExitIPTileUsesGluetun(t *testing.T) {
 	})
 
 	mux := http.NewServeMux()
-	registerSpeedRoutes(mux, s, nil, func() (string, bool) { return "185.9.9.9", true }, speedActions{}, navConfig{})
+	registerSpeedRoutes(mux, s, nil, nil, func() (string, bool) { return "185.9.9.9", true }, speedActions{}, navConfig{})
 	_, body := getBody(t, mux, "/speedtest")
 
 	tile := summarySection(t, body)
@@ -586,7 +586,7 @@ func TestSpeedTestPage_ExitIPTileUnknown(t *testing.T) {
 	s.AddResult(SpeedResult{At: time.Now(), DownloadMbps: 412.5, ExitIP: "45.12.3.9"})
 
 	mux := http.NewServeMux()
-	registerSpeedRoutes(mux, s, nil, func() (string, bool) { return "", false }, speedActions{}, navConfig{})
+	registerSpeedRoutes(mux, s, nil, nil, func() (string, bool) { return "", false }, speedActions{}, navConfig{})
 	_, body := getBody(t, mux, "/speedtest")
 
 	tile := summarySection(t, body)
@@ -801,7 +801,7 @@ func TestRotationsPage_EmptyStore(t *testing.T) {
 // worse than a 404 -- the same call the /speedtest route makes.
 func TestRotationsPage_NilStoreNotRegistered(t *testing.T) {
 	mux := http.NewServeMux()
-	registerSpeedRoutes(mux, nil, nil, nil, speedActions{}, navConfig{})
+	registerSpeedRoutes(mux, nil, nil, nil, nil, speedActions{}, navConfig{})
 
 	if code, _ := getBody(t, mux, "/rotations"); code != http.StatusNotFound {
 		t.Errorf("status = %d without a speed store, want 404", code)
@@ -865,4 +865,100 @@ func mustBody(t *testing.T, mux *http.ServeMux, path string) string {
 		t.Fatalf("GET %s = %d, want 200", path, code)
 	}
 	return body
+}
+
+// ---- forwarded port / port open tiles ----
+
+// The two peer-port tiles answer the question the exit IP tile cannot: which
+// port Gluetun forwards, and whether Transmission can actually reach it.
+func TestSpeedTestPage_PeerPortTilesOpen(t *testing.T) {
+	s := tempSpeedFile(t)
+	s.AddResult(SpeedResult{At: time.Now(), DownloadMbps: 412.5})
+
+	mux := http.NewServeMux()
+	registerSpeedRoutes(mux, s,
+		func() (bool, bool) { return true, true },
+		func() (int64, bool) { return 51413, true },
+		nil, speedActions{}, navConfig{})
+	_, body := getBody(t, mux, "/speedtest")
+
+	tile := summarySection(t, body)
+	if !strings.Contains(tile, "Forwarded port") {
+		t.Errorf("summary has no forwarded port tile\ngot:\n%s", tile)
+	}
+	if !strings.Contains(tile, "51413") {
+		t.Errorf("summary does not show the forwarded port\ngot:\n%s", tile)
+	}
+	if !strings.Contains(tile, "Port open") {
+		t.Errorf("summary has no port open tile\ngot:\n%s", tile)
+	}
+	if !strings.Contains(tile, `<span class="value ok">yes</span>`) {
+		t.Errorf("summary does not report the port as open\ngot:\n%s", tile)
+	}
+}
+
+func TestSpeedTestPage_PeerPortTileClosed(t *testing.T) {
+	s := tempSpeedFile(t)
+	s.AddResult(SpeedResult{At: time.Now(), DownloadMbps: 412.5})
+
+	mux := http.NewServeMux()
+	registerSpeedRoutes(mux, s,
+		func() (bool, bool) { return false, true },
+		func() (int64, bool) { return 51413, true },
+		nil, speedActions{}, navConfig{})
+	_, body := getBody(t, mux, "/speedtest")
+
+	tile := summarySection(t, body)
+	if !strings.Contains(tile, `<span class="value error">no</span>`) {
+		t.Errorf("summary does not report the port as closed\ngot:\n%s", tile)
+	}
+}
+
+// Nothing checked yet, or no Gluetun to ask, is not the same as "closed" or
+// "no port forwarded", so both tiles stay empty rather than report a guess.
+func TestSpeedTestPage_PeerPortTilesUnknown(t *testing.T) {
+	s := tempSpeedFile(t)
+	s.AddResult(SpeedResult{At: time.Now(), DownloadMbps: 412.5})
+
+	mux := http.NewServeMux()
+	registerSpeedRoutes(mux, s,
+		func() (bool, bool) { return false, false },
+		func() (int64, bool) { return 0, false },
+		nil, speedActions{}, navConfig{})
+	_, body := getBody(t, mux, "/speedtest")
+
+	tile := summarySection(t, body)
+	if strings.Contains(tile, `<span class="value ok">yes</span>`) ||
+		strings.Contains(tile, `<span class="value error">no</span>`) {
+		t.Errorf("summary reports a port state it has not checked\ngot:\n%s", tile)
+	}
+	if strings.Contains(tile, `<span class="value">0</span>`) {
+		t.Errorf("summary shows a zero forwarded port\ngot:\n%s", tile)
+	}
+}
+
+// A measure-only deployment wires neither func. The page must still render.
+func TestBuildSpeedPageData_NilPortFuncs(t *testing.T) {
+	data := buildSpeedPageData(tempSpeedFile(t), nil, nil, nil)
+
+	if data.PortOpenKnown {
+		t.Error("PortOpenKnown is set without a port-open func")
+	}
+	if data.PeerPortKnown {
+		t.Error("PeerPortKnown is set without a peer-port func")
+	}
+}
+
+func TestBuildSpeedPageData_PortFuncs(t *testing.T) {
+	data := buildSpeedPageData(tempSpeedFile(t),
+		func() (bool, bool) { return true, true },
+		func() (int64, bool) { return 51413, true },
+		nil)
+
+	if !data.PortOpenKnown || !data.PortOpen {
+		t.Errorf("PortOpen = %v, known = %v, want true/true", data.PortOpen, data.PortOpenKnown)
+	}
+	if !data.PeerPortKnown || data.PeerPort != 51413 {
+		t.Errorf("PeerPort = %d, known = %v, want 51413/true", data.PeerPort, data.PeerPortKnown)
+	}
 }

--- a/cmd/rss4transmission/transmissionweb_test.go
+++ b/cmd/rss4transmission/transmissionweb_test.go
@@ -30,7 +30,7 @@ func TestNav_LinksTransmissionWhenEnabled(t *testing.T) {
 func TestNav_SpeedPagesLinkTransmission(t *testing.T) {
 	sf := &SpeedFile{}
 	mux := http.NewServeMux()
-	registerSpeedRoutes(mux, sf, nil, nil, speedActions{}, navConfig{Transmission: true})
+	registerSpeedRoutes(mux, sf, nil, nil, nil, speedActions{}, navConfig{Transmission: true})
 
 	for _, page := range []string{"/speedtest", "/rotations"} {
 		_, body := getBody(t, mux, page)

--- a/cmd/rss4transmission/watch.go
+++ b/cmd/rss4transmission/watch.go
@@ -264,7 +264,7 @@ func setupWebServers(cmd *WatchCmd, ctx *RunContext, removeT removeFunc, getProg
 				log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
 			}
 			privMux := newWebMux(ctx.History, retryHistory, feedConfigured, feedGroups, forgetHistory, nav)
-			registerSpeedRoutes(privMux, ctx.Speed, ctx.PeerPortOpen, ctx.ExitIP, ctx.SpeedActions, nav)
+			registerSpeedRoutes(privMux, ctx.Speed, ctx.PeerPortOpen, ctx.PeerPort, ctx.ExitIP, ctx.SpeedActions, nav)
 			if txTarget != nil {
 				registerTransmissionRoutes(privMux, txTarget, tx.Username, tx.Password, nav)
 			}
@@ -280,7 +280,7 @@ func setupWebServers(cmd *WatchCmd, ctx *RunContext, removeT removeFunc, getProg
 			log.Warnf("--private-listen is set but --history-file was not provided; history page will return 404")
 		}
 		mux := newWebMux(ctx.History, retryHistory, feedConfigured, feedGroups, forgetHistory, nav)
-		registerSpeedRoutes(mux, ctx.Speed, ctx.PeerPortOpen, ctx.ExitIP, ctx.SpeedActions, nav)
+		registerSpeedRoutes(mux, ctx.Speed, ctx.PeerPortOpen, ctx.PeerPort, ctx.ExitIP, ctx.SpeedActions, nav)
 		if txTarget != nil {
 			registerTransmissionRoutes(mux, txTarget, tx.Username, tx.Password, nav)
 		}
@@ -435,6 +435,7 @@ func (cmd *WatchCmd) Run(ctx *RunContext) error {
 	if g != nil || ctx.Config.PortCheck.Enabled {
 		portMonitor = NewPortMonitor(ctx.Transmission, g, ctx.Config.Ntfy)
 		ctx.PeerPortOpen = portMonitor.LastOpen
+		ctx.PeerPort = portMonitor.LastPeerPort
 		// Set before startSpeedMonitor: that is what builds the SpeedMonitor,
 		// which reads it for the exit IP its rotation alerts name.
 		ctx.ExitIP = exitIPSource(g, portMonitor)

--- a/cmd/rss4transmission/web/speedtest.html
+++ b/cmd/rss4transmission/web/speedtest.html
@@ -100,6 +100,26 @@
             <span class="value">{{ if .ExitIP }}{{ .ExitIP }}{{ if .ExitIPSource }} <span class="source">({{ .ExitIPSource }})</span>{{ end }}{{ else }}&mdash;{{ end }}</span>
         </div>
         <div>
+            <span class="label">Forwarded port</span>
+            {{- if .PeerPortKnown }}
+            <span class="value">{{ .PeerPort }}</span>
+            {{- else }}
+            <span class="value muted">&mdash;</span>
+            {{- end }}
+        </div>
+        <div>
+            <span class="label">Port open</span>
+            {{- if .PortOpenKnown }}
+            {{- if .PortOpen }}
+            <span class="value ok">yes</span>
+            {{- else }}
+            <span class="value error">no</span>
+            {{- end }}
+            {{- else }}
+            <span class="value muted">&mdash;</span>
+            {{- end }}
+        </div>
+        <div>
             <span class="label">Rotations</span>
             <span class="value"><a href="/rotations">{{ len .Rotations }}</a></span>
         </div>

--- a/docs/speedtest.md
+++ b/docs/speedtest.md
@@ -209,8 +209,12 @@ the tunnel's peer either. Gluetun's own startup log is the only place that addre
 
 With `--private-listen` set, the private web server serves:
 
-- `GET /speedtest` — recent measurements, the current exit IP as reported by Gluetun, and a
-  **Last rotation** tile giving the date, time and source of the most recent rotation
+- `GET /speedtest` — recent measurements, the current exit IP as reported by Gluetun, a
+  **Last rotation** tile giving the date, time and source of the most recent rotation, and a
+  **Forwarded port** / **Port open** pair. The port comes from Gluetun's `GET /v1/portforward` on
+  the same 5-minute port check that refreshes the exit IP. The open state is the result of
+  Transmission's own port test on that check. Each reads `—` until the first check answers, so
+  "not checked yet" never looks like "closed" or "no port forwarded"
 - `GET /rotations` — the rotation log, on its own page because measurements arrive every
   `Interval` while rotations are rare, and one combined page meant scrolling past hours of rows to
   reach them. Every rotation is logged, not only the speedtest-driven ones: the **Source** column


### PR DESCRIPTION
## Summary

The `/speedtest` header answered "which exit are we on" but said nothing about the peer port. Two
facts decide whether the tunnel is useful for torrenting:

- the port that Gluetun forwards,
- whether Transmission's port test sees that port as open.

Both facts already existed in the process. The port test result only reached `/metrics`, and the
forwarded port never left Gluetun. This adds two tiles to the page header.

## Changes

- `portcheck.go` — `PortMonitor` caches the forwarded port. `refreshPeerPort()` calls Gluetun
  `GET /v1/portforward` on the same 5-minute check that refreshes the exit IP, under the same mutex.
  A failed query keeps the previous port and logs only the transition into the failure, exactly as
  `refreshPublicIP` does. `LastPeerPort()` exposes it.
- `speedweb.go` — new `peerPortFunc` type. `speedPageData` gained `PeerPort`, `PeerPortKnown`,
  `PortOpen` and `PortOpenKnown`. `registerSpeedRoutes` and `buildSpeedPageData` take the two funcs,
  either of which can be nil.
- `web/speedtest.html` — **Forwarded port** and **Port open** tiles, after **Exit IP**. Open renders
  green `yes`, closed renders red `no`, and an unchecked state renders a muted dash.
- `main.go`, `watch.go` — `RunContext.PeerPort` wired from `portMonitor.LastPeerPort`.
- `docs/speedtest.md`, `README.md` — the two tiles and their sources are documented.

The port comes from Gluetun rather than from `Gluetun.peerPort`. That field holds the value last
pushed into Transmission, is refreshed only when the port test reports closed, and is reset by a
rotation.

Both tiles carry their own `Known` flag, so "not checked yet" never renders as "closed" or as "no
port forwarded".

## Tests

Written before the code, per the repository TDD rule.

- `portcheck_test.go` — unknown before the first check, unknown without Gluetun, cached and updated
  across checks, previous value kept when Gluetun fails.
- `speedweb_test.go` — open, closed and unknown tile rendering, plus `buildSpeedPageData` with and
  without the funcs.

`make test` passes. `make fmt` ran clean. `make lint` could not run in this environment: the
installed `golangci-lint` panics with `file requires newer Go version go1.27 (application built with
go1.26)` before it reaches any code. That failure is not related to this change, but CI lint is the
only check on this branch that stayed unverified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)