### PR TITLE
Fix allLabels overwriting class with a non-matching sibling-class file

### DIFF
--- a/cmd/rss4transmission/once.go
+++ b/cmd/rss4transmission/once.go
@@ -194,25 +194,44 @@ type coverage struct {
 }
 
 // allLabels returns titleLabels merged with the labels of every file that
-// forms a valid coverage for identityLabels (same scoping as coverages()),
+// forms a valid coverage for feedCfg.Identity and matches at least one of
+// feedCfg.Groups (the same scoping selectWinners uses to decide a match),
 // with extractor defaults filled in for anything still missing. A file that
 // matches only a Prefer-dimension regex but not the identity regexes (a
 // sample clip, an NFO, a stray extra) never wins selection and must not be
-// allowed to overwrite a value that came from the file that did. This is the
-// full label set used when recording a dispatched candidate in the seen
-// cache, so Prefer dimensions that only appear in file names (e.g.
-// resolution) aren't lost on future preference-rank comparisons.
-func (c *candidate) allLabels(identityLabels []string) map[string]string {
+// allowed to overwrite a value that came from the file that did. Nor may a
+// file that belongs to a sibling class or session a shared Extractor also
+// happens to parse — e.g. a WSS support-race file bundled inside a WSBK
+// "Full Weekend" pack — since it never satisfied this feed's Group and had
+// no part in winning selection. This is the full label set used when
+// recording a dispatched candidate in the seen cache, so Prefer dimensions
+// that only appear in file names (e.g. resolution) aren't lost on future
+// preference-rank comparisons.
+func (c *candidate) allLabels(feedCfg Feed) map[string]string {
 	merged := make(map[string]string, len(c.titleLabels)+len(c.fileLabels))
 	maps.Copy(merged, c.titleLabels)
 	for _, fl := range c.fileLabels {
 		combined := withDefaultLabels(MergeLabels(c.titleLabels, fl), c.defaults)
-		if _, ok := IdentityKey(combined, identityLabels); !ok {
+		if _, ok := IdentityKey(combined, feedCfg.Identity); !ok {
+			continue
+		}
+		if !matchesAnyGroup(feedCfg.Groups, combined) {
 			continue
 		}
 		maps.Copy(merged, fl)
 	}
 	return withDefaultLabels(merged, c.defaults)
+}
+
+// matchesAnyGroup reports whether labels satisfy at least one group's
+// Require constraints.
+func matchesAnyGroup(groups []Group, labels map[string]string) bool {
+	for _, g := range groups {
+		if g.Matches(labels) {
+			return true
+		}
+	}
+	return false
 }
 
 // feedAllowed reports whether feedName should be processed given the --feed filter.
@@ -385,7 +404,7 @@ func (cmd *OnceCmd) Run(ctx *RunContext) error {
 // never stop processing, since nothing was produced.
 func (cmd *OnceCmd) dispatch(ctx *RunContext, feedCfg Feed, feedName string, w *candidate, keys []string) bool {
 	var err error
-	labels := w.allLabels(feedCfg.Identity)
+	labels := w.allLabels(feedCfg)
 
 	if cmd.NoAction {
 		log.Infof("%s match: %s", feedName, w.item.Item.Title)
@@ -510,7 +529,7 @@ func retryHistoryItem(ctx *RunContext, rec HistoryRecord) (int64, error) {
 // selected Quit.
 func (cmd *OnceCmd) dispatchInteractive(ctx *RunContext, feedCfg Feed, feedName string, w *candidate, keys []string) bool {
 	var err error
-	labels := w.allLabels(feedCfg.Identity)
+	labels := w.allLabels(feedCfg)
 
 	switch prompt(feedName, w.item.Item.Title) {
 	case Download:

--- a/cmd/rss4transmission/once_test.go
+++ b/cmd/rss4transmission/once_test.go
@@ -160,7 +160,9 @@ func TestAllLabels_MergesFileLabelsOverTitle(t *testing.T) {
 		map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race"},
 		[]map[string]string{{"resolution": "1080p"}},
 	)
-	got := c.allLabels([]string{"series", "round", "session"})
+	feedCfg := makeFeed([]string{"series", "round", "session"}, nil,
+		[]Group{{Require: map[string][]string{"series": {"MotoGP"}}}})
+	got := c.allLabels(feedCfg)
 	if got["resolution"] != "1080p" {
 		t.Errorf("allLabels()[resolution] = %q, want 1080p (from file label)", got["resolution"])
 	}
@@ -174,7 +176,9 @@ func TestAllLabels_FileLabelOverridesTitleLabel(t *testing.T) {
 		map[string]string{"series": "MotoGP", "resolution": "720p"},
 		[]map[string]string{{"resolution": "1080p"}},
 	)
-	got := c.allLabels([]string{"series"})
+	feedCfg := makeFeed([]string{"series"}, nil,
+		[]Group{{Require: map[string][]string{"series": {"MotoGP"}}}})
+	got := c.allLabels(feedCfg)
 	if got["resolution"] != "1080p" {
 		t.Errorf("allLabels()[resolution] = %q, want 1080p (file label overrides title)", got["resolution"])
 	}
@@ -183,7 +187,8 @@ func TestAllLabels_FileLabelOverridesTitleLabel(t *testing.T) {
 func TestAllLabels_AppliesDefaultsForMissingLabels(t *testing.T) {
 	c := makeCandidate("t1", map[string]string{"series": "MotoGP"}, nil)
 	c.defaults = map[string]string{"language": "English"}
-	got := c.allLabels([]string{"series"})
+	feedCfg := makeFeed([]string{"series"}, nil, nil)
+	got := c.allLabels(feedCfg)
 	if got["language"] != "English" {
 		t.Errorf("allLabels()[language] = %q, want English (from default)", got["language"])
 	}
@@ -200,9 +205,39 @@ func TestAllLabels_ExcludesFileWithoutValidIdentityKey(t *testing.T) {
 			{"resolution": "720p"},                      // sample: no series -> no valid coverage
 		},
 	)
-	got := c.allLabels([]string{"series", "round", "session"})
+	feedCfg := makeFeed([]string{"series", "round", "session"}, nil,
+		[]Group{{Require: map[string][]string{"series": {"MotoGP"}}}})
+	got := c.allLabels(feedCfg)
 	if got["resolution"] != "1080p" {
 		t.Errorf("allLabels()[resolution] = %q, want 1080p (sample file's 720p must not override the winning coverage's value)", got["resolution"])
+	}
+}
+
+func TestAllLabels_ExcludesFileNotMatchingAnyGroup(t *testing.T) {
+	// Regression: a "Full Weekend" WSBK pack can bundle a WSS support-class
+	// race file alongside the WSBK files, since both classes race on the
+	// same event weekend. The WSS file forms a valid identity key (every
+	// identity label is present), but its class does not satisfy this feed's
+	// Group Require, so it must not be allowed to overwrite the class value
+	// that actually matched and won selection for this feed.
+	c := makeCandidate("wsbk-bundle",
+		map[string]string{
+			"class": "WSBK", "network": "WEB", "year": "2026",
+			"round": "03", "language": "English",
+		},
+		[]map[string]string{
+			{"session": "Race2"},                 // WSBK Race2 file: class inherited from title
+			{"class": "WSS", "session": "Race2"}, // bundled WSS support-race file
+		},
+	)
+	feedCfg := makeFeed(
+		[]string{"network", "year", "round", "class", "session", "language"},
+		nil,
+		[]Group{{Require: map[string][]string{"class": {"WSBK"}}}},
+	)
+	got := c.allLabels(feedCfg)
+	if got["class"] != "WSBK" {
+		t.Errorf("allLabels()[class] = %q, want WSBK (a bundled WSS file must not overwrite the class that matched this feed's Group)", got["class"])
 	}
 }
 
@@ -219,7 +254,8 @@ func TestDispatch_Skip_RecordsFileDerivedLabelsInCache(t *testing.T) {
 		map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race"},
 		[]map[string]string{{"resolution": "1080p"}},
 	)
-	feedCfg := makeFeed([]string{"series", "round", "session"}, nil, nil)
+	feedCfg := makeFeed([]string{"series", "round", "session"}, nil,
+		[]Group{{Require: map[string][]string{"series": {"MotoGP"}}}})
 	keys := []string{"series=MotoGP|round=RD01|session=Race"}
 
 	ctx := &RunContext{Cache: emptyCache()}
@@ -240,7 +276,8 @@ func TestDispatch_Skip_RecordsFileDerivedLabelsInHistory(t *testing.T) {
 		map[string]string{"series": "MotoGP", "round": "RD01", "session": "Race"},
 		[]map[string]string{{"resolution": "1080p"}},
 	)
-	feedCfg := makeFeed([]string{"series", "round", "session"}, nil, nil)
+	feedCfg := makeFeed([]string{"series", "round", "session"}, nil,
+		[]Group{{Require: map[string][]string{"series": {"MotoGP"}}}})
 	keys := []string{"series=MotoGP|round=RD01|session=Race"}
 
 	ctx := &RunContext{

--- a/cmd/rss4transmission/simulate.go
+++ b/cmd/rss4transmission/simulate.go
@@ -128,7 +128,7 @@ func (cmd *SimulateCmd) dispatchBatch(ctx *RunContext, feedCfg Feed, candidates 
 			for j, cov := range covs {
 				keys[j] = cov.identityKey
 			}
-			labels := c.allLabels(feedCfg.Identity)
+			labels := c.allLabels(feedCfg)
 			log.Infof("WINNER: %s labels=%v", c.item.Item.Title, labels)
 			ctx.Cache.AddItem(c.item, labels, keys)
 			count++


### PR DESCRIPTION
## Summary
- A "Full Weekend" pack can bundle files for a sibling class on the same event weekend (e.g. a WSS support race inside a WSBK pack). `candidate.allLabels()` merged labels from any file that formed a valid identity key, regardless of whether that file matched the feed's own `Groups.Require`, so a bundled sibling-class file could overwrite the `class` value (and other fields) that actually won selection — visible as a WSBK dispatch showing `class=WSS` in the history UI.
- `allLabels()` now also requires a file's labels to match at least one of the feed's `Groups` before merging, matching the scoping `selectWinners` already uses to decide a match.

## Test plan
- [x] Added `TestAllLabels_ExcludesFileNotMatchingAnyGroup`, a regression test reproducing the WSBK/WSS bundle scenario
- [x] Updated existing `allLabels` tests to pass a `Feed` with a matching `Group`
- [x] `make precheck` (test, fmt, tidy, lint, govulncheck) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)