### PR TITLE
Add a favicon to the web UI

### DIFF
--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -70,6 +70,15 @@ var cancelTmpl string
 //go:embed web/start.html
 var startTmpl string
 
+//go:embed web/favicon.svg
+var faviconSVG string
+
+// faviconHandler serves the browser tab icon shared by every page.
+func faviconHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "image/svg+xml")
+	fmt.Fprint(w, faviconSVG) //nolint:errcheck
+}
+
 // removeFunc is the signature for removing torrents from Transmission.
 type removeFunc func(ctx context.Context, ids []int64) error
 
@@ -367,6 +376,8 @@ func newWebMux(history *HistoryFile, retry retryFunc, feedConfigured func(name s
 		w.WriteHeader(http.StatusOK)
 	})
 
+	mux.HandleFunc("GET /favicon.svg", faviconHandler)
+
 	return mux
 }
 
@@ -434,7 +445,7 @@ func makePostForgetHandler(history *HistoryFile, forget forgetFunc) http.Handler
 }
 
 // newCancelMux builds a public-facing mux serving GET/POST /cancel, GET/POST
-// /start, and GET /healthz. Use this when --public-listen is set to expose
+// /start, GET /healthz, and GET /favicon.svg. Use this when --public-listen is set to expose
 // these token-gated endpoints on their own port, keeping the history page on
 // a separate private listener.
 // POST /cancel is only registered when both store and remove are non-nil.
@@ -460,6 +471,7 @@ func newCancelMux(store *Store, cfg NotificationsConfig, remove removeFunc, getP
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
+	mux.HandleFunc("GET /favicon.svg", faviconHandler)
 	return mux
 }
 

--- a/cmd/rss4transmission/web/cancel.html
+++ b/cmd/rss4transmission/web/cancel.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <title>Cancel Download — RSS4Transmission</title>
     <style>
         body { font-family: monospace; margin: 2em; background: #1a1a1a; color: #e0e0e0; }

--- a/cmd/rss4transmission/web/favicon.svg
+++ b/cmd/rss4transmission/web/favicon.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect x="1" y="1" width="30" height="30" rx="8" fill="#16181c" stroke="#2c3036"/>
+  <circle cx="9" cy="24" r="3" fill="#ffaa33"/>
+  <path d="M9 17 A7 7 0 0 1 16 24" fill="none" stroke="#ffaa33"
+        stroke-width="3.2" stroke-linecap="round"/>
+  <path d="M9 10 A14 14 0 0 1 23 24" fill="none" stroke="#ffaa33"
+        stroke-width="3.2" stroke-linecap="round"/>
+  <path d="M19 8 L24 13 L29 8" fill="none" stroke="#6aa8e0"
+        stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/cmd/rss4transmission/web/history.html
+++ b/cmd/rss4transmission/web/history.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <title>RSS4Transmission Torrents</title>
     <style>
         body { font-family: monospace; margin: 2em; background: #1a1a1a; color: #e0e0e0; }

--- a/cmd/rss4transmission/web/rotations.html
+++ b/cmd/rss4transmission/web/rotations.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <meta http-equiv="refresh" content="60">
     <title>RSS4Transmission VPN Rotations</title>
     <style>

--- a/cmd/rss4transmission/web/speedtest.html
+++ b/cmd/rss4transmission/web/speedtest.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <meta http-equiv="refresh" content="60">
     <title>RSS4Transmission VPN Speed</title>
     <style>

--- a/cmd/rss4transmission/web/start.html
+++ b/cmd/rss4transmission/web/start.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <title>Start Download — RSS4Transmission</title>
     <style>
         body { font-family: monospace; margin: 2em; background: #1a1a1a; color: #e0e0e0; }

--- a/cmd/rss4transmission/web/transmission.html
+++ b/cmd/rss4transmission/web/transmission.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <title>RSS4Transmission Transmission</title>
     <style>
         html, body { height: 100%; }

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -30,6 +30,46 @@ func TestHealthzHandler(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
+// --- /favicon.svg ---
+
+func TestFaviconHandler_ServesSVG(t *testing.T) {
+	mux := newWebMux(nil, nil, nil, nil, nil, navConfig{})
+	req := httptest.NewRequest("GET", "/favicon.svg", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "image/svg+xml", rr.Header().Get("Content-Type"))
+	assert.Contains(t, rr.Body.String(), "<svg")
+}
+
+func TestNewCancelMux_FaviconReachable(t *testing.T) {
+	cfg := makeCancelCfg("", "")
+	mux := newCancelMux(nil, cfg, nil, nil, nil, nil, nil, nil)
+
+	req := httptest.NewRequest("GET", "/favicon.svg", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "image/svg+xml", rr.Header().Get("Content-Type"))
+}
+
+// Every page template links the favicon, so a browser tab always shows the
+// app icon rather than a blank page. One test guards all six rather than a
+// per-page test, so a new page cannot ship without picking up the link.
+func TestPageTemplates_LinkTheFavicon(t *testing.T) {
+	pages := map[string]string{
+		"history.html":      historyTmpl,
+		"cancel.html":       cancelTmpl,
+		"start.html":        startTmpl,
+		"speedtest.html":    speedTmpl,
+		"rotations.html":    rotationsTmpl,
+		"transmission.html": transmissionTmpl,
+	}
+	for name, tmpl := range pages {
+		assert.Contains(t, tmpl, `rel="icon"`, "%s is missing the favicon link", name)
+	}
+}
+
 // --- /cancel helpers ---
 
 func makeCancelCfg(secret, baseURL string) NotificationsConfig {


### PR DESCRIPTION
## Summary

The `watch` command's web pages (history, speedtest, rotations, transmission, cancel, start) had
no favicon, so the browser tab fell back to a blank page icon.

## What changed

- New `cmd/rss4transmission/web/favicon.svg`: RSS feed waves resolving into a download chevron,
  drawn in the orange and blue the web UI already uses (outcome pills and nav-bar links), so the
  tab icon reads as the same product.
- `web.go` embeds the SVG and serves it at `GET /favicon.svg` from both the private mux (history,
  speedtest, rotations, transmission) and the public cancel/start mux.
- Every page template now has `<link rel="icon" type="image/svg+xml" href="/favicon.svg">` in its
  `<head>`.

## Test plan

Written test-first, per `CLAUDE.md`.

- `TestFaviconHandler_ServesSVG` — `GET /favicon.svg` on the private mux returns 200,
  `image/svg+xml`, and SVG body.
- `TestNewCancelMux_FaviconReachable` — same route on the public cancel/start mux.
- `TestPageTemplates_LinkTheFavicon` — asserts all six embedded page templates contain the icon
  link, so a future page cannot ship without it.
- `make test` — ok
- `go test -race ./...` — ok
- `make lint` — 0 issues
- `gofmt -l` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)