### PR TITLE
Make speedtest server selection stable and report dead upload legs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Pre-built images are available on [DockerHub](https://hub.docker.com/r/synfinati
   tunnel is back up. The `/speedtest` page also has **Run speedtest now** and **Rotate VPN now**
   buttons for acting immediately instead of waiting for the next interval; its header also shows
   the port Gluetun forwards and whether Transmission sees that port as open, and
-  `rss4transmission speedtest` runs a single on-demand measurement from the CLI
+  `rss4transmission speedtest` runs a single on-demand measurement from the CLI, and
+  `--server` targets one speedtest.net server ID for that run
 - **Torrent file cache** — avoids re-fetching `.torrent` files on every watch-loop iteration;
   pruned automatically
 - **Ordered, stop-after-dispatch processing** — feeds are processed in the order they're listed

--- a/cmd/rss4transmission/speedtest.go
+++ b/cmd/rss4transmission/speedtest.go
@@ -512,7 +512,11 @@ func newSpeedtestRunner(cfg SpeedTestConfig) (speedTestFunc, error) {
 		if err := server.DownloadTestContext(ctx); err != nil {
 			return result, fmt.Errorf("download test failed: %w", err)
 		}
-		result.DownloadMbps = server.DLSpeed.Mbps()
+		dlMbps, err := downloadMbps(server.DLSpeed)
+		if err != nil {
+			return result, err
+		}
+		result.DownloadMbps = dlMbps
 
 		if !cfg.DownloadOnly {
 			if err := server.UploadTestContext(ctx); err != nil {
@@ -529,8 +533,31 @@ func newSpeedtestRunner(cfg SpeedTestConfig) (speedTestFunc, error) {
 	}, nil
 }
 
-// uploadRateNotAvailable is the ULSpeed value speedtest-go uses for "N/A".
-const uploadRateNotAvailable speedtest.ByteRate = -1
+// rateNotAvailable is the sentinel speedtest-go uses for "N/A" on both the
+// download and upload legs (speedtest/request.go).
+const rateNotAvailable speedtest.ByteRate = -1
+
+// downloadMbps converts speedtest-go's download rate to Mbps, or reports the
+// dead download leg it declined to report itself.
+//
+// When every download request fails, speedtest-go returns no error and instead
+// sets DLSpeed to the -1 sentinel it prints as "N/A" (speedtest/request.go).
+// Divided by 125000 that is -0.000008 Mbps, which is indistinguishable from a
+// real measurement of a very slow link: it renders as "-0.0" in the web UI and
+// it sits below any MinDownloadMbps floor, so it requests a rotation on every
+// run. Rotation cannot fix it. Report it as the failure it is instead, which
+// leaves OK() false and stops shouldRotate before it looks at the floors.
+//
+// A genuine zero is left alone: speedtest-go sets the sentinel only when the
+// request error rate also exceeds 10%, so a zero rate here is a measurement of
+// a dead link and the download floor must still act on it.
+func downloadMbps(rate speedtest.ByteRate) (float64, error) {
+	if rate == rateNotAvailable {
+		return 0, fmt.Errorf("download test reported no throughput: every download request " +
+			"to the speedtest server failed")
+	}
+	return rate.Mbps(), nil
+}
 
 // uploadMbps converts speedtest-go's upload rate to Mbps, or reports the dead
 // upload leg it declined to report itself.
@@ -549,7 +576,7 @@ const uploadRateNotAvailable speedtest.ByteRate = -1
 // request error rate also exceeds 10%, so a zero rate here is a measurement of
 // a dead link and the upload floor must still act on it.
 func uploadMbps(rate speedtest.ByteRate) (float64, error) {
-	if rate == uploadRateNotAvailable {
+	if rate == rateNotAvailable {
 		return 0, fmt.Errorf("upload test reported no throughput: every upload request " +
 			"to the speedtest server failed")
 	}

--- a/cmd/rss4transmission/speedtest.go
+++ b/cmd/rss4transmission/speedtest.go
@@ -20,8 +20,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
+	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/showwin/speedtest-go/speedtest"
@@ -476,15 +479,7 @@ func newSpeedtestRunner(cfg SpeedTestConfig) (speedTestFunc, error) {
 	return func(ctx context.Context) (SpeedResult, error) {
 		result := SpeedResult{At: time.Now()}
 
-		st := speedtest.New(speedtest.WithUserConfig(&speedtest.UserConfig{
-			Proxy:          cfg.Proxy,
-			UserAgent:      fmt.Sprintf("rss4transmission/%s", Version),
-			MaxConnections: threads,
-			// HTTP ping is mandatory here: ICMP and raw-TCP probes cannot
-			// traverse an HTTP CONNECT proxy, so any other mode would either
-			// fail outright or measure the host's path instead of the VPN's.
-			PingMode: speedtest.HTTP,
-		}))
+		st := newSpeedtestClient(cfg, threads)
 
 		// The IP speedtest.net sees is the VPN exit IP. If it ever matches the
 		// host's own public IP, the proxy isn't being used and every number
@@ -523,11 +518,122 @@ func newSpeedtestRunner(cfg SpeedTestConfig) (speedTestFunc, error) {
 			if err := server.UploadTestContext(ctx); err != nil {
 				return result, fmt.Errorf("upload test failed: %w", err)
 			}
-			result.UploadMbps = server.ULSpeed.Mbps()
+			mbps, err := uploadMbps(server.ULSpeed)
+			if err != nil {
+				return result, err
+			}
+			result.UploadMbps = mbps
 		}
 
 		return result, nil
 	}, nil
+}
+
+// uploadRateNotAvailable is the ULSpeed value speedtest-go uses for "N/A".
+const uploadRateNotAvailable speedtest.ByteRate = -1
+
+// uploadMbps converts speedtest-go's upload rate to Mbps, or reports the dead
+// upload leg it declined to report itself.
+//
+// When every upload request fails, speedtest-go returns no error and instead
+// sets ULSpeed to the -1 sentinel it prints as "N/A" (speedtest/request.go).
+// Divided by 125000 that is -0.000008 Mbps, which is indistinguishable from a
+// real measurement of a very slow link: it renders as "-0.0" in the web UI and
+// it sits below any MinUploadMbps floor, so it requests a rotation on every
+// run. Rotation cannot fix it. The server is chosen from speedtest.net's list
+// and not from the exit, so a server with a broken upload endpoint survives
+// every rotation. Report it as the failure it is instead, which leaves OK()
+// false and stops shouldRotate before it looks at the floors.
+//
+// A genuine zero is left alone: speedtest-go sets the sentinel only when the
+// request error rate also exceeds 10%, so a zero rate here is a measurement of
+// a dead link and the upload floor must still act on it.
+func uploadMbps(rate speedtest.ByteRate) (float64, error) {
+	if rate == uploadRateNotAvailable {
+		return 0, fmt.Errorf("upload test reported no throughput: every upload request " +
+			"to the speedtest server failed")
+	}
+	return rate.Mbps(), nil
+}
+
+// speedtestConfigHost serves the config and server-list endpoints, and is the
+// only host behind the shared Cloudflare cache. The throughput legs run against
+// per-server hosts, whose URLs carry parameters the server itself parses.
+const speedtestConfigHost = "www.speedtest.net"
+
+// cacheBusterParam is namespaced so it cannot collide with a parameter Ookla
+// reads.
+const cacheBusterParam = "r4tnocache"
+
+// cacheBuster forces www.speedtest.net requests past the Cloudflare cache.
+//
+// speedtest-config.php reports the caller's IP and coordinates, and Cloudflare
+// caches it without regard to who is asking. A HIT therefore returns the
+// response built for whoever populated that edge: observed values included a
+// Cox Business address in Tempe, a Comcast address, and a Zscaler address, none
+// of them this host's exit. speedtest-go reads that as its own identity and
+// picks a server near the stranger, which is how a fixed tunnel produced a
+// server list that moved between Los Angeles, Texas, and Arizona.
+//
+// Cloudflare's default cache key includes the query string, so a value that is
+// unique per request reaches the origin.
+type cacheBuster struct {
+	next http.RoundTripper
+	seq  atomic.Uint64
+}
+
+func (c *cacheBuster) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Host != speedtestConfigHost {
+		return c.next.RoundTrip(req)
+	}
+	// RoundTrip must not modify the request it is given.
+	clone := req.Clone(req.Context())
+	q := clone.URL.Query()
+	q.Set(cacheBusterParam, c.token())
+	clone.URL.RawQuery = q.Encode()
+	return c.next.RoundTrip(clone)
+}
+
+// token pairs the clock with a counter: the counter alone repeats across a
+// restart, and the clock alone can repeat when two requests share a nanosecond.
+func (c *cacheBuster) token() string {
+	return strconv.FormatInt(time.Now().UnixNano(), 36) + "-" +
+		strconv.FormatUint(c.seq.Add(1), 36)
+}
+
+// newSpeedtestClient builds the speedtest-go client with its HTTP path wrapped
+// in a cacheBuster, so identity and server selection come from the origin.
+//
+// It also repairs a global that speedtest-go mutates. New() assigns its doer to
+// http.DefaultClient and calls NewUserConfig, which sets that client's Transport
+// to the Speedtest itself -- and it does both before it applies any option, so
+// WithDoer redirects later requests without undoing the assignment. Left alone,
+// every http.DefaultClient caller in this process (Gluetun.control,
+// fetchTorrentBytes) moves onto the VPN proxy after the first measurement.
+// Saving and restoring the field is racy in principle, but the window spans one
+// constructor with no I/O in it.
+func newSpeedtestClient(cfg SpeedTestConfig, threads int) *speedtest.Speedtest {
+	saved := http.DefaultClient.Transport
+	client := &http.Client{}
+
+	// WithDoer must precede WithUserConfig: NewUserConfig is what assigns
+	// client.Transport, and it reads whichever doer is current when it runs.
+	st := speedtest.New(
+		speedtest.WithDoer(client),
+		speedtest.WithUserConfig(&speedtest.UserConfig{
+			Proxy:          cfg.Proxy,
+			UserAgent:      fmt.Sprintf("rss4transmission/%s", Version),
+			MaxConnections: threads,
+			// HTTP ping is mandatory here: ICMP and raw-TCP probes cannot
+			// traverse an HTTP CONNECT proxy, so any other mode would either
+			// fail outright or measure the host's path instead of the VPN's.
+			PingMode: speedtest.HTTP,
+		}),
+	)
+
+	http.DefaultClient.Transport = saved
+	client.Transport = &cacheBuster{next: client.Transport}
+	return st
 }
 
 // pickServer returns the configured speedtest.net server, or the closest one

--- a/cmd/rss4transmission/speedtest_test.go
+++ b/cmd/rss4transmission/speedtest_test.go
@@ -929,6 +929,42 @@ func TestUploadMbps_KeepsGenuineZero(t *testing.T) {
 	}
 }
 
+// speedtest-go reports a dead download leg by setting DLSpeed to -1 and
+// returning no error (speedtest/request.go). Divided by 125000 that becomes
+// -0.000008 Mbps, which reads as a real measurement far below MinDownloadMbps
+// and drives a rotation that cannot help.
+func TestDownloadMbps_RejectsNotAvailableSentinel(t *testing.T) {
+	got, err := downloadMbps(-1)
+	if err == nil {
+		t.Fatalf("downloadMbps(-1) = %v, nil error, want an error for the N/A sentinel", got)
+	}
+	if !strings.Contains(err.Error(), "download") {
+		t.Errorf("error = %q, want it to name the download leg", err)
+	}
+}
+
+func TestDownloadMbps_ConvertsRealRate(t *testing.T) {
+	got, err := downloadMbps(125000 * 100)
+	if err != nil {
+		t.Fatalf("downloadMbps: %v", err)
+	}
+	if got != 100 {
+		t.Errorf("downloadMbps = %v Mbps, want 100", got)
+	}
+}
+
+// A zero rate with a low request error rate is a real measurement of a dead
+// link, not the sentinel. MinDownloadMbps must still see it and rotate.
+func TestDownloadMbps_KeepsGenuineZero(t *testing.T) {
+	got, err := downloadMbps(0)
+	if err != nil {
+		t.Fatalf("downloadMbps: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("downloadMbps = %v Mbps, want 0", got)
+	}
+}
+
 // ---- cache buster ----
 
 // captureRT records the requests it is handed and returns a canned response.

--- a/cmd/rss4transmission/speedtest_test.go
+++ b/cmd/rss4transmission/speedtest_test.go
@@ -889,3 +889,172 @@ func TestSpeedMonitor_MeasureNowSaysItNeverRotates(t *testing.T) {
 		t.Error("measureNow staged a rotation")
 	}
 }
+
+// ---- upload sentinel ----
+
+// speedtest-go reports a dead upload leg by setting ULSpeed to -1 and returning
+// no error (speedtest/request.go). Divided by 125000 that becomes -0.000008
+// Mbps, which reads as a real measurement far below MinUploadMbps and drives a
+// rotation that cannot help: the broken leg belongs to the speedtest server,
+// not to the exit.
+func TestUploadMbps_RejectsNotAvailableSentinel(t *testing.T) {
+	got, err := uploadMbps(-1)
+	if err == nil {
+		t.Fatalf("uploadMbps(-1) = %v, nil error, want an error for the N/A sentinel", got)
+	}
+	if !strings.Contains(err.Error(), "upload") {
+		t.Errorf("error = %q, want it to name the upload leg", err)
+	}
+}
+
+func TestUploadMbps_ConvertsRealRate(t *testing.T) {
+	got, err := uploadMbps(125000 * 100)
+	if err != nil {
+		t.Fatalf("uploadMbps: %v", err)
+	}
+	if got != 100 {
+		t.Errorf("uploadMbps = %v Mbps, want 100", got)
+	}
+}
+
+// A zero rate with a low request error rate is a real measurement of a dead
+// link, not the sentinel. MinUploadMbps must still see it and rotate.
+func TestUploadMbps_KeepsGenuineZero(t *testing.T) {
+	got, err := uploadMbps(0)
+	if err != nil {
+		t.Fatalf("uploadMbps: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("uploadMbps = %v Mbps, want 0", got)
+	}
+}
+
+// ---- cache buster ----
+
+// captureRT records the requests it is handed and returns a canned response.
+type captureRT struct {
+	got []*http.Request
+}
+
+func (c *captureRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.got = append(c.got, req)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     http.Header{},
+	}, nil
+}
+
+func mustRoundTrip(t *testing.T, rt http.RoundTripper, rawURL string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	_ = resp.Body.Close()
+}
+
+// Cloudflare fronts speedtest-config.php with a cache that ignores who is
+// asking, so a HIT hands back the address and coordinates of whoever populated
+// the edge. A unique query parameter forces the origin, because Cloudflare
+// includes the query string in its cache key.
+func TestCacheBuster_AddsUniqueParam(t *testing.T) {
+	next := &captureRT{}
+	cb := &cacheBuster{next: next}
+
+	mustRoundTrip(t, cb, "https://www.speedtest.net/speedtest-config.php")
+	mustRoundTrip(t, cb, "https://www.speedtest.net/speedtest-config.php")
+
+	if len(next.got) != 2 {
+		t.Fatalf("next saw %d requests, want 2", len(next.got))
+	}
+	first := next.got[0].URL.Query().Get(cacheBusterParam)
+	second := next.got[1].URL.Query().Get(cacheBusterParam)
+	if first == "" || second == "" {
+		t.Fatalf("cache buster param missing: %q, %q", first, second)
+	}
+	if first == second {
+		t.Errorf("both requests used %q, want a unique value per request", first)
+	}
+	if next.got[0].URL.Path != "/speedtest-config.php" {
+		t.Errorf("path = %q, want it left alone", next.got[0].URL.Path)
+	}
+}
+
+// The server list endpoint takes a search keyword and coordinates. Busting the
+// cache must not drop them.
+func TestCacheBuster_PreservesExistingQuery(t *testing.T) {
+	next := &captureRT{}
+	cb := &cacheBuster{next: next}
+
+	mustRoundTrip(t, cb, "https://www.speedtest.net/api/js/servers?search=austin&lat=37.751")
+
+	q := next.got[0].URL.Query()
+	if q.Get("search") != "austin" {
+		t.Errorf("search = %q, want %q", q.Get("search"), "austin")
+	}
+	if q.Get("lat") != "37.751" {
+		t.Errorf("lat = %q, want %q", q.Get("lat"), "37.751")
+	}
+	if q.Get(cacheBusterParam) == "" {
+		t.Error("cache buster param missing")
+	}
+}
+
+// The throughput legs run against per-server hosts, whose URLs carry parameters
+// the server itself parses. Only the Cloudflare-fronted host may be rewritten.
+func TestCacheBuster_IgnoresOtherHosts(t *testing.T) {
+	next := &captureRT{}
+	cb := &cacheBuster{next: next}
+
+	const raw = "https://speedtest.example.net/upload.php?nocache=1"
+	mustRoundTrip(t, cb, raw)
+
+	if got := next.got[0].URL.String(); got != raw {
+		t.Errorf("URL = %q, want it passed through as %q", got, raw)
+	}
+}
+
+// RoundTrip must not modify the request it is given.
+func TestCacheBuster_DoesNotMutateRequest(t *testing.T) {
+	next := &captureRT{}
+	cb := &cacheBuster{next: next}
+
+	req, err := http.NewRequest(http.MethodGet, "https://www.speedtest.net/speedtest-config.php", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := cb.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if req.URL.RawQuery != "" {
+		t.Errorf("caller's request was mutated: RawQuery = %q, want empty", req.URL.RawQuery)
+	}
+}
+
+// speedtest-go's New() assigns its doer to http.DefaultClient and NewUserConfig
+// points that client's Transport at the Speedtest -- before any option runs, so
+// WithDoer does not undo it. Left alone, every http.DefaultClient user in this
+// process (Gluetun.control, fetchTorrentBytes) moves onto the VPN proxy after
+// the first measurement.
+func TestNewSpeedtestClient_LeavesDefaultClientAlone(t *testing.T) {
+	before := http.DefaultClient.Transport
+	t.Cleanup(func() { http.DefaultClient.Transport = before })
+
+	cfg := testSpeedCfg()
+	cfg.Proxy = "http://gluetun:8888"
+	if st := newSpeedtestClient(cfg, 2); st == nil {
+		t.Fatal("newSpeedtestClient = nil")
+	}
+
+	if http.DefaultClient.Transport != before {
+		t.Error("http.DefaultClient.Transport was replaced, want it left untouched")
+	}
+}

--- a/cmd/rss4transmission/speedtestcmd.go
+++ b/cmd/rss4transmission/speedtestcmd.go
@@ -26,14 +26,23 @@ import (
 )
 
 type SpeedTestCmd struct {
-	Save bool `kong:"help='Record the result in SpeedTest.ResultsFile'"`
+	Save   bool   `kong:"help='Record the result in SpeedTest.ResultsFile'"`
+	Server string `kong:"help='Test this speedtest.net server ID instead of SpeedTest.ServerID'"`
 }
 
 // oneShotSpeedConfig prepares the SpeedTest config for a single manual run.
 // Enabled is forced on: the whole point of this command is to prove the proxy
 // is wired up correctly *before* the user turns the background monitor on.
-func oneShotSpeedConfig(cfg SpeedTestConfig) (SpeedTestConfig, error) {
+//
+// serverID overrides SpeedTest.ServerID when it is not empty, so candidates can
+// be compared over the same proxy the monitor uses without an edit to the
+// config file between runs. That matters because a server can carry download at
+// full rate and fail upload entirely, which only a real run reveals.
+func oneShotSpeedConfig(cfg SpeedTestConfig, serverID string) (SpeedTestConfig, error) {
 	cfg.Enabled = true
+	if serverID != "" {
+		cfg.ServerID = serverID
+	}
 	if err := cfg.Validate(); err != nil {
 		return cfg, err
 	}
@@ -90,7 +99,7 @@ func speedResultForOutput(r SpeedResult, err error) SpeedResult {
 }
 
 func (cmd *SpeedTestCmd) Run(ctx *RunContext) error {
-	cfg, err := oneShotSpeedConfig(ctx.Config.SpeedTest)
+	cfg, err := oneShotSpeedConfig(ctx.Config.SpeedTest, cmd.Server)
 	if err != nil {
 		return fmt.Errorf("invalid SpeedTest configuration: %w", err)
 	}

--- a/cmd/rss4transmission/speedtestcmd_test.go
+++ b/cmd/rss4transmission/speedtestcmd_test.go
@@ -15,7 +15,7 @@ func TestOneShotSpeedConfig_WorksWhileDisabled(t *testing.T) {
 		Proxy: "http://gluetun:8888", CaptureSeconds: 5, Threads: 2,
 	}
 
-	got, err := oneShotSpeedConfig(cfg)
+	got, err := oneShotSpeedConfig(cfg, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -27,7 +27,7 @@ func TestOneShotSpeedConfig_WorksWhileDisabled(t *testing.T) {
 func TestOneShotSpeedConfig_RejectsBadProxy(t *testing.T) {
 	cfg := SpeedTestConfig{Interval: "1h", Cooldown: "2h", Proxy: "gluetun:8888", CaptureSeconds: 5}
 
-	if _, err := oneShotSpeedConfig(cfg); err == nil {
+	if _, err := oneShotSpeedConfig(cfg, ""); err == nil {
 		t.Error("expected an error for a proxy with no scheme")
 	}
 }
@@ -104,5 +104,40 @@ func TestSpeedResultForOutput_SuccessUnchanged(t *testing.T) {
 	}
 	if out := formatSpeedResult(r); !strings.Contains(out, "412.5") {
 		t.Errorf("successful run lost its measurement:\n%s", out)
+	}
+}
+
+// Finding a working server means testing candidates one at a time through the
+// same proxy the monitor uses, so the one-shot command has to be able to target
+// a server without an edit to the config file.
+func TestOneShotSpeedConfig_OverridesServerID(t *testing.T) {
+	cfg := SpeedTestConfig{
+		Interval: "1h", Cooldown: "2h", Proxy: "http://gluetun:8888",
+		CaptureSeconds: 5, Threads: 2, ServerID: "1111",
+	}
+
+	got, err := oneShotSpeedConfig(cfg, "2222")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if got.ServerID != "2222" {
+		t.Errorf("ServerID = %q, want the override %q", got.ServerID, "2222")
+	}
+}
+
+// An empty override must leave the configured server alone, so the flag is
+// genuinely optional.
+func TestOneShotSpeedConfig_KeepsConfiguredServerID(t *testing.T) {
+	cfg := SpeedTestConfig{
+		Interval: "1h", Cooldown: "2h", Proxy: "http://gluetun:8888",
+		CaptureSeconds: 5, Threads: 2, ServerID: "1111",
+	}
+
+	got, err := oneShotSpeedConfig(cfg, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if got.ServerID != "1111" {
+		t.Errorf("ServerID = %q, want the configured %q", got.ServerID, "1111")
 	}
 }

--- a/docs/speedtest.md
+++ b/docs/speedtest.md
@@ -121,6 +121,48 @@ necessarily the same as the address Gluetun reports for itself — see
 
 Pass `--save` to append the result to `ResultsFile`.
 
+Pass `--server` to test one speedtest.net server ID without an edit to the config file:
+
+```bash
+rss4transmission speedtest --config config.yaml --server 12345
+```
+
+The override applies to that run only. Use it to compare candidates before you commit one to
+`ServerID` — see [Choosing a ServerID](#choosing-a-serverid) below.
+
+## Choosing a ServerID
+
+`ServerID` is optional, but leave it empty and the nearest server is chosen from the coordinates
+speedtest.net returns for your exit. Many VPN addresses do not geolocate. speedtest.net then falls
+back to `37.751, -97.822`, a placeholder near the center of the United States, and the "nearest"
+server lands hundreds of kilometers from your real exit. The choice also moves between runs, which
+makes `MinDownloadMbps` and `MinUploadMbps` compare measurements that are not comparable.
+
+To pick a server, follow these steps:
+
+1. List the candidates Ookla offers for your exit. Run this from inside the Gluetun container:
+
+   ```bash
+   curl -s "https://www.speedtest.net/api/js/servers?engine=js&limit=20&nocache=$(date +%s)"
+   ```
+
+   The `nocache` parameter is required. Without it a shared cache can return the list built for
+   another user.
+
+2. Test each candidate over the proxy the monitor uses:
+
+   ```bash
+   rss4transmission speedtest --config config.yaml --server 12345
+   ```
+
+3. Read both legs. A server can carry download at full rate and fail upload completely. A failed
+   upload leg reports `upload test reported no throughput`.
+
+4. Set `ServerID` to the candidate with the best upload and download.
+
+Re-check the pinned server if measurements degrade. Servers are run by third parties and are
+retired without notice.
+
 ## How rotation works
 
 Gluetun has no "switch to a different server" API. The only mechanism is to stop the VPN and


### PR DESCRIPTION
## Why

Three separate problems made the speedtest numbers untrustworthy, and one of them requested a VPN
rotation on every run.

**A shared cache handed back a stranger's identity.** Cloudflare fronts `speedtest-config.php` and
caches it without regard to who is asking. A cache hit returns the response built for whoever
populated that edge. Observed values included a Cox Business address in Tempe, a Comcast address,
and a Zscaler address, none of them this host's exit. speedtest-go reads that as its own identity
and picks a server near the stranger, which is how a fixed tunnel produced a server list that moved
between Los Angeles, Texas, and Arizona.

**A dead upload leg looked like a slow link.** When every upload request fails, speedtest-go returns
no error and sets `ULSpeed` to the `-1` sentinel it prints as `N/A`. Divided by 125000 that is
`-0.000008` Mbps. It renders as `-0.0` in the web UI, it sits below any `MinUploadMbps` floor, and
it requests a rotation on every run. Rotation cannot fix it. The server is chosen from
speedtest.net's list and not from the exit, so a server with a broken upload endpoint survives every
rotation.

**The library captured `http.DefaultClient`.** `speedtest.New()` assigns its doer to
`http.DefaultClient` and points that client's `Transport` at the `Speedtest`, and it does both
before it applies any option. `WithDoer` redirects later requests without undoing the assignment.
Left alone, every `http.DefaultClient` caller in this process (`Gluetun.control`,
`fetchTorrentBytes`) moved onto the VPN proxy after the first measurement.

## What changed

- `cacheBuster` is an `http.RoundTripper` that adds a unique query parameter to `www.speedtest.net`
  requests. Cloudflare's default cache key includes the query string, so the request reaches the
  origin. Other hosts pass through untouched, because the throughput legs run against per-server
  hosts whose URLs carry parameters the server itself parses.
- `uploadMbps` rejects the `-1` sentinel and reports the failure instead. That leaves `OK()` false
  and stops `shouldRotate` before it looks at the floors. A genuine zero is left alone: speedtest-go
  sets the sentinel only when the request error rate also exceeds 10%, so a zero rate is a real
  measurement of a dead link and the upload floor must still act on it.
- `newSpeedtestClient` passes an explicit `*http.Client` and restores
  `http.DefaultClient.Transport`.
- `speedtest --server <id>` overrides `SpeedTest.ServerID` for one run, so candidates can be
  compared over the same proxy the monitor uses without an edit to the config file.
- `docs/speedtest.md` gains a **Choosing a ServerID** section, and `README.md` covers the new flag.

## Tests

Ten new tests, written before the implementation:

- `TestUploadMbps_*` — the sentinel is rejected, a real rate converts, a genuine zero survives.
- `TestCacheBuster_*` — a unique parameter per request, existing query parameters preserved, other
  hosts passed through byte for byte, and the caller's request left unmutated.
- `TestNewSpeedtestClient_LeavesDefaultClientAlone` — `http.DefaultClient.Transport` is unchanged.
- `TestOneShotSpeedConfig_OverridesServerID` and `..._KeepsConfiguredServerID`.

`make test` passes. `make lint` reports one `gosec` G705 finding in
`cmd/rss4transmission/transmissionweb_test.go:311`. That file is not touched here and the finding
already exists on `main` (commit 3c8940f).

## Known residual

`speedtest-go` runs `var defaultClient = New()` at package init, which sets
`http.DefaultClient.Transport` to a `*speedtest.Speedtest` before `main` starts. That one carries no
proxy, so it does not move traffic onto the VPN. This change stops the proxied client from landing
there, which is the harm that mattered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)