### PR TITLE
Fix make test-fmt and test-tidy to ignore unrelated uncommitted files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,11 @@ fmt: ## Format Go code
 .PHONY: test-fmt
 test-fmt: ## Test to make sure code is formatted correctly
 	@UNFORMATTED=`gofmt -l cmd`; \
+	STATUS=$$?; \
+	if [ $$STATUS -ne 0 ]; then \
+	    echo "gofmt failed" ; \
+	    exit 1 ; \
+	fi; \
 	if [ -n "$$UNFORMATTED" ]; then \
 	    echo "The following files are not formatted. Run 'make fmt' to fix:" ; \
 	    echo "$$UNFORMATTED" ; \
@@ -137,14 +142,14 @@ test-fmt: ## Test to make sure code is formatted correctly
 
 .PHONY: test-tidy
 test-tidy:  ## Test to make sure go.mod is tidy
-	@cp go.mod /tmp/go.mod.orig.$$$$; \
-	go mod tidy; \
-	if ! diff -q go.mod /tmp/go.mod.orig.$$$$ >/dev/null; then \
+	@TMPFILE=`mktemp`; \
+	trap 'rm -f "$$TMPFILE"' EXIT; \
+	cp go.mod "$$TMPFILE" || exit 1; \
+	go mod tidy || exit 1; \
+	if ! diff -q go.mod "$$TMPFILE" >/dev/null; then \
 	    echo "Need to run 'go mod tidy' to clean up go.mod" ; \
-	    rm -f /tmp/go.mod.orig.$$$$ ; \
 	    exit 1 ; \
-	fi; \
-	rm -f /tmp/go.mod.orig.$$$$
+	fi
 
 coverage: coverage.out
 coverage.out: .build_files

--- a/Makefile
+++ b/Makefile
@@ -127,20 +127,24 @@ fmt: ## Format Go code
 	@go fmt ./cmd
 
 .PHONY: test-fmt
-test-fmt: fmt ## Test to make sure code if formatted correctly
-	@if test `git diff ./cmd | wc -l` -gt 0; then \
-	    echo "Code changes detected when running 'go fmt':" ; \
-	    git diff -Xfiles ; \
-	    exit -1 ; \
+test-fmt: ## Test to make sure code is formatted correctly
+	@UNFORMATTED=`gofmt -l cmd`; \
+	if [ -n "$$UNFORMATTED" ]; then \
+	    echo "The following files are not formatted. Run 'make fmt' to fix:" ; \
+	    echo "$$UNFORMATTED" ; \
+	    exit 1 ; \
 	fi
 
 .PHONY: test-tidy
 test-tidy:  ## Test to make sure go.mod is tidy
-	@go mod tidy
-	@if test `git diff go.mod | wc -l` -gt 0; then \
+	@cp go.mod /tmp/go.mod.orig.$$$$; \
+	go mod tidy; \
+	if ! diff -q go.mod /tmp/go.mod.orig.$$$$ >/dev/null; then \
 	    echo "Need to run 'go mod tidy' to clean up go.mod" ; \
-	    exit -1 ; \
-	fi
+	    rm -f /tmp/go.mod.orig.$$$$ ; \
+	    exit 1 ; \
+	fi; \
+	rm -f /tmp/go.mod.orig.$$$$
 
 coverage: coverage.out
 coverage.out: .build_files

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -44,7 +44,7 @@ func TestFaviconHandler_ServesSVG(t *testing.T) {
 
 func TestNewCancelMux_FaviconReachable(t *testing.T) {
 	cfg := makeCancelCfg("", "")
-	mux := newCancelMux(nil, cfg, nil, nil, nil, nil, nil, nil)
+	mux := newCancelMux(nil, staticNotif(cfg), nil, nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("GET", "/favicon.svg", nil)
 	rr := httptest.NewRecorder()


### PR DESCRIPTION
## Summary
- `test-fmt` used `git diff ./cmd` to check for gofmt changes, which also counted any unrelated pre-existing uncommitted diff in `cmd/`, causing false failures. It now uses `gofmt -l cmd` instead, which checks formatting directly without depending on git state.
- `test-tidy` had the same class of bug scoped to `go.mod`. It now compares a copy of `go.mod` taken before `go mod tidy` runs instead of using `git diff go.mod`.
- Fixed a leftover call site in `web_test.go` that passed a `NotificationsConfig` value directly to `newCancelMux` instead of wrapping it with `staticNotif`, which broke `go vet`.

## Test plan
- [x] `make test`
- [x] `make test-fmt`
- [x] `make test-tidy`
- [x] `make precheck`
- [x] Verified `test-fmt`/`test-tidy` pass with an unrelated uncommitted file present

🤖 Generated with [Claude Code](https://claude.com/claude-code)