### PR TITLE
Show which labels caused "no group matched labels" on the history page

### DIFF
--- a/cmd/rss4transmission/cache.go
+++ b/cmd/rss4transmission/cache.go
@@ -36,9 +36,9 @@ type CacheFile struct {
 	filename string
 	needSave bool
 
-	// identityIndex maps identity key → all label maps seen for that key.
+	// identityIndex maps identity key → all cache records seen for that key.
 	// Rebuilt from Seen on load; never persisted.
-	identityIndex map[string][]map[string]string
+	identityIndex map[string][]CacheRecord
 }
 
 type CacheRecord struct {
@@ -73,13 +73,13 @@ func OpenCache(path string) (*CacheFile, error) {
 }
 
 func (c *CacheFile) rebuildIdentityIndex() {
-	c.identityIndex = make(map[string][]map[string]string)
+	c.identityIndex = make(map[string][]CacheRecord)
 	for _, r := range c.Seen {
 		if len(r.Labels) == 0 {
 			continue
 		}
 		for _, key := range r.IdentityKeys {
-			c.identityIndex[key] = append(c.identityIndex[key], r.Labels)
+			c.identityIndex[key] = append(c.identityIndex[key], r)
 		}
 	}
 }
@@ -87,15 +87,27 @@ func (c *CacheFile) rebuildIdentityIndex() {
 // BestRankForKey returns the best (lowest) preference rank seen for the given
 // identity key, or (nil, false) if the key has never been cached.
 func (c *CacheFile) BestRankForKey(key string, prefer []PreferDimension) ([]int, bool) {
-	labelSets, ok := c.identityIndex[key]
+	rec, ok := c.BestRecordForKey(key, prefer)
 	if !ok {
 		return nil, false
 	}
-	var best []int
-	for _, labels := range labelSets {
-		rank := PreferenceRank(labels, prefer)
-		if best == nil || IsBetter(rank, best) {
-			best = rank
+	return PreferenceRank(rec.Labels, prefer), true
+}
+
+// BestRecordForKey returns the cache record with the best (lowest) preference
+// rank for the given identity key, or (CacheRecord{}, false) if the key has
+// never been cached.
+func (c *CacheFile) BestRecordForKey(key string, prefer []PreferDimension) (CacheRecord, bool) {
+	records, ok := c.identityIndex[key]
+	if !ok {
+		return CacheRecord{}, false
+	}
+	best := records[0]
+	bestRank := PreferenceRank(best.Labels, prefer)
+	for _, rec := range records[1:] {
+		rank := PreferenceRank(rec.Labels, prefer)
+		if IsBetter(rank, bestRank) {
+			best, bestRank = rec, rank
 		}
 	}
 	return best, true
@@ -188,10 +200,10 @@ func (c *CacheFile) AddItem(item *FeedItem, labels map[string]string, identityKe
 
 	// Update in-memory identity index immediately.
 	if c.identityIndex == nil {
-		c.identityIndex = make(map[string][]map[string]string)
+		c.identityIndex = make(map[string][]CacheRecord)
 	}
 	for _, key := range identityKeys {
-		c.identityIndex[key] = append(c.identityIndex[key], labels)
+		c.identityIndex[key] = append(c.identityIndex[key], cr)
 	}
 
 	c.needSave = true

--- a/cmd/rss4transmission/cache_test.go
+++ b/cmd/rss4transmission/cache_test.go
@@ -88,7 +88,7 @@ func TestAddSkippedItem_IsFoundByExists(t *testing.T) {
 		Version:       CACHE_VERSION,
 		Errors:        map[string]int64{},
 		Seen:          []CacheRecord{},
-		identityIndex: map[string][]map[string]string{},
+		identityIndex: map[string][]CacheRecord{},
 	}
 	c.AddSkippedItem(fi)
 
@@ -109,7 +109,7 @@ func TestAddSkippedItem_DoesNotUpdateIdentityIndex(t *testing.T) {
 		Version:       CACHE_VERSION,
 		Errors:        map[string]int64{},
 		Seen:          []CacheRecord{},
-		identityIndex: map[string][]map[string]string{},
+		identityIndex: map[string][]CacheRecord{},
 	}
 	c.AddSkippedItem(fi)
 
@@ -130,7 +130,7 @@ func TestRemoveEntry_RemovesExisting(t *testing.T) {
 		Version:       CACHE_VERSION,
 		Errors:        map[string]int64{},
 		Seen:          []CacheRecord{},
-		identityIndex: map[string][]map[string]string{},
+		identityIndex: map[string][]CacheRecord{},
 	}
 	c.AddSkippedItem(fi)
 	c.needSave = false
@@ -154,7 +154,7 @@ func TestRemoveEntry_RebuildsIdentityIndex(t *testing.T) {
 		Version:       CACHE_VERSION,
 		Errors:        map[string]int64{},
 		Seen:          []CacheRecord{},
-		identityIndex: map[string][]map[string]string{},
+		identityIndex: map[string][]CacheRecord{},
 	}
 	labels := map[string]string{"series": "MotoGP"}
 	c.AddItem(fi, labels, []string{"series=MotoGP"})
@@ -172,7 +172,7 @@ func TestRemoveEntry_UnknownPair_NoOp(t *testing.T) {
 		Version:       CACHE_VERSION,
 		Errors:        map[string]int64{},
 		Seen:          []CacheRecord{},
-		identityIndex: map[string][]map[string]string{},
+		identityIndex: map[string][]CacheRecord{},
 	}
 	c.AddSkippedItem(fi)
 	c.needSave = false
@@ -196,7 +196,7 @@ func TestAddItem(t *testing.T) {
 		Errors:        map[string]int64{},
 		Seen:          []CacheRecord{},
 		needSave:      false,
-		identityIndex: map[string][]map[string]string{},
+		identityIndex: map[string][]CacheRecord{},
 	}
 	fi := makeFeedItem("guid-add")
 	labels := map[string]string{"series": "MotoGP", "resolution": "1080p"}
@@ -226,7 +226,7 @@ func TestAddItem(t *testing.T) {
 }
 
 func TestBestRankForKey_Miss(t *testing.T) {
-	c := &CacheFile{identityIndex: map[string][]map[string]string{}}
+	c := &CacheFile{identityIndex: map[string][]CacheRecord{}}
 	prefer := []PreferDimension{{Label: "resolution", Order: []string{"1080p", "720p"}}}
 	_, ok := c.BestRankForKey("series=MotoGP|round=RD01|session=Race", prefer)
 	if ok {
@@ -237,10 +237,9 @@ func TestBestRankForKey_Miss(t *testing.T) {
 func TestBestRankForKey_Single(t *testing.T) {
 	prefer := []PreferDimension{{Label: "resolution", Order: []string{"1080p", "720p"}}}
 	key := "series=MotoGP|round=RD01|session=Race"
-	labels := map[string]string{"resolution": "720p"}
 	c := &CacheFile{
-		identityIndex: map[string][]map[string]string{
-			key: {labels},
+		identityIndex: map[string][]CacheRecord{
+			key: {{Labels: map[string]string{"resolution": "720p"}}},
 		},
 	}
 	rank, ok := c.BestRankForKey(key, prefer)
@@ -256,10 +255,10 @@ func TestBestRankForKey_PicksBest(t *testing.T) {
 	prefer := []PreferDimension{{Label: "resolution", Order: []string{"1080p", "720p"}}}
 	key := "series=MotoGP|round=RD01|session=Race"
 	c := &CacheFile{
-		identityIndex: map[string][]map[string]string{
+		identityIndex: map[string][]CacheRecord{
 			key: {
-				{"resolution": "720p"},
-				{"resolution": "1080p"},
+				{Labels: map[string]string{"resolution": "720p"}},
+				{Labels: map[string]string{"resolution": "1080p"}},
 			},
 		},
 	}
@@ -269,6 +268,44 @@ func TestBestRankForKey_PicksBest(t *testing.T) {
 	}
 	if rank[0] != 0 { // 1080p is index 0 (best)
 		t.Errorf("rank[0] = %d, want 0 (1080p)", rank[0])
+	}
+}
+
+func TestBestRecordForKey_Miss(t *testing.T) {
+	c := &CacheFile{identityIndex: map[string][]CacheRecord{}}
+	prefer := []PreferDimension{{Label: "resolution", Order: []string{"1080p", "720p"}}}
+	_, ok := c.BestRecordForKey("series=MotoGP|round=RD01|session=Race", prefer)
+	if ok {
+		t.Error("expected ok=false for key not in index")
+	}
+}
+
+func TestBestRecordForKey_Single(t *testing.T) {
+	prefer := []PreferDimension{{Label: "resolution", Order: []string{"1080p", "720p"}}}
+	key := "series=MotoGP|round=RD01|session=Race"
+	rec := CacheRecord{Feed: "MotoGP", GUID: "guid-1", Labels: map[string]string{"resolution": "720p"}}
+	c := &CacheFile{identityIndex: map[string][]CacheRecord{key: {rec}}}
+	got, ok := c.BestRecordForKey(key, prefer)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got.Feed != "MotoGP" || got.GUID != "guid-1" {
+		t.Errorf("got Feed=%q GUID=%q, want Feed=MotoGP GUID=guid-1", got.Feed, got.GUID)
+	}
+}
+
+func TestBestRecordForKey_PicksBest(t *testing.T) {
+	prefer := []PreferDimension{{Label: "resolution", Order: []string{"1080p", "720p"}}}
+	key := "series=MotoGP|round=RD01|session=Race"
+	worse := CacheRecord{Feed: "MotoGP", GUID: "guid-worse", Labels: map[string]string{"resolution": "720p"}}
+	better := CacheRecord{Feed: "MotoGP", GUID: "guid-better", Labels: map[string]string{"resolution": "1080p"}}
+	c := &CacheFile{identityIndex: map[string][]CacheRecord{key: {worse, better}}}
+	got, ok := c.BestRecordForKey(key, prefer)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got.GUID != "guid-better" {
+		t.Errorf("GUID = %q, want guid-better", got.GUID)
 	}
 }
 
@@ -460,7 +497,7 @@ func TestSaveCache_PruningRebuildsIdentityIndex(t *testing.T) {
 		},
 		filename:      path,
 		needSave:      true,
-		identityIndex: map[string][]map[string]string{},
+		identityIndex: map[string][]CacheRecord{},
 	}
 	c.rebuildIdentityIndex()
 

--- a/cmd/rss4transmission/config.go
+++ b/cmd/rss4transmission/config.go
@@ -427,12 +427,14 @@ func (f *Feed) Check(item *gofeed.Item) (bool, string) {
 
 	if f.minSize > 0 && totalSize < f.minSize {
 		log.Debugf("Too small: %s [%d]", item.Title, totalSize)
-		return false, "below minimum size"
+		return false, fmt.Sprintf("below minimum size: %s < %s",
+			formatGB(int64(totalSize)), formatGB(int64(f.minSize))) //nolint:gosec // G115: torrent sizes are well within int64 range
 	}
 
 	if f.maxSize > 0 && totalSize > f.maxSize {
 		log.Debugf("Too large: %s [%d]", item.Title, totalSize)
-		return false, "above maximum size"
+		return false, fmt.Sprintf("above maximum size: %s > %s",
+			formatGB(int64(totalSize)), formatGB(int64(f.maxSize))) //nolint:gosec // G115: torrent sizes are well within int64 range
 	}
 
 	return true, ""

--- a/cmd/rss4transmission/config.go
+++ b/cmd/rss4transmission/config.go
@@ -411,7 +411,7 @@ func (f *Feed) Check(item *gofeed.Item) (bool, string) {
 
 	for _, r := range f.exclude {
 		if r.Find([]byte(item.Title)) != nil {
-			return false, "matched exclude filter"
+			return false, "matched exclude filter: " + r.String()
 		}
 	}
 

--- a/cmd/rss4transmission/config_test.go
+++ b/cmd/rss4transmission/config_test.go
@@ -75,6 +75,24 @@ func TestFeedCheck_MaxSize(t *testing.T) {
 	}
 }
 
+func TestFeedCheck_MinSizeReasonIncludesActualAndThreshold(t *testing.T) {
+	f := &Feed{MinSize: "1GB"}
+	_, reason := f.Check(makeItem("Anything", "104857600")) // 100MB
+	want := "below minimum size: 0.10 GB < 1.00 GB"
+	if reason != want {
+		t.Errorf("reason = %q, want %q", reason, want)
+	}
+}
+
+func TestFeedCheck_MaxSizeReasonIncludesActualAndThreshold(t *testing.T) {
+	f := &Feed{MaxSize: "100MB"}
+	_, reason := f.Check(makeItem("Anything", "2147483648")) // 2GB
+	want := "above maximum size: 2.00 GB > 0.10 GB"
+	if reason != want {
+		t.Errorf("reason = %q, want %q", reason, want)
+	}
+}
+
 func TestFeedCheck_SizeRange(t *testing.T) {
 	f := &Feed{MinSize: "100MB", MaxSize: "10GB"}
 	// 1GB — within range

--- a/cmd/rss4transmission/config_test.go
+++ b/cmd/rss4transmission/config_test.go
@@ -34,6 +34,24 @@ func TestFeedCheck_Excluded(t *testing.T) {
 	}
 }
 
+func TestFeedCheck_ExcludedReasonIncludesPattern(t *testing.T) {
+	f := &Feed{Exclude: []string{`(?i).*Highlights.*`}}
+	_, reason := f.Check(makeItem("MyShow.Highlights.S01E01", ""))
+	want := "matched exclude filter: (?i).*Highlights.*"
+	if reason != want {
+		t.Errorf("reason = %q, want %q", reason, want)
+	}
+}
+
+func TestFeedCheck_ExcludedReasonUsesMatchingPattern(t *testing.T) {
+	f := &Feed{Exclude: []string{`(?i).*720p.*`, `(?i).*Highlights.*`}}
+	_, reason := f.Check(makeItem("MyShow.Highlights.S01E01", ""))
+	want := "matched exclude filter: (?i).*Highlights.*"
+	if reason != want {
+		t.Errorf("reason = %q, want %q", reason, want)
+	}
+}
+
 func TestFeedCheck_NoFilters(t *testing.T) {
 	f := &Feed{}
 	if ok, _ := f.Check(makeItem("AnythingAtAll", "")); !ok {

--- a/cmd/rss4transmission/history.go
+++ b/cmd/rss4transmission/history.go
@@ -49,6 +49,11 @@ type HistoryRecord struct {
 	Labels      map[string]string `json:"Labels,omitempty"`
 	TorrentURL  string            `json:"TorrentURL,omitempty"`
 	SizeBytes   int64             `json:"SizeBytes,omitempty"`
+	// BetterFeed/BetterGUID identify the cache record that beat this one out
+	// (see skipReasonCacheBetter in once.go), letting the history page link to
+	// it. Empty unless that reason applies and the winner is known.
+	BetterFeed string `json:"BetterFeed,omitempty"`
+	BetterGUID string `json:"BetterGUID,omitempty"`
 }
 
 // outcomeRank returns a rank for dedup: lower is more interesting.
@@ -170,13 +175,21 @@ func (h *HistoryFile) SaveHistory(d time.Duration) error {
 // to the history file when one is configured. The log always fires — it's the
 // only visibility into per-item outcomes when --history-file isn't set.
 func (ctx *RunContext) recordHistory(feedName string, item *gofeed.Item, outcome, reason string, labels map[string]string) {
-	if reason != "" {
-		log.Infof("[%s] %s: %s (%s)", feedName, outcome, item.Title, reason)
+	ctx.recordHistoryRecord(NewHistoryRecord(feedName, item, outcome, reason, labels))
+}
+
+// recordHistoryRecord logs and persists a caller-built HistoryRecord. Used
+// instead of recordHistory when a call site needs to set fields recordHistory's
+// signature doesn't carry (e.g. BetterFeed/BetterGUID for cache-rejected
+// skips).
+func (ctx *RunContext) recordHistoryRecord(rec HistoryRecord) {
+	if rec.Reason != "" {
+		log.Infof("[%s] %s: %s (%s)", rec.Feed, rec.Outcome, rec.Title, rec.Reason)
 	} else {
-		log.Infof("[%s] %s: %s", feedName, outcome, item.Title)
+		log.Infof("[%s] %s: %s", rec.Feed, rec.Outcome, rec.Title)
 	}
 	if ctx.History != nil {
-		ctx.History.AddOrUpdateRecord(NewHistoryRecord(feedName, item, outcome, reason, labels))
+		ctx.History.AddOrUpdateRecord(rec)
 	}
 }
 

--- a/cmd/rss4transmission/history_test.go
+++ b/cmd/rss4transmission/history_test.go
@@ -656,6 +656,40 @@ func TestRecordHistory_WithHistory_AddsRecord(t *testing.T) {
 	}
 }
 
+func TestRecordHistoryRecord_PersistsBetterFeedAndGUID(t *testing.T) {
+	h := emptyHistory()
+	ctx := &RunContext{History: h}
+	rec := NewHistoryRecord("feed", makeGofeedItem("Show S01E01", "guid1"), "skipped", skipReasonCacheBetter, nil)
+	rec.BetterFeed = "otherfeed"
+	rec.BetterGUID = "guid2"
+	ctx.recordHistoryRecord(rec)
+
+	if len(h.Records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(h.Records))
+	}
+	if h.Records[0].BetterFeed != "otherfeed" || h.Records[0].BetterGUID != "guid2" {
+		t.Errorf("BetterFeed/BetterGUID = %q/%q, want otherfeed/guid2", h.Records[0].BetterFeed, h.Records[0].BetterGUID)
+	}
+}
+
+func TestRecordHistoryRecord_LogsOneInfoLineWithOutcome(t *testing.T) {
+	hook := withTestLogHook(t)
+	ctx := &RunContext{} // History is nil
+	rec := NewHistoryRecord("myfeed", makeGofeedItem("Show S01E01", "guid1"), "dispatched", "", nil)
+	ctx.recordHistoryRecord(rec)
+
+	entries := hook.AllEntries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(entries))
+	}
+	msg := entries[0].Message
+	for _, want := range []string{"myfeed", "Show S01E01", "dispatched"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("log message %q does not contain %q", msg, want)
+		}
+	}
+}
+
 func TestOpenHistory_UsesProcessedAtWhenPublishedZero(t *testing.T) {
 	dir := t.TempDir()
 	h := &HistoryFile{

--- a/cmd/rss4transmission/once.go
+++ b/cmd/rss4transmission/once.go
@@ -274,7 +274,9 @@ func (cmd *OnceCmd) processFeed(ctx *RunContext, feedName string, feedCfg Feed, 
 	winners, skipped := selectWinners(candidates, feedCfg, ctx.Cache)
 	markSkippedSeen(skipped, ctx.Cache)
 	for _, s := range skipped {
-		ctx.recordHistory(feedName, s.cand.item.Item, "skipped", s.reason, s.cand.titleLabels)
+		rec := NewHistoryRecord(feedName, s.cand.item.Item, "skipped", s.reason, s.cand.titleLabels)
+		rec.BetterFeed, rec.BetterGUID = s.betterFeed, s.betterGUID
+		ctx.recordHistoryRecord(rec)
 	}
 
 	// Phase 4: Dispatch winners.
@@ -587,6 +589,10 @@ func markSkippedSeen(skipped []skippedCandidate, cache *CacheFile) {
 type skippedCandidate struct {
 	cand   *candidate
 	reason string
+	// betterFeed/betterGUID identify the cache record that beat this
+	// candidate, set only when reason is skipReasonCacheBetter.
+	betterFeed string
+	betterGUID string
 }
 
 // selectWinners returns winners and skipped candidates with reasons. For each
@@ -630,6 +636,8 @@ func selectWinners(candidates []*candidate, feedCfg Feed, cache *CacheFile) ([]*
 		}
 	}
 
+	betterFeed := map[*candidate]string{}
+	betterGUID := map[*candidate]string{}
 	seen := map[*candidate]bool{}
 	var winners []*candidate
 	for key, e := range best {
@@ -638,6 +646,9 @@ func selectWinners(candidates []*candidate, feedCfg Feed, cache *CacheFile) ([]*
 			log.Debugf("Skipping %s for key %s: cache has equal or better preference", e.cand.item.Item.Title, key)
 			if !seen[e.cand] {
 				skipReasons[e.cand] = skipReasonCacheBetter
+				if rec, ok := cache.BestRecordForKey(key, feedCfg.Prefer); ok {
+					betterFeed[e.cand], betterGUID[e.cand] = rec.Feed, rec.GUID
+				}
 			}
 			continue
 		}
@@ -674,7 +685,12 @@ func selectWinners(candidates []*candidate, feedCfg Feed, cache *CacheFile) ([]*
 	var skipped []skippedCandidate
 	for _, c := range candidates {
 		if reason, ok := skipReasons[c]; ok {
-			skipped = append(skipped, skippedCandidate{cand: c, reason: reason})
+			skipped = append(skipped, skippedCandidate{
+				cand:       c,
+				reason:     reason,
+				betterFeed: betterFeed[c],
+				betterGUID: betterGUID[c],
+			})
 		}
 	}
 

--- a/cmd/rss4transmission/once.go
+++ b/cmd/rss4transmission/once.go
@@ -627,17 +627,24 @@ func selectWinners(candidates []*candidate, feedCfg Feed, cache *CacheFile) ([]*
 		inBest[e.cand] = true
 	}
 
+	betterFeed := map[*candidate]string{}
+	betterGUID := map[*candidate]string{}
+
 	skipReasons := map[*candidate]string{}
 	for _, c := range candidates {
 		if !matchedCands[c] {
 			skipReasons[c] = skipReasonNoGroupMatched
 		} else if !inBest[c] {
 			skipReasons[c] = "outranked by better candidate in this run"
+			for _, cov := range c.coverages(feedCfg.Identity) {
+				if e, ok := best[cov.identityKey]; ok && e.cand != c {
+					betterFeed[c], betterGUID[c] = feedCfg.Name, e.cand.item.Item.GUID
+					break
+				}
+			}
 		}
 	}
 
-	betterFeed := map[*candidate]string{}
-	betterGUID := map[*candidate]string{}
 	seen := map[*candidate]bool{}
 	var winners []*candidate
 	for key, e := range best {

--- a/cmd/rss4transmission/once_test.go
+++ b/cmd/rss4transmission/once_test.go
@@ -970,6 +970,36 @@ func TestSelectWinners_PicksHighestPreference(t *testing.T) {
 	}
 }
 
+func TestSelectWinners_OutrankedThisRun_RecordsBetterFeedAndGUID(t *testing.T) {
+	c1 := makeCandidate("tnt-1080p",
+		map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race", "network": "TNT", "resolution": "1080p"},
+		nil,
+	)
+	c2 := makeCandidate("global-720p",
+		map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race", "network": "Global", "resolution": "720p"},
+		nil,
+	)
+	feed := makeFeed(
+		[]string{"series", "round", "session"},
+		[]PreferDimension{
+			{Label: "network", Order: []string{"TNT", "Global"}},
+			{Label: "resolution", Order: []string{"1080p", "720p"}},
+		},
+		[]Group{{Require: map[string][]string{"series": {"MotoGP"}}}},
+	)
+	feed.Name = "MotoGP"
+	_, skipped := selectWinners([]*candidate{c1, c2}, feed, emptyCache())
+	if len(skipped) != 1 {
+		t.Fatalf("expected 1 skipped candidate, got %d", len(skipped))
+	}
+	if skipped[0].reason != "outranked by better candidate in this run" {
+		t.Errorf("reason = %q, want %q", skipped[0].reason, "outranked by better candidate in this run")
+	}
+	if skipped[0].betterFeed != "MotoGP" || skipped[0].betterGUID != "tnt-1080p" {
+		t.Errorf("betterFeed/betterGUID = %q/%q, want MotoGP/tnt-1080p", skipped[0].betterFeed, skipped[0].betterGUID)
+	}
+}
+
 func TestSelectWinners_GroupFilter(t *testing.T) {
 	c := makeCandidate("guid1",
 		map[string]string{"series": "WorldSBK", "round": "RD01", "session": "Race"},

--- a/cmd/rss4transmission/once_test.go
+++ b/cmd/rss4transmission/once_test.go
@@ -38,7 +38,7 @@ func makeFeed(identity []string, prefer []PreferDimension, groups []Group) Feed 
 }
 
 func emptyCache() *CacheFile {
-	return &CacheFile{identityIndex: map[string][]map[string]string{}}
+	return &CacheFile{identityIndex: map[string][]CacheRecord{}}
 }
 
 // --- candidate.coverages ---
@@ -435,7 +435,7 @@ func TestRealMotoGPFeeds_ExcludedHighlightsShowsLabelsAndMotoGPWinsPrimary(t *te
 	require.Len(t, records, 3)
 	for _, r := range records {
 		assert.Equal(t, "excluded", r.Outcome)
-		assert.Equal(t, "matched exclude filter", r.Reason)
+		assert.Equal(t, "matched exclude filter: (?i).*Highlights.*", r.Reason)
 		assert.Equal(t, "MotoGP", r.Labels["class"],
 			"excluded records must carry extracted labels for the group tie-break to use")
 	}
@@ -883,13 +883,42 @@ func TestSelectWinners_CacheHit_Equal(t *testing.T) {
 	)
 	key := "series=MotoGP|round=RD01|session=Race"
 	cache := &CacheFile{
-		identityIndex: map[string][]map[string]string{
-			key: {{"resolution": "1080p"}},
+		identityIndex: map[string][]CacheRecord{
+			key: {{Labels: map[string]string{"resolution": "1080p"}}},
 		},
 	}
 	winners, _ := selectWinners([]*candidate{c}, feed, cache)
 	if len(winners) != 0 {
 		t.Errorf("expected 0 winners (cache at equal preference), got %d", len(winners))
+	}
+}
+
+func TestSelectWinners_CacheHit_RecordsBetterFeedAndGUID(t *testing.T) {
+	c := makeCandidate("guid1",
+		map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race", "network": "TNT", "resolution": "1080p"},
+		nil,
+	)
+	feed := makeFeed(
+		[]string{"series", "round", "session"},
+		[]PreferDimension{{Label: "resolution", Order: []string{"1080p", "720p"}}},
+		[]Group{{Require: map[string][]string{"series": {"MotoGP"}}}},
+	)
+	feed.Name = "MotoGP"
+	key := "series=MotoGP|round=RD01|session=Race"
+	cache := &CacheFile{
+		identityIndex: map[string][]CacheRecord{
+			key: {{Feed: "MotoGP", GUID: "better-guid", Labels: map[string]string{"resolution": "1080p"}}},
+		},
+	}
+	_, skipped := selectWinners([]*candidate{c}, feed, cache)
+	if len(skipped) != 1 {
+		t.Fatalf("expected 1 skipped candidate, got %d", len(skipped))
+	}
+	if skipped[0].reason != skipReasonCacheBetter {
+		t.Errorf("reason = %q, want %q", skipped[0].reason, skipReasonCacheBetter)
+	}
+	if skipped[0].betterFeed != "MotoGP" || skipped[0].betterGUID != "better-guid" {
+		t.Errorf("betterFeed/betterGUID = %q/%q, want MotoGP/better-guid", skipped[0].betterFeed, skipped[0].betterGUID)
 	}
 }
 
@@ -905,8 +934,8 @@ func TestSelectWinners_CacheHit_BetterAvailable(t *testing.T) {
 	)
 	key := "series=MotoGP|round=RD01|session=Race"
 	cache := &CacheFile{
-		identityIndex: map[string][]map[string]string{
-			key: {{"resolution": "720p"}}, // worse than new candidate
+		identityIndex: map[string][]CacheRecord{
+			key: {{Labels: map[string]string{"resolution": "720p"}}}, // worse than new candidate
 		},
 	}
 	winners, _ := selectWinners([]*candidate{c}, feed, cache)
@@ -1132,7 +1161,7 @@ func TestMarkSkippedSeen_AddsCacheRejected(t *testing.T) {
 		Version:       CACHE_VERSION,
 		Errors:        map[string]int64{},
 		Seen:          []CacheRecord{},
-		identityIndex: map[string][]map[string]string{},
+		identityIndex: map[string][]CacheRecord{},
 	}
 	skipped := []skippedCandidate{
 		{cand: c, reason: skipReasonCacheBetter},
@@ -1157,7 +1186,7 @@ func TestMarkSkippedSeen_AddsAllReasons(t *testing.T) {
 		Version:       CACHE_VERSION,
 		Errors:        map[string]int64{},
 		Seen:          []CacheRecord{},
-		identityIndex: map[string][]map[string]string{},
+		identityIndex: map[string][]CacheRecord{},
 	}
 	skipped := []skippedCandidate{
 		{cand: c, reason: "no group matched labels"},

--- a/cmd/rss4transmission/select.go
+++ b/cmd/rss4transmission/select.go
@@ -52,6 +52,22 @@ func (g *Group) MatchScore(labels map[string]string) int {
 	return score
 }
 
+// MismatchedRequire returns the names of Require labels that reject labels:
+// either absent from labels, or present with a value outside the acceptable
+// set. Returns nil when every Require key is satisfied. Sorted for a stable
+// order.
+func (g *Group) MismatchedRequire(labels map[string]string) []string {
+	var mismatched []string
+	for label, acceptable := range g.Require {
+		v, ok := labels[label]
+		if !ok || !slices.Contains(acceptable, v) {
+			mismatched = append(mismatched, label)
+		}
+	}
+	slices.Sort(mismatched)
+	return mismatched
+}
+
 // IdentityKey computes a stable string key from the given labels using the
 // declared identity label names. Returns ("", false) if any identity label is
 // absent from labels.

--- a/cmd/rss4transmission/select_test.go
+++ b/cmd/rss4transmission/select_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -347,5 +348,64 @@ func TestGroupMatchScore_EmptyRequire(t *testing.T) {
 	labels := map[string]string{"series": "MotoGP"}
 	if got := g.MatchScore(labels); got != 0 {
 		t.Errorf("MatchScore = %d, want 0 (nothing to require, nothing to score)", got)
+	}
+}
+
+// --- Group.MismatchedRequire ---
+
+func TestGroupMismatchedRequire_MissingLabel(t *testing.T) {
+	g := Group{Require: map[string][]string{
+		"series":  {"MotoGP"},
+		"session": {"Race"},
+	}}
+	labels := map[string]string{"series": "MotoGP"} // session missing
+	got := g.MismatchedRequire(labels)
+	want := []string{"session"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("MismatchedRequire = %v, want %v", got, want)
+	}
+}
+
+func TestGroupMismatchedRequire_WrongValue(t *testing.T) {
+	g := Group{Require: map[string][]string{
+		"series": {"MotoGP"},
+	}}
+	labels := map[string]string{"series": "Moto2"}
+	got := g.MismatchedRequire(labels)
+	want := []string{"series"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("MismatchedRequire = %v, want %v", got, want)
+	}
+}
+
+func TestGroupMismatchedRequire_MultipleFailingKeysSorted(t *testing.T) {
+	g := Group{Require: map[string][]string{
+		"series":  {"MotoGP"},
+		"session": {"Race"},
+	}}
+	labels := map[string]string{"series": "Moto2"} // series wrong, session missing
+	got := g.MismatchedRequire(labels)
+	want := []string{"series", "session"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("MismatchedRequire = %v, want %v (sorted)", got, want)
+	}
+}
+
+func TestGroupMismatchedRequire_EmptyRequire(t *testing.T) {
+	g := Group{Require: map[string][]string{}}
+	labels := map[string]string{"series": "MotoGP"}
+	if got := g.MismatchedRequire(labels); got != nil {
+		t.Errorf("MismatchedRequire = %v, want nil (nothing to require, nothing can mismatch)", got)
+	}
+}
+
+func TestGroupMismatchedRequire_AllSatisfied(t *testing.T) {
+	g := Group{Require: map[string][]string{
+		"series":  {"MotoGP"},
+		"session": {"Race", "Qualifying"},
+	}}
+	labels := map[string]string{"series": "MotoGP", "session": "Qualifying"}
+	if got := g.MismatchedRequire(labels); got != nil {
+		t.Errorf("MismatchedRequire = %v, want nil (every Require key satisfied)", got)
 	}
 }

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -218,6 +218,12 @@ type historyRow struct {
 	// MismatchedLabels lists the Require label(s) that kept every group from
 	// matching, populated only when isNoGroupMatched(HistoryRecord) is true.
 	MismatchedLabels []string
+	// BetterFeed/BetterGUID identify the row this one lost to (see
+	// skipReasonCacheBetter), populated only when that row is present among
+	// the records passed to groupHistoryRows — otherwise left empty so the
+	// template renders no link to a row that doesn't exist on this page.
+	BetterFeed string
+	BetterGUID string
 }
 
 // isNoGroupMatched reports whether a record's feed never applied to the item
@@ -299,6 +305,11 @@ func groupHistoryRows(records []HistoryRecord, feedGroups func(name string) []Gr
 		records []HistoryRecord
 	}
 
+	recordExists := make(map[string]bool, len(records))
+	for _, r := range records {
+		recordExists[r.Feed+"\x00"+r.GUID] = true
+	}
+
 	order := make([]string, 0, len(records))
 	groups := make(map[string]*group, len(records))
 	empties := 0
@@ -349,6 +360,10 @@ func groupHistoryRows(records []HistoryRecord, feedGroups func(name string) []Gr
 			}
 			if isNoGroupMatched(r) {
 				row.MismatchedLabels = mismatchedLabels(feedGroups(r.Feed), r.Labels)
+			}
+			if r.BetterFeed != "" && recordExists[r.BetterFeed+"\x00"+r.BetterGUID] {
+				row.BetterFeed = r.BetterFeed
+				row.BetterGUID = r.BetterGUID
 			}
 			rows = append(rows, row)
 		}

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -215,6 +215,9 @@ type historyRow struct {
 	HistoryRecord
 	IsPrimary bool
 	GroupSize int // total records sharing this GUID; 1 = ungrouped
+	// MismatchedLabels lists the Require label(s) that kept every group from
+	// matching, populated only when isNoGroupMatched(HistoryRecord) is true.
+	MismatchedLabels []string
 }
 
 // isNoGroupMatched reports whether a record's feed never applied to the item
@@ -238,6 +241,41 @@ func bestGroupScore(groups []Group, labels map[string]string) int {
 		}
 	}
 	return best
+}
+
+// mismatchedLabels returns the Require label names responsible for a
+// "no group matched labels" row: the sorted, deduplicated union of
+// Group.MismatchedRequire() across whichever group(s) in groups came closest
+// to matching labels (the highest Group.MatchScore, ties included). Unlike
+// bestGroupScore, a negative score is not clamped to 0 — the closest group is
+// the true maximum, even when every group contradicts. Returns nil when
+// groups is empty.
+func mismatchedLabels(groups []Group, labels map[string]string) []string {
+	best := 0
+	var closest []Group
+	for i, g := range groups {
+		s := g.MatchScore(labels)
+		switch {
+		case i == 0 || s > best:
+			best = s
+			closest = []Group{g}
+		case s == best:
+			closest = append(closest, g)
+		}
+	}
+
+	seen := map[string]bool{}
+	var mismatched []string
+	for _, g := range closest {
+		for _, label := range g.MismatchedRequire(labels) {
+			if !seen[label] {
+				seen[label] = true
+				mismatched = append(mismatched, label)
+			}
+		}
+	}
+	sort.Strings(mismatched)
+	return mismatched
 }
 
 // groupHistoryRows reorders records so rows sharing a GUID are contiguous.
@@ -304,11 +342,15 @@ func groupHistoryRows(records []HistoryRecord, feedGroups func(name string) []Gr
 			return recs[i].Feed < recs[j].Feed
 		})
 		for i, r := range recs {
-			rows = append(rows, historyRow{
+			row := historyRow{
 				HistoryRecord: r,
 				IsPrimary:     i == 0,
 				GroupSize:     len(recs),
-			})
+			}
+			if isNoGroupMatched(r) {
+				row.MismatchedLabels = mismatchedLabels(feedGroups(r.Feed), r.Labels)
+			}
+			rows = append(rows, row)
 		}
 	}
 	return rows

--- a/cmd/rss4transmission/web/history.html
+++ b/cmd/rss4transmission/web/history.html
@@ -113,6 +113,8 @@
         tr.group-child:hover td { background: #2b333e; }
         tr.group-child td:first-child { box-shadow: inset 3px 0 0 #3a6ea5; }
         tr.group-child td:nth-child(2) { padding-left: 1.8em; }
+
+        tr.flash-highlight td { background: #3a4d63; }
     </style>
 </head>
 <body>
@@ -185,7 +187,7 @@
                     {{ if .Labels }}<div class="labels">{{ range $k, $v := .Labels }}{{ $k }}={{ $v }} {{ end }}</div>{{ end }}
                 </td>
                 <td class="outcome {{ outcomeClass .Outcome }}">{{ .Outcome }}</td>
-                <td>{{ .Reason }}{{ if .MismatchedLabels }}<div class="labels">not matched: {{ range $i, $l := .MismatchedLabels }}{{ if $i }}, {{ end }}{{ $l }}{{ end }}</div>{{ end }}</td>
+                <td>{{ .Reason }}{{ if .MismatchedLabels }}<div class="labels">not matched: {{ range $i, $l := .MismatchedLabels }}{{ if $i }}, {{ end }}{{ $l }}{{ end }}</div>{{ end }}{{ if .BetterFeed }}<div class="labels"><a href="#" class="better-link" data-feed="{{ .BetterFeed }}" data-guid="{{ .BetterGUID }}">view better version</a></div>{{ end }}</td>
                 <td class="action">
                     {{ if and .TorrentURL (ne .Outcome "dispatched") (ne .Outcome "downloaded") (feedConfigured .Feed) }}
                     <button class="btn-torrent" data-feed="{{ .Feed }}" data-guid="{{ .GUID }}">Torrent</button>
@@ -331,6 +333,24 @@
                 var guid = toggle.dataset.guid;
                 if (expandedGroups.has(guid)) expandedGroups.delete(guid); else expandedGroups.add(guid);
                 apply();
+                return;
+            }
+
+            var betterLink = e.target.closest('.better-link');
+            if (betterLink) {
+                e.preventDefault();
+                var bFeed = betterLink.dataset.feed;
+                var bGuid = betterLink.dataset.guid;
+                var target = rows.find(function (r) { return r.dataset.feed === bFeed && r.dataset.guid === bGuid; });
+                if (!target) return;
+
+                if (isChild(target) && !expandedGroups.has(target.dataset.guid)) {
+                    expandedGroups.add(target.dataset.guid);
+                    apply();
+                }
+                target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                target.classList.add('flash-highlight');
+                setTimeout(function () { target.classList.remove('flash-highlight'); }, 1500);
                 return;
             }
 

--- a/cmd/rss4transmission/web/history.html
+++ b/cmd/rss4transmission/web/history.html
@@ -185,7 +185,7 @@
                     {{ if .Labels }}<div class="labels">{{ range $k, $v := .Labels }}{{ $k }}={{ $v }} {{ end }}</div>{{ end }}
                 </td>
                 <td class="outcome {{ outcomeClass .Outcome }}">{{ .Outcome }}</td>
-                <td>{{ .Reason }}</td>
+                <td>{{ .Reason }}{{ if .MismatchedLabels }}<div class="labels">not matched: {{ range $i, $l := .MismatchedLabels }}{{ if $i }}, {{ end }}{{ $l }}{{ end }}</div>{{ end }}</td>
                 <td class="action">
                     {{ if and .TorrentURL (ne .Outcome "dispatched") (ne .Outcome "downloaded") (feedConfigured .Feed) }}
                     <button class="btn-torrent" data-feed="{{ .Feed }}" data-guid="{{ .GUID }}">Torrent</button>

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -860,6 +860,39 @@ func TestGroupHistoryRows_MatchScoreIgnoresGroupsWithNoOverlap(t *testing.T) {
 		"BSB's positive match must win even though WSBK sorts first alphabetically")
 }
 
+func TestGroupHistoryRows_PopulatesMismatchedLabelsOnNoGroupMatched(t *testing.T) {
+	records := []HistoryRecord{
+		NewHistoryRecord("MotoGP", makeGofeedItem("MotoGP Title", "guid-1"), "skipped", skipReasonNoGroupMatched,
+			map[string]string{"series": "Moto2"}),
+	}
+	feedGroups := func(name string) []Group {
+		if name == "MotoGP" {
+			return []Group{{Require: map[string][]string{"series": {"MotoGP"}}}}
+		}
+		return nil
+	}
+
+	rows := groupHistoryRows(records, feedGroups)
+
+	require.Len(t, rows, 1)
+	assert.Equal(t, []string{"series"}, rows[0].MismatchedLabels)
+}
+
+func TestGroupHistoryRows_MismatchedLabelsEmptyForOtherReasons(t *testing.T) {
+	records := []HistoryRecord{
+		NewHistoryRecord("MotoGP", makeGofeedItem("MotoGP Title", "guid-1"), "dispatched", "",
+			map[string]string{"series": "MotoGP"}),
+	}
+	feedGroups := func(name string) []Group {
+		return []Group{{Require: map[string][]string{"series": {"Moto2"}}}}
+	}
+
+	rows := groupHistoryRows(records, feedGroups)
+
+	require.Len(t, rows, 1)
+	assert.Nil(t, rows[0].MismatchedLabels, "MismatchedLabels must only be populated for no-group-matched rows")
+}
+
 func TestGroupHistoryRows_NilFeedGroupsFallsBackToAlphabetical(t *testing.T) {
 	records := []HistoryRecord{
 		NewHistoryRecord("WSBK", makeGofeedItem("BSB Title", "guid-1"), "skipped", skipReasonNoGroupMatched, nil),
@@ -871,6 +904,69 @@ func TestGroupHistoryRows_NilFeedGroupsFallsBackToAlphabetical(t *testing.T) {
 	require.Len(t, rows, 2)
 	assert.True(t, rows[0].IsPrimary)
 	assert.Equal(t, "BSB", rows[0].Feed, "a nil feedGroups must behave like every feed scoring 0")
+}
+
+// --- mismatchedLabels ---
+
+func TestMismatchedLabels_SingleGroupMissingKey(t *testing.T) {
+	groups := []Group{{Require: map[string][]string{"series": {"MotoGP"}, "session": {"Race"}}}}
+	labels := map[string]string{"series": "MotoGP"} // session missing
+	got := mismatchedLabels(groups, labels)
+	want := []string{"session"}
+	assert.Equal(t, want, got)
+}
+
+func TestMismatchedLabels_SingleGroupWrongValue(t *testing.T) {
+	groups := []Group{{Require: map[string][]string{"series": {"MotoGP"}}}}
+	labels := map[string]string{"series": "Moto2"}
+	got := mismatchedLabels(groups, labels)
+	want := []string{"series"}
+	assert.Equal(t, want, got)
+}
+
+func TestMismatchedLabels_TiedGroupsUnionFailingKeys(t *testing.T) {
+	// Both groups score 0 (no positive evidence, no contradiction) — a tie —
+	// so the result must be the union of both groups' missing Require keys.
+	groups := []Group{
+		{Require: map[string][]string{"series": {"MotoGP"}}},
+		{Require: map[string][]string{"session": {"Race"}}},
+	}
+	labels := map[string]string{"resolution": "1080p"}
+	got := mismatchedLabels(groups, labels)
+	want := []string{"series", "session"}
+	assert.Equal(t, want, got)
+}
+
+func TestMismatchedLabels_ContradictionBeatsNoOverlapAsClosest(t *testing.T) {
+	// The "series" group scores -1 (present contradiction), the "class" group
+	// scores 0 (no overlap at all). -1 > ... no: -1 is still the higher of the
+	// two only if class's score is lower. Here class has zero overlap (score
+	// 0), which is HIGHER than a contradiction's -1, so class is the closest
+	// group and its own missing key is what gets reported.
+	groups := []Group{
+		{Require: map[string][]string{"series": {"Moto2"}}},    // present, contradicted: score -1
+		{Require: map[string][]string{"class": {"Superbike"}}}, // absent, no contradiction: score 0
+	}
+	labels := map[string]string{"series": "MotoGP"}
+	got := mismatchedLabels(groups, labels)
+	want := []string{"class"}
+	assert.Equal(t, want, got, "the group with no overlap (score 0) is closer than the contradicted group (score -1)")
+}
+
+func TestMismatchedLabels_AllGroupsContradictReturnsUnion(t *testing.T) {
+	groups := []Group{
+		{Require: map[string][]string{"series": {"Moto2"}}},
+		{Require: map[string][]string{"series": {"Moto3"}}},
+	}
+	labels := map[string]string{"series": "MotoGP"} // contradicts both, tied at -1
+	got := mismatchedLabels(groups, labels)
+	want := []string{"series"}
+	assert.Equal(t, want, got)
+}
+
+func TestMismatchedLabels_EmptyGroupsReturnsNil(t *testing.T) {
+	assert.Nil(t, mismatchedLabels(nil, map[string]string{"series": "MotoGP"}))
+	assert.Nil(t, mismatchedLabels([]Group{}, map[string]string{"series": "MotoGP"}))
 }
 
 func TestHistoryPage_GroupsRecordsSharingGUID(t *testing.T) {
@@ -945,6 +1041,43 @@ func TestHistoryPage_FeedGroupsBreaksNoGroupMatchedTie(t *testing.T) {
 	assert.Contains(t, primaryRow, `data-feed="MotoGP"`,
 		"the record whose own group Require is actually satisfied by its labels must be the primary row, "+
 			"even though its siblings extracted the identical labels via a shared Extractor")
+}
+
+func TestHistoryPage_RendersMismatchedLabelsForNoGroupMatched(t *testing.T) {
+	h := emptyHistory()
+	h.AddOrUpdateRecord(NewHistoryRecord("MotoGP",
+		makeGofeedItemWithEnclosure("MotoGP Title", "guid-1", "https://example.com/motogp.torrent"),
+		"skipped", skipReasonNoGroupMatched, map[string]string{"series": "Moto2"}))
+
+	feedGroups := func(name string) []Group {
+		if name == "MotoGP" {
+			return []Group{{Require: map[string][]string{"series": {"MotoGP"}}}}
+		}
+		return nil
+	}
+
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, feedGroups, nil, navConfig{})
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "not matched: series")
+}
+
+func TestHistoryPage_NoMismatchedLabelsLineForOtherReasons(t *testing.T) {
+	h := emptyHistory()
+	h.AddOrUpdateRecord(NewHistoryRecord("MotoGP",
+		makeGofeedItemWithEnclosure("MotoGP Title", "guid-1", "https://example.com/motogp.torrent"),
+		"dispatched", "", map[string]string{"series": "MotoGP"}))
+
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil, navConfig{})
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.NotContains(t, rr.Body.String(), "not matched:")
 }
 
 func TestHistoryPage_UniqueGUIDRendersUngrouped(t *testing.T) {

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -878,6 +878,37 @@ func TestGroupHistoryRows_PopulatesMismatchedLabelsOnNoGroupMatched(t *testing.T
 	assert.Equal(t, []string{"series"}, rows[0].MismatchedLabels)
 }
 
+func TestGroupHistoryRows_PopulatesBetterLinkWhenTargetPresent(t *testing.T) {
+	skipped := NewHistoryRecord("MotoGP", makeGofeedItem("MotoGP 720p", "guid-1"), "skipped", skipReasonCacheBetter, nil)
+	skipped.BetterFeed = "MotoGP"
+	skipped.BetterGUID = "guid-2"
+	winner := NewHistoryRecord("MotoGP", makeGofeedItem("MotoGP 1080p", "guid-2"), "dispatched", "", nil)
+	records := []HistoryRecord{skipped, winner}
+
+	rows := groupHistoryRows(records, nil)
+
+	require.Len(t, rows, 2)
+	skippedRow := rows[0]
+	if skippedRow.GUID != "guid-1" {
+		skippedRow = rows[1]
+	}
+	assert.Equal(t, "MotoGP", skippedRow.BetterFeed)
+	assert.Equal(t, "guid-2", skippedRow.BetterGUID)
+}
+
+func TestGroupHistoryRows_OmitsBetterLinkWhenTargetAbsent(t *testing.T) {
+	skipped := NewHistoryRecord("MotoGP", makeGofeedItem("MotoGP 720p", "guid-1"), "skipped", skipReasonCacheBetter, nil)
+	skipped.BetterFeed = "MotoGP"
+	skipped.BetterGUID = "guid-pruned"
+	records := []HistoryRecord{skipped}
+
+	rows := groupHistoryRows(records, nil)
+
+	require.Len(t, rows, 1)
+	assert.Empty(t, rows[0].BetterFeed)
+	assert.Empty(t, rows[0].BetterGUID)
+}
+
 func TestGroupHistoryRows_MismatchedLabelsEmptyForOtherReasons(t *testing.T) {
 	records := []HistoryRecord{
 		NewHistoryRecord("MotoGP", makeGofeedItem("MotoGP Title", "guid-1"), "dispatched", "",
@@ -1078,6 +1109,46 @@ func TestHistoryPage_NoMismatchedLabelsLineForOtherReasons(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rr.Code)
 	assert.NotContains(t, rr.Body.String(), "not matched:")
+}
+
+func TestHistoryPage_RendersBetterLinkWhenTargetPresent(t *testing.T) {
+	h := emptyHistory()
+	skipped := NewHistoryRecord("MotoGP",
+		makeGofeedItemWithEnclosure("MotoGP 720p", "guid-1", "https://example.com/motogp-720p.torrent"),
+		"skipped", skipReasonCacheBetter, nil)
+	skipped.BetterFeed = "MotoGP"
+	skipped.BetterGUID = "guid-2"
+	h.AddOrUpdateRecord(skipped)
+	h.AddOrUpdateRecord(NewHistoryRecord("MotoGP",
+		makeGofeedItemWithEnclosure("MotoGP 1080p", "guid-2", "https://example.com/motogp-1080p.torrent"),
+		"dispatched", "", nil))
+
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil, navConfig{})
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	assert.Contains(t, body, `class="better-link" data-feed="MotoGP" data-guid="guid-2"`)
+}
+
+func TestHistoryPage_OmitsBetterLinkWhenTargetAbsent(t *testing.T) {
+	h := emptyHistory()
+	skipped := NewHistoryRecord("MotoGP",
+		makeGofeedItemWithEnclosure("MotoGP 720p", "guid-1", "https://example.com/motogp-720p.torrent"),
+		"skipped", skipReasonCacheBetter, nil)
+	skipped.BetterFeed = "MotoGP"
+	skipped.BetterGUID = "guid-pruned"
+	h.AddOrUpdateRecord(skipped)
+
+	mux := newWebMux(h, makeRetryFunc(new(bool), nil, 0, nil), nil, nil, nil, navConfig{})
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.NotContains(t, rr.Body.String(), `class="better-link"`)
 }
 
 func TestHistoryPage_UniqueGUIDRendersUngrouped(t *testing.T) {


### PR DESCRIPTION
The history page only said a candidate matched no group, with no way to tell why without checking the feed config and the item's own labels by hand. Add a second line under the reason listing the Require label(s) that rejected every group, computed from the closest-matching group(s) so the message stays useful even when several groups share an Extractor.