### PR TITLE
Cross-reference history file pruning in Seen Cache docs

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -217,7 +217,9 @@ and the rotation rules.
 
 `SeenFile` is a JSON file that records every torrent rss4transmission has dispatched. It
 prevents re-downloading the same content and tracks the best preference rank seen for each
-identity key. `SeenCacheDays` controls how long records are retained before being pruned.
+identity key. `SeenCacheDays` controls how long records are retained before being pruned. The
+same setting also prunes the history file when `--history-file` is set; see
+[History Web UI](notifications.md#history-web-ui).
 
 ```yaml
 SeenFile:      /config/seen.json


### PR DESCRIPTION
## Summary
- `docs/deployment.md`'s Seen Cache section documented that `SeenCacheDays` prunes the seen cache
  and torrent file cache, but not that it also prunes the history file.
- Added a link to `notifications.md#history-web-ui`, which already documents that record pruning.

## Test plan
- [x] Doc-only change; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)