### PR TITLE
Pin the Go toolchain and the golangci-lint path in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,19 @@ LINUXARM64_BIN            := $(DIST_DIR)$(PROJECT_NAME)-$(PROJECT_VERSION)-linux
 LINUXARM32_BIN            := $(DIST_DIR)$(PROJECT_NAME)-$(PROJECT_VERSION)-linux-arm32
 DARWIN_BIN                := $(DIST_DIR)$(PROJECT_NAME)-$(PROJECT_VERSION)-darwin-amd64
 GOLANGCI_LINT_VERSION     := 2.10.1
+GOLANGCI_LINT             := $(shell go env GOPATH)/bin/golangci-lint
+
+# Pin the Go toolchain to the version go.mod declares, which is the same
+# version CI installs via setup-go's `go-version-file: go.mod`. Without this,
+# every go command uses whatever Go is first in PATH. A newer local Go then
+# builds against a newer standard library than the pinned golangci-lint can
+# type-check, and `make lint` panics instead of linting.
+#
+# The environment variable is what pins. A `toolchain` line in go.mod does not:
+# Go upgrades to a named toolchain when the local one is older, but it never
+# downgrades. Go downloads the pinned toolchain on first use.
+GO_VERSION                := $(shell awk '$$1 == "go" { print $$2 }' go.mod)
+export GOTOOLCHAIN        := go$(GO_VERSION)
 
 
 
@@ -131,7 +144,7 @@ vulncheck: ## Run govulncheck to detect known vulnerabilities
 precheck: test test-fmt test-tidy lint vulncheck ## Run all tests that happen in a PR
 
 lint: .lint-check  ## Run golangci-lint
-	golangci-lint run
+	$(GOLANGCI_LINT) run
 
 lint-install:  ## Install golangci-lint
 	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v$(GOLANGCI_LINT_VERSION)
@@ -142,7 +155,7 @@ lint-install:  ## Install golangci-lint
 
 .PHONY: .lint-check
 .lint-check:
-	@if test $$(golangci-lint --version 2>&1 | grep -c "version $(GOLANGCI_LINT_VERSION)") -eq 0 ; then \
+	@if test $$($(GOLANGCI_LINT) --version 2>&1 | grep -c "version $(GOLANGCI_LINT_VERSION)") -eq 0 ; then \
 	   echo "Need to install golangci-lint $(GOLANGCI_LINT_VERSION)" ; \
 	   echo "Run: make lint-install" ; \
 	   exit -1 ; \


### PR DESCRIPTION
## Problem

`make lint` panicked instead of linting:

```
panic: file requires newer Go version go1.27 (application built with go1.26)
```

Nothing in the repository changed. Homebrew upgraded Go to 1.27.0, and the Makefile ran whatever
`go` and `golangci-lint` came first in PATH. The pinned golangci-lint 2.10.1 embeds a go1.26 type
checker, which cannot read the Go 1.27 standard library.

CI never saw this, because CI pins both sides: `setup-go` installs Go 1.26.4 from
`go-version-file: 'go.mod'`, and the action installs the version that
`make .print-golangci-lint-version` prints. Local builds pinned neither.

## Changes

- `GOTOOLCHAIN` is derived from the `go` directive in `go.mod` and exported, so every recipe uses
  the same Go version CI uses. Go downloads that toolchain on first use.
- `GOLANGCI_LINT` names the installed binary by full path. The `lint` target and the `.lint-check`
  version guard both use it, so a Homebrew copy can neither shadow the pinned one nor be picked up
  by accident. Previously `.lint-check` inspected the same PATH-resolved binary it was meant to
  guard, so it approved the stale copy.

A `toolchain` line in `go.mod` would not fix this. Go upgrades to a named toolchain when the local
one is older, but it never downgrades, so Go 1.27 would still satisfy `go 1.26.4`. The environment
variable is what pins.

## Verification

- `make lint` runs to completion instead of panicking.
- `make test` passes.
- `make` builds, and `go version dist/rss4transmission` now reports `go1.26.4` rather than the
  local `go1.27.0`.

## One thing this surfaces

With lint working again locally, `golangci-lint` reports one pre-existing finding that CI does not
report:

```
cmd/rss4transmission/transmissionweb_test.go:311:17: G705: XSS via taint analysis (gosec)
        _, _ = w.Write([]byte(r.Method))
```

The line is untouched by this branch. The same pinned 2.10.1 that prints `0 issues` in CI reports
this finding locally. Ruled out as causes: the Go version, `GOOS`/`GOARCH`, the golangci-lint
cache, `--concurrency`, and config resolution (`golangci-lint config path` returns
`.golangci.yaml`). The cause is still unknown, so no code change is included here for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)