### PR TITLE
Add Notifications/Alerts nav pages for ntfy topics

### DIFF
--- a/cmd/rss4transmission/livecfg_web_test.go
+++ b/cmd/rss4transmission/livecfg_web_test.go
@@ -24,6 +24,10 @@ func staticNotif(cfg NotificationsConfig) func() NotificationsConfig {
 	return func() NotificationsConfig { return cfg }
 }
 
+func staticNtfy(cfg NtfyConfig) func() NtfyConfig {
+	return func() NtfyConfig { return cfg }
+}
+
 func staticTx(cfg Transmission) func() Transmission {
 	return func() Transmission { return cfg }
 }

--- a/cmd/rss4transmission/ntfyweb.go
+++ b/cmd/rss4transmission/ntfyweb.go
@@ -1,0 +1,103 @@
+package main
+
+/*
+ * RSS4Transmission
+ * Copyright (c) 2023 Aaron Turner  <aturner at synfin dot net>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	_ "embed"
+	"html/template"
+	"net/http"
+	"strings"
+)
+
+//go:embed web/notifications.html
+var notificationsTmpl string
+
+//go:embed web/alerts.html
+var alertsTmpl string
+
+// ntfyPageData is passed to the notifications/alerts page templates.
+type ntfyPageData struct {
+	IframeSrc string
+}
+
+// ntfyTopicURL builds the ntfy web page URL for a topic, or returns "" when
+// either baseURL or topic is empty -- callers read that as "nothing to
+// frame" and 404 the route.
+func ntfyTopicURL(baseURL, topic string) string {
+	if baseURL == "" || topic == "" {
+		return ""
+	}
+	return strings.TrimRight(baseURL, "/") + "/" + topic
+}
+
+// registerNtfyRoutes adds GET /notifications and GET /alerts to mux. Each
+// frames the ntfy web page for Ntfy.Topic / Ntfy.AlertTopic directly.
+//
+// Unlike Transmission there is no reverse proxy here: ntfy's web app serves
+// its static assets from the domain root (/static/..., /manifest.json), so
+// proxying it under a path prefix would 404 those assets, and a root-domain
+// proxy would collide with rss4transmission's own routes. Ntfy.BaseURL is
+// already documented as a server the browser can reach directly -- the same
+// one phones subscribe to -- so the iframe just points at it.
+//
+// ntfy reads the live Ntfy config block; both routes are registered once and
+// resolve per request, so editing BaseURL/Topic/AlertTopic in the config file
+// takes effect without a restart. Either route 404s while its own topic (and
+// BaseURL) is unset.
+//
+// Notifications and Alerts are gated independently of each other -- unlike
+// /speedtest and /rotations, which share one gate -- so each page needs its
+// own template set: one forces only its own nav predicate to alwaysNav and
+// leaves the other page's predicate live, otherwise visiting one page while
+// the other topic is unset would still link to a page that 404s.
+func registerNtfyRoutes(mux *http.ServeMux, ntfy func() NtfyConfig, nav navConfig) {
+	notifNav := nav
+	notifNav.Notifications = alwaysNav
+	notifTmpl := template.Must(template.Must(
+		template.New("notifications").Funcs(notifNav.navFuncs()).Parse(navTmpl)).Parse(notificationsTmpl))
+
+	alertNav := nav
+	alertNav.Alerts = alwaysNav
+	alertTmpl := template.Must(template.Must(
+		template.New("alerts").Funcs(alertNav.navFuncs()).Parse(navTmpl)).Parse(alertsTmpl))
+
+	mux.HandleFunc("GET /notifications", func(w http.ResponseWriter, r *http.Request) {
+		src := ntfyTopicURL(ntfy().BaseURL, ntfy().Topic)
+		if src == "" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := notifTmpl.Execute(w, ntfyPageData{IframeSrc: src}); err != nil {
+			log.WithError(err).Error("Failed to render notifications template")
+		}
+	})
+
+	mux.HandleFunc("GET /alerts", func(w http.ResponseWriter, r *http.Request) {
+		src := ntfyTopicURL(ntfy().BaseURL, ntfy().AlertTopic)
+		if src == "" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := alertTmpl.Execute(w, ntfyPageData{IframeSrc: src}); err != nil {
+			log.WithError(err).Error("Failed to render alerts template")
+		}
+	})
+}

--- a/cmd/rss4transmission/ntfyweb_test.go
+++ b/cmd/rss4transmission/ntfyweb_test.go
@@ -1,0 +1,196 @@
+package main
+
+/*
+ * RSS4Transmission
+ * Copyright (c) 2023 Aaron Turner  <aturner at synfin dot net>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// ---- nav item ----
+
+func TestNav_LinksNotificationsAndAlertsWhenEnabled(t *testing.T) {
+	h := &HistoryFile{Records: []HistoryRecord{}, guidIndex: map[string]int{}}
+
+	_, both := getBody(t, newWebMux(h, nil, nil, nil, nil,
+		navConfig{Notifications: navOn(), Alerts: navOn()}), "/")
+	if !strings.Contains(navLine(t, both), `href="/notifications"`) {
+		t.Errorf("torrents page nav is missing the Notifications link\ngot:\n%s", navLine(t, both))
+	}
+	if !strings.Contains(navLine(t, both), `href="/alerts"`) {
+		t.Errorf("torrents page nav is missing the Alerts link\ngot:\n%s", navLine(t, both))
+	}
+
+	_, notifOnly := getBody(t, newWebMux(h, nil, nil, nil, nil,
+		navConfig{Notifications: navOn()}), "/")
+	if !strings.Contains(navLine(t, notifOnly), `href="/notifications"`) {
+		t.Errorf("torrents page nav is missing the Notifications link\ngot:\n%s", navLine(t, notifOnly))
+	}
+	if strings.Contains(navLine(t, notifOnly), `href="/alerts"`) {
+		t.Errorf("torrents page links /alerts when only Notifications is enabled\ngot:\n%s", navLine(t, notifOnly))
+	}
+
+	_, off := getBody(t, newWebMux(h, nil, nil, nil, nil, navConfig{}), "/")
+	if strings.Contains(navLine(t, off), `href="/notifications"`) ||
+		strings.Contains(navLine(t, off), `href="/alerts"`) {
+		t.Errorf("torrents page links ntfy pages when neither is enabled\ngot:\n%s", navLine(t, off))
+	}
+}
+
+// ---- ntfyTopicURL ----
+
+func TestNtfyTopicURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		topic   string
+		want    string
+	}{
+		{"basic", "https://ntfy.sh", "mytopic", "https://ntfy.sh/mytopic"},
+		{"trailing slash trimmed", "https://ntfy.sh/", "mytopic", "https://ntfy.sh/mytopic"},
+		{"empty base url", "", "mytopic", ""},
+		{"empty topic", "https://ntfy.sh", "", ""},
+		{"both empty", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ntfyTopicURL(tt.baseURL, tt.topic); got != tt.want {
+				t.Errorf("ntfyTopicURL(%q, %q) = %q, want %q", tt.baseURL, tt.topic, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---- page ----
+
+// ntfyNavFor mirrors how watch.go wires the two gates: each is derived from
+// cfg the same way the handlers themselves decide whether to 404, so a test
+// against it also proves the two pages are gated independently.
+func ntfyNavFor(cfg NtfyConfig) navConfig {
+	return navConfig{
+		Notifications: func() bool { return ntfyTopicURL(cfg.BaseURL, cfg.Topic) != "" },
+		Alerts:        func() bool { return ntfyTopicURL(cfg.BaseURL, cfg.AlertTopic) != "" },
+	}
+}
+
+func withNtfy(t *testing.T, cfg NtfyConfig) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+	registerNtfyRoutes(mux, staticNtfy(cfg), ntfyNavFor(cfg))
+	return mux
+}
+
+func TestNotificationsPage_FramesTopicURL(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", Topic: "torrents", AlertTopic: "alerts"}
+
+	code, body := getBody(t, withNtfy(t, cfg), "/notifications")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if !strings.Contains(body, `src="https://ntfy.sh/torrents"`) {
+		t.Errorf("page does not frame the topic URL\ngot:\n%s", body)
+	}
+	if !strings.Contains(navLine(t, body), `<span class="here">Notifications</span>`) {
+		t.Errorf("page nav does not mark Notifications as current\ngot:\n%s", navLine(t, body))
+	}
+	if !strings.Contains(navLine(t, body), `href="/alerts"`) {
+		t.Errorf("page nav is missing the Alerts link\ngot:\n%s", navLine(t, body))
+	}
+}
+
+func TestAlertsPage_FramesAlertTopicURL(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", Topic: "torrents", AlertTopic: "alerts"}
+
+	code, body := getBody(t, withNtfy(t, cfg), "/alerts")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if !strings.Contains(body, `src="https://ntfy.sh/alerts"`) {
+		t.Errorf("page does not frame the alert topic URL\ngot:\n%s", body)
+	}
+	if !strings.Contains(navLine(t, body), `<span class="here">Alerts</span>`) {
+		t.Errorf("page nav does not mark Alerts as current\ngot:\n%s", navLine(t, body))
+	}
+	if !strings.Contains(navLine(t, body), `href="/notifications"`) {
+		t.Errorf("page nav is missing the Notifications link\ngot:\n%s", navLine(t, body))
+	}
+}
+
+// Notifications and Alerts are independently gated, unlike /speedtest and
+// /rotations which share one gate. Visiting one page while the other topic is
+// unset must not link to a page that will 404.
+func TestNotificationsPage_AlertsLinkHiddenWhenAlertTopicEmpty(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", Topic: "torrents"}
+
+	_, body := getBody(t, withNtfy(t, cfg), "/notifications")
+	if strings.Contains(navLine(t, body), `href="/alerts"`) {
+		t.Errorf("notifications page links /alerts while AlertTopic is empty\ngot:\n%s", navLine(t, body))
+	}
+}
+
+func TestAlertsPage_NotificationsLinkHiddenWhenTopicEmpty(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", AlertTopic: "alerts"}
+
+	_, body := getBody(t, withNtfy(t, cfg), "/alerts")
+	if strings.Contains(navLine(t, body), `href="/notifications"`) {
+		t.Errorf("alerts page links /notifications while Topic is empty\ngot:\n%s", navLine(t, body))
+	}
+}
+
+func TestNotificationsPage_404WhenTopicEmpty(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", AlertTopic: "alerts"} // Topic unset
+	if code, _ := getBody(t, withNtfy(t, cfg), "/notifications"); code != http.StatusNotFound {
+		t.Errorf("status = %d while Topic is empty, want 404", code)
+	}
+}
+
+func TestAlertsPage_404WhenAlertTopicEmpty(t *testing.T) {
+	cfg := NtfyConfig{BaseURL: "https://ntfy.sh", Topic: "torrents"} // AlertTopic unset
+	if code, _ := getBody(t, withNtfy(t, cfg), "/alerts"); code != http.StatusNotFound {
+		t.Errorf("status = %d while AlertTopic is empty, want 404", code)
+	}
+}
+
+func TestNtfyRoutes_NotRegistered(t *testing.T) {
+	mux := http.NewServeMux()
+	for _, path := range []string{"/notifications", "/alerts"} {
+		if code, _ := getBody(t, mux, path); code != http.StatusNotFound {
+			t.Errorf("%s status = %d without the routes, want 404", path, code)
+		}
+	}
+}
+
+// On the real private mux the history page is the catch-all for "/", so
+// unregistered /notifications and /alerts render the torrents page instead of
+// 404ing. What matters is that nothing reaches ntfy.
+func TestNtfyRoutes_NotRegisteredOnHistoryMux(t *testing.T) {
+	h := &HistoryFile{Records: []HistoryRecord{}, guidIndex: map[string]int{}}
+	mux := newWebMux(h, nil, nil, nil, nil, navConfig{})
+
+	for _, path := range []string{"/notifications", "/alerts"} {
+		code, body := getBody(t, mux, path)
+		if code != http.StatusOK {
+			t.Errorf("%s status = %d, want the torrents page", path, code)
+		}
+		if !strings.Contains(body, "<title>RSS4Transmission Torrents</title>") {
+			t.Errorf("%s did not render the torrents page", path)
+		}
+	}
+}

--- a/cmd/rss4transmission/watch.go
+++ b/cmd/rss4transmission/watch.go
@@ -283,9 +283,18 @@ func setupWebServers(cmd *WatchCmd, ctx *RunContext, live liveState, removeT rem
 	// so a link never leads to a 404.
 	notif := func() NotificationsConfig { return live.Config().Notifications }
 	tx := func() Transmission { return live.Config().Transmission }
+	ntfyCfg := func() NtfyConfig { return live.Config().Ntfy }
 	nav := navConfig{
 		Speedtest:    func() bool { return live.Speed() != nil },
 		Transmission: func() bool { return transmissionProxyTarget(tx()) != nil },
+		Notifications: func() bool {
+			c := ntfyCfg()
+			return ntfyTopicURL(c.BaseURL, c.Topic) != ""
+		},
+		Alerts: func() bool {
+			c := ntfyCfg()
+			return ntfyTopicURL(c.BaseURL, c.AlertTopic) != ""
+		},
 	}
 
 	if cmd.PublicListen != "" {
@@ -313,6 +322,7 @@ func setupWebServers(cmd *WatchCmd, ctx *RunContext, live liveState, removeT rem
 			privMux := newWebMux(ctx.History, retryHistory, feedConfigured, feedGroups, forgetHistory, nav)
 			registerSpeedRoutes(privMux, live.Speed, ctx.PeerPortOpen, ctx.PeerPort, live.ExitIP, live.Actions, nav)
 			registerTransmissionRoutes(privMux, tx, nav)
+			registerNtfyRoutes(privMux, ntfyCfg, nav)
 			go startWebServer("private", privMux, histAddr)
 		}
 	} else if cmd.PrivateListen != "" {
@@ -327,6 +337,7 @@ func setupWebServers(cmd *WatchCmd, ctx *RunContext, live liveState, removeT rem
 		mux := newWebMux(ctx.History, retryHistory, feedConfigured, feedGroups, forgetHistory, nav)
 		registerSpeedRoutes(mux, live.Speed, ctx.PeerPortOpen, ctx.PeerPort, live.ExitIP, live.Actions, nav)
 		registerTransmissionRoutes(mux, tx, nav)
+		registerNtfyRoutes(mux, ntfyCfg, nav)
 		registerCancelRoutes(mux, ctx.CancelStore, notif, removeT, getProgress, accessLog)
 		ctx.CancelRoutesEnabled = true
 		if ctx.History != nil {

--- a/cmd/rss4transmission/web.go
+++ b/cmd/rss4transmission/web.go
@@ -53,8 +53,10 @@ var navTmpl string
 // page on or off, and the nav bar must agree with the gate on the next render.
 // A nil field means the page is off.
 type navConfig struct {
-	Speedtest    func() bool
-	Transmission func() bool
+	Speedtest     func() bool
+	Transmission  func() bool
+	Notifications func() bool
+	Alerts        func() bool
 }
 
 // navFuncs returns the FuncMap entries that web/nav.html needs. Every template
@@ -62,8 +64,10 @@ type navConfig struct {
 // render time, so the templates still compile once.
 func (n navConfig) navFuncs() template.FuncMap {
 	return template.FuncMap{
-		"speedtestEnabled":    func() bool { return n.Speedtest != nil && n.Speedtest() },
-		"transmissionEnabled": func() bool { return n.Transmission != nil && n.Transmission() },
+		"speedtestEnabled":     func() bool { return n.Speedtest != nil && n.Speedtest() },
+		"transmissionEnabled":  func() bool { return n.Transmission != nil && n.Transmission() },
+		"notificationsEnabled": func() bool { return n.Notifications != nil && n.Notifications() },
+		"alertsEnabled":        func() bool { return n.Alerts != nil && n.Alerts() },
 	}
 }
 

--- a/cmd/rss4transmission/web/alerts.html
+++ b/cmd/rss4transmission/web/alerts.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <title>RSS4Transmission Alerts</title>
+    <style>
+        html, body { height: 100%; }
+        body {
+            font-family: monospace;
+            margin: 0;
+            background: #1a1a1a;
+            color: #e0e0e0;
+            display: flex;
+            flex-direction: column;
+        }
+        #nav { margin: 0; padding: 0.8em 1em; background: #2a2a2a; }
+        #nav a { color: #6aa8e0; text-decoration: underline; }
+        #nav .here { color: #e0e0e0; }
+
+        /* ntfy owns everything below the nav bar. It keeps its own scroll
+           position, so the page itself never scrolls. */
+        iframe { flex: 1; width: 100%; border: 0; }
+    </style>
+</head>
+<body>
+    {{ template "nav" "alerts" }}
+    <iframe src="{{.IframeSrc}}" title="Alerts"></iframe>
+</body>
+</html>

--- a/cmd/rss4transmission/web/history.html
+++ b/cmd/rss4transmission/web/history.html
@@ -118,9 +118,9 @@
     </style>
 </head>
 <body>
+    {{ template "nav" "torrents" }}
     <h1>Torrents</h1>
     <p id="count">{{ len . }} record(s) &mdash; auto-refreshes every 60 seconds.</p>
-{{ template "nav" "torrents" }}
 
     <div id="filters">
         <span>

--- a/cmd/rss4transmission/web/nav.html
+++ b/cmd/rss4transmission/web/nav.html
@@ -1,10 +1,12 @@
 {{- define "nav" -}}
-{{- /* The dot is the current page: "torrents", "speedtest", "rotations" or
-       "transmission".
+{{- /* The dot is the current page: "torrents", "speedtest", "rotations",
+       "transmission", "notifications" or "alerts".
        The page you are on is named but not linked, so the bar reads the same
        everywhere and still says where you are. The VPN pages only exist when a
        speed store is configured, so their links are gated on the same flag that
-       decides whether those routes were registered at all. */ -}}
+       decides whether those routes were registered at all. Notifications and
+       Alerts are gated independently of each other -- one ntfy topic can be
+       configured without the other. */ -}}
     <p id="nav">
         {{- if eq . "torrents" }}<span class="here">Torrents</span>
         {{- else }}<a href="/">Torrents</a>{{ end }}
@@ -20,6 +22,16 @@
         &middot;
         {{- if eq . "transmission" }} <span class="here">Transmission</span>
         {{- else }} <a href="/transmission">Transmission</a>{{ end }}
+        {{- end }}
+        {{- if notificationsEnabled }}
+        &middot;
+        {{- if eq . "notifications" }} <span class="here">Notifications</span>
+        {{- else }} <a href="/notifications">Notifications</a>{{ end }}
+        {{- end }}
+        {{- if alertsEnabled }}
+        &middot;
+        {{- if eq . "alerts" }} <span class="here">Alerts</span>
+        {{- else }} <a href="/alerts">Alerts</a>{{ end }}
         {{- end }}
     </p>
 {{- end -}}

--- a/cmd/rss4transmission/web/notifications.html
+++ b/cmd/rss4transmission/web/notifications.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <title>RSS4Transmission Notifications</title>
+    <style>
+        html, body { height: 100%; }
+        body {
+            font-family: monospace;
+            margin: 0;
+            background: #1a1a1a;
+            color: #e0e0e0;
+            display: flex;
+            flex-direction: column;
+        }
+        #nav { margin: 0; padding: 0.8em 1em; background: #2a2a2a; }
+        #nav a { color: #6aa8e0; text-decoration: underline; }
+        #nav .here { color: #e0e0e0; }
+
+        /* ntfy owns everything below the nav bar. It keeps its own scroll
+           position, so the page itself never scrolls. */
+        iframe { flex: 1; width: 100%; border: 0; }
+    </style>
+</head>
+<body>
+    {{ template "nav" "notifications" }}
+    <iframe src="{{.IframeSrc}}" title="Notifications"></iframe>
+</body>
+</html>

--- a/cmd/rss4transmission/web/rotations.html
+++ b/cmd/rss4transmission/web/rotations.html
@@ -38,9 +38,9 @@
     </style>
 </head>
 <body>
+    {{ template "nav" "rotations" }}
     <h1>VPN Rotations</h1>
     <p id="count">{{ len .Rotations }} rotation(s) &mdash; auto-refreshes every 60 seconds.</p>
-    {{ template "nav" "rotations" }}
 
     <div id="summary">
         <div>

--- a/cmd/rss4transmission/web/speedtest.html
+++ b/cmd/rss4transmission/web/speedtest.html
@@ -73,9 +73,9 @@
     </style>
 </head>
 <body>
+    {{ template "nav" "speedtest" }}
     <h1>VPN Speed</h1>
     <p id="count">{{ len .Rows }} measurement(s) &mdash; auto-refreshes every 60 seconds.</p>
-    {{ template "nav" "speedtest" }}
 
     <div id="summary">
         <div>

--- a/cmd/rss4transmission/web_test.go
+++ b/cmd/rss4transmission/web_test.go
@@ -57,12 +57,14 @@ func TestNewCancelMux_FaviconReachable(t *testing.T) {
 // per-page test, so a new page cannot ship without picking up the link.
 func TestPageTemplates_LinkTheFavicon(t *testing.T) {
 	pages := map[string]string{
-		"history.html":      historyTmpl,
-		"cancel.html":       cancelTmpl,
-		"start.html":        startTmpl,
-		"speedtest.html":    speedTmpl,
-		"rotations.html":    rotationsTmpl,
-		"transmission.html": transmissionTmpl,
+		"history.html":       historyTmpl,
+		"cancel.html":        cancelTmpl,
+		"start.html":         startTmpl,
+		"speedtest.html":     speedTmpl,
+		"rotations.html":     rotationsTmpl,
+		"transmission.html":  transmissionTmpl,
+		"notifications.html": notificationsTmpl,
+		"alerts.html":        alertsTmpl,
 	}
 	for name, tmpl := range pages {
 		assert.Contains(t, tmpl, `rel="icon"`, "%s is missing the favicon link", name)

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -357,7 +357,8 @@ publication date, outcome, and extracted labels. Records are pruned on the same 
 seen cache (`SeenCacheDays`). When `SpeedTest` is enabled it carries a nav bar linking the
 **VPN Speed** (`/speedtest`) and **Rotations** (`/rotations`) pages; see
 [VPN Speed Testing](speedtest.md#viewing-results). The nav bar also links the
-[Transmission page](#transmission-page).
+[Transmission page](#transmission-page) and, when the respective ntfy topic is configured, the
+[Notifications and Alerts pages](#notifications-and-alerts-pages).
 
 When multiple sibling feeds share one RSS URL — for example, separate feeds for different
 categories of content that all happen to be published through the same feed URL — the same item
@@ -427,6 +428,26 @@ listener already needs for `POST /torrent` and `POST /forget`. The proxy is neve
 unchanged. If you set a custom `Path`, Transmission already sits behind a proxy of your own. Set
 `WebUI: false` and use that proxy.
 
+## Notifications and Alerts Pages
+
+The **Notifications** page (`/notifications`) and **Alerts** page (`/alerts`) each show the ntfy
+web page for one topic inside a frame, next to the Transmission page in the nav bar. Notifications
+frames `Ntfy.Topic` (torrent started/completed/found); Alerts frames `Ntfy.AlertTopic`
+(config-reload and port-state alerts). The two pages are gated independently: each is on only
+when `Ntfy.BaseURL` and that page's own topic are both set, so you can enable one without the
+other.
+
+Unlike the Transmission page, there is no reverse proxy here. The frame loads
+`{Ntfy.BaseURL}/{Topic}` (or `{Ntfy.BaseURL}/{AlertTopic}`) directly from the browser. A proxy
+would not work the way it does for Transmission: ntfy's web app serves its static assets from the
+domain root, so proxying it under a path prefix would break those asset URLs, and proxying the
+whole domain would collide with rss4transmission's own routes. This works because `Ntfy.BaseURL`
+is already the externally reachable server your ntfy client subscribes to.
+
+Because there is no proxy, the browser talks to the ntfy server directly: it must be reachable
+from wherever you view the page, and it must not send `X-Frame-Options` or a CSP
+`frame-ancestors` directive that blocks framing, or the frame stays blank.
+
 ## Routes Overview
 
 | Route | `--private-listen` (single) | `--private-listen` (split) | `--public-listen` (split) |
@@ -436,6 +457,8 @@ unchanged. If you set a custom `Path`, Transmission already sits behind a proxy 
 | `/forget` | ✓ (requires `--history-file`) | ✓ (requires `--history-file`) | — |
 | `/transmission` (page) | ✓ (requires `WebUI`) | ✓ (requires `WebUI`) | — |
 | `/transmission/` (proxy) | ✓ (requires `WebUI`) | ✓ (requires `WebUI`) | — |
+| `/notifications` | ✓ (requires `Ntfy.BaseURL` + `Ntfy.Topic`) | ✓ (requires `Ntfy.BaseURL` + `Ntfy.Topic`) | — |
+| `/alerts` | ✓ (requires `Ntfy.BaseURL` + `Ntfy.AlertTopic`) | ✓ (requires `Ntfy.BaseURL` + `Ntfy.AlertTopic`) | — |
 | `/cancel` | ✓ | — | ✓ |
 | `/start` | ✓ (requires `--history-file`) | — | ✓ (requires `--history-file`) |
 | `/healthz` | ✓ | ✓ | ✓ |


### PR DESCRIPTION
## Summary
- Add **Notifications** (`/notifications`) and **Alerts** (`/alerts`) nav links, each framing the
  ntfy web page for `Ntfy.Topic` / `Ntfy.AlertTopic` inside an iframe, next to the Transmission
  page.
- No reverse proxy, unlike Transmission: ntfy's web app serves static assets from the domain root,
  so a path-prefixed proxy would break them. The iframe points straight at `Ntfy.BaseURL`.
- The two pages are gated independently, so either topic can be enabled without the other.

## Test plan
- [x] `make test`
- [x] `make lint`
- [x] New tests cover nav gating, page rendering, 404 behavior, and independent gating between
      the two pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)